### PR TITLE
Fix `CBSPPart::ReplaceColor`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@ The following people have contributed to this port:
 
 * Dan Watson <@dcwatson>
 * Jonathan Voss <@jonathan-voss>
+* Ryan Herriman <@rherriman>

--- a/src/bsp/CBSPPart.cpp
+++ b/src/bsp/CBSPPart.cpp
@@ -103,6 +103,7 @@ void CBSPPart::IBSPPart(short resId) {
         json poly = doc["polys"][i];
         // Color
         polyTable[i].color = poly["color"];
+        polyTable[i].origColor = poly["color"];
         // Normal
         polyTable[i].normal[0] = poly["normal"][0];
         polyTable[i].normal[1] = poly["normal"][1];
@@ -443,9 +444,8 @@ Matrix *CBSPPart::GetInverseTransform() {
 }
 
 void CBSPPart::ReplaceColor(int origColor, int newColor) {
-    // SDL_Log("Replacing color %x -> %x\n", origColor, newColor);
     for (int i = 0; i < polyCount; i++) {
-        if (polyTable[i].color == origColor) {
+        if (polyTable[i].origColor == origColor) {
             polyTable[i].color = newColor;
         }
     }

--- a/src/bsp/CBSPPart.h
+++ b/src/bsp/CBSPPart.h
@@ -39,6 +39,7 @@ typedef struct {
 
 typedef struct {
     uint32_t color;
+    uint32_t origColor;
     float normal[3];
     uint16_t triCount;
     uint16_t *triPoints;

--- a/src/game/AvaraDefines.h
+++ b/src/game/AvaraDefines.h
@@ -20,6 +20,7 @@ enum {
     kStatusRedColor
 };
 
+#define kNeutralTeamColor 0x00ffffff
 #define kGreenTeamColor 0x00006600
 #define kYellowTeamColor 0x00cccc00
 #define kRedTeamColor 0x00cc0000

--- a/src/game/CAbstractActor.cpp
+++ b/src/game/CAbstractActor.cpp
@@ -1158,9 +1158,6 @@ short CAbstractActor::GetPlayerPosition() {
 long CAbstractActor::GetLongTeamColorOr(long defaultColor) {
     long longTeamColor;
     switch (teamColor) {
-        case kNeutralTeam:
-            longTeamColor = kNeutralTeamColor;
-            break;
         case kGreenTeam:
             longTeamColor = kGreenTeamColor;
             break;

--- a/src/game/CAbstractActor.cpp
+++ b/src/game/CAbstractActor.cpp
@@ -1155,6 +1155,37 @@ short CAbstractActor::GetPlayerPosition() {
     return -1; //	Not a player, as far as we know, so return -1 (invalid position)
 }
 
+long CAbstractActor::GetLongTeamColorOr(long defaultColor) {
+    long longTeamColor;
+    switch (teamColor) {
+        case kNeutralTeam:
+            longTeamColor = kNeutralTeamColor;
+            break;
+        case kGreenTeam:
+            longTeamColor = kGreenTeamColor;
+            break;
+        case kYellowTeam:
+            longTeamColor = kYellowTeamColor;
+            break;
+        case kRedTeam:
+            longTeamColor = kRedTeamColor;
+            break;
+        case kPinkTeam:
+            longTeamColor = kPinkTeamColor;
+            break;
+        case kPurpleTeam:
+            longTeamColor = kPurpleTeamColor;
+            break;
+        case kBlueTeam:
+            longTeamColor = kBlueTeamColor;
+            break;
+        default:
+            longTeamColor = defaultColor;
+            break;
+    }
+    return longTeamColor;
+}
+
 short CAbstractActor::GetBallSnapPoint(long theGroup,
     Fixed *ballLocation,
     Fixed *snapDest,

--- a/src/game/CAbstractActor.h
+++ b/src/game/CAbstractActor.h
@@ -208,6 +208,8 @@ public:
     virtual void RayTestWithGround(RayHitRecord *hitRec, MaskType testMask);
     virtual short GetPlayerPosition();
 
+    long GetLongTeamColorOr(long defaultColor);
+
     virtual short GetBallSnapPoint(long theGroup,
         Fixed *ballLocation,
         Fixed *snapDest,

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -181,13 +181,12 @@ void CAbstractPlayer::ReplacePartColors() {
 }
 
 void CAbstractPlayer::SetSpecialColor(long specialColor) {
-    long origColor = GetLongTeamColorOr(kMarkerColor);
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
-        (*thePart)->ReplaceColor(origColor, specialColor);
+        (*thePart)->ReplaceColor(kMarkerColor, specialColor);
     }
 
     if (itsScout) {
-        itsScout->partList[0]->ReplaceColor(origColor, specialColor);
+        itsScout->partList[0]->ReplaceColor(kMarkerColor, specialColor);
     }
 }
 

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -165,37 +165,15 @@ void CAbstractPlayer::LoadScout() {
     scoutCommand = kScoutNullCommand;
 
     itsScout = new CScout;
-    itsScout->IScout(this, teamColor, longTeamColor);
+    itsScout->IScout(this, teamColor, GetLongTeamColorOr(kNeutralTeamColor));
     itsScout->BeginScript();
     FreshCalc();
     itsScout->EndScript();
 }
 
 void CAbstractPlayer::ReplacePartColors() {
+    long longTeamColor = GetLongTeamColorOr(kNeutralTeamColor);
     teamMask = 1 << teamColor;
-    switch (teamColor) {
-        case kGreenTeam:
-            longTeamColor = kGreenTeamColor;
-            break;
-        case kYellowTeam:
-            longTeamColor = kYellowTeamColor;
-            break;
-        case kRedTeam:
-            longTeamColor = kRedTeamColor;
-            break;
-        case kPinkTeam:
-            longTeamColor = kPinkTeamColor;
-            break;
-        case kPurpleTeam:
-            longTeamColor = kPurpleTeamColor;
-            break;
-        case kBlueTeam:
-            longTeamColor = kBlueTeamColor;
-            break;
-        default:
-            longTeamColor = 0x000000ff;
-            break;
-    }
 
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
         (*thePart)->ReplaceColor(kMarkerColor, longTeamColor);
@@ -203,13 +181,13 @@ void CAbstractPlayer::ReplacePartColors() {
 }
 
 void CAbstractPlayer::SetSpecialColor(long specialColor) {
-    longTeamColor = specialColor;
+    long origColor = GetLongTeamColorOr(kMarkerColor);
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
-        (*thePart)->ReplaceColor(kMarkerColor, specialColor);
+        (*thePart)->ReplaceColor(origColor, specialColor);
     }
 
     if (itsScout) {
-        itsScout->partList[0]->ReplaceColor(kMarkerColor, specialColor);
+        itsScout->partList[0]->ReplaceColor(origColor, specialColor);
     }
 }
 

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -44,8 +44,6 @@ public:
     CAbstractPlayer *nextPlayer;
     PlayerConfigRecord defaultConfig;
 
-    long longTeamColor; //	Team color in 0x00RRGGBB format.
-
     //	Shields & energy:
     Fixed energy;
     Fixed maxEnergy; //	Maximum stored energy level

--- a/src/game/CBall.cpp
+++ b/src/game/CBall.cpp
@@ -206,35 +206,11 @@ void CBall::Dispose() {
 }
 
 void CBall::ChangeOwnership(short ownerId, short ownerTeamColor) {
-    long longTeamColor;
-
     teamColor = ownerTeamColor;
     teamMask = 1 << teamColor;
     ownerScoringId = ownerId;
 
-    switch (teamColor) {
-        case kGreenTeam:
-            longTeamColor = kGreenTeamColor;
-            break;
-        case kYellowTeam:
-            longTeamColor = kYellowTeamColor;
-            break;
-        case kRedTeam:
-            longTeamColor = kRedTeamColor;
-            break;
-        case kPinkTeam:
-            longTeamColor = kPinkTeamColor;
-            break;
-        case kPurpleTeam:
-            longTeamColor = kPurpleTeamColor;
-            break;
-        case kBlueTeam:
-            longTeamColor = kBlueTeamColor;
-            break;
-        default:
-            longTeamColor = origLongColor;
-            break;
-    }
+    long longTeamColor = GetLongTeamColorOr(origLongColor);
 
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
         (*thePart)->ReplaceColor(kMarkerColor, longTeamColor);

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -22,15 +22,17 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
 
     int p = 0;
     float pY;
+    long longTeamColor;
     int colorR, colorG, colorB;
     float fontsz_m = 15.0, fontsz_s = 10.0;
     while (eachPlayer) {
         if (p >= 6)
             break;
         pY = (bufferHeight - 72) + (11 * p);
-        colorR = (eachPlayer->longTeamColor >> 16) & 0xff;
-        colorG = (eachPlayer->longTeamColor >> 8) & 0xff;
-        colorB = eachPlayer->longTeamColor & 0xff;
+        longTeamColor = eachPlayer->GetLongTeamColorOr(kNeutralTeamColor);
+        colorR = (longTeamColor >> 16) & 0xff;
+        colorG = (longTeamColor >> 8) & 0xff;
+        colorB = longTeamColor & 0xff;
 
         std::string playerName((char *)eachPlayer->itsManager->playerName + 1, eachPlayer->itsManager->playerName[0]);
         std::string playerLives = std::to_string(eachPlayer->lives);

--- a/src/game/CWalkerActor.cpp
+++ b/src/game/CWalkerActor.cpp
@@ -719,7 +719,7 @@ void CWalkerActor::ReceiveConfig(PlayerConfigRecord *config) {
         viewPortPart = partList[0];
         viewPortPart->usesPrivateHither = true;
         viewPortPart->hither = FIX3(100);
-        viewPortPart->ReplaceColor(kMarkerColor, longTeamColor);
+        viewPortPart->ReplaceColor(kMarkerColor, GetLongTeamColorOr(kNeutralTeamColor));
 
         proximityRadius = viewPortPart->enclosureRadius << 2;
         itsGame->itsWorld->AddPart(viewPortPart);


### PR DESCRIPTION
Resolves issues #3 and #9. Feedback welcome since it may not be the most efficient solution.

Also contains additional tweaks to team colors, although the hull head is still not applying "special" colors correctly. (I'm aware of why it isn't working but haven't decided on a solution yet.)