### PR TITLE
Fix hull head special color bug in a hacky way

### DIFF
--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -183,6 +183,7 @@ void CAbstractPlayer::ReplacePartColors() {
 }
 
 void CAbstractPlayer::SetSpecialColor(long specialColor) {
+    hullColorOverride = specialColor;
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
         (*thePart)->ReplaceColor(kMarkerColor, specialColor);
     }

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -174,8 +174,8 @@ void CAbstractPlayer::LoadScout() {
 }
 
 void CAbstractPlayer::ReplacePartColors() {
-    long longTeamColor = GetLongTeamColorOr(kNeutralTeamColor);
     teamMask = 1 << teamColor;
+    longTeamColor = GetLongTeamColorOr(kNeutralTeamColor);
 
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
         (*thePart)->ReplaceColor(kMarkerColor, longTeamColor);
@@ -183,7 +183,7 @@ void CAbstractPlayer::ReplacePartColors() {
 }
 
 void CAbstractPlayer::SetSpecialColor(long specialColor) {
-    hullColorOverride = specialColor;
+    longTeamColor = specialColor;
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
         (*thePart)->ReplaceColor(kMarkerColor, specialColor);
     }

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -44,7 +44,7 @@ public:
     CAbstractPlayer *nextPlayer;
     PlayerConfigRecord defaultConfig;
 
-    long hullColorOverride; // Hull color in 0x00RRGGBB format.
+    long longTeamColor; // Hull color in 0x00RRGGBB format.
 
     //	Shields & energy:
     Fixed energy;

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -44,6 +44,8 @@ public:
     CAbstractPlayer *nextPlayer;
     PlayerConfigRecord defaultConfig;
 
+    long hullColorOverride; // Hull color in 0x00RRGGBB format.
+
     //	Shields & energy:
     Fixed energy;
     Fixed maxEnergy; //	Maximum stored energy level

--- a/src/game/CWalkerActor.cpp
+++ b/src/game/CWalkerActor.cpp
@@ -719,9 +719,14 @@ void CWalkerActor::ReceiveConfig(PlayerConfigRecord *config) {
         viewPortPart = partList[0];
         viewPortPart->usesPrivateHither = true;
         viewPortPart->hither = FIX3(100);
-        viewPortPart->ReplaceColor(kMarkerColor, GetLongTeamColorOr(kNeutralTeamColor));
+        if (hullColorOverride) {
+            viewPortPart->ReplaceColor(kMarkerColor, hullColorOverride);
+        } else {
+            viewPortPart->ReplaceColor(kMarkerColor, GetLongTeamColorOr(kNeutralTeamColor));
+        }
 
         proximityRadius = viewPortPart->enclosureRadius << 2;
+
         itsGame->itsWorld->AddPart(viewPortPart);
 
         viewPortHeight = hull.rideHeight;

--- a/src/game/CWalkerActor.cpp
+++ b/src/game/CWalkerActor.cpp
@@ -719,11 +719,7 @@ void CWalkerActor::ReceiveConfig(PlayerConfigRecord *config) {
         viewPortPart = partList[0];
         viewPortPart->usesPrivateHither = true;
         viewPortPart->hither = FIX3(100);
-        if (hullColorOverride) {
-            viewPortPart->ReplaceColor(kMarkerColor, hullColorOverride);
-        } else {
-            viewPortPart->ReplaceColor(kMarkerColor, GetLongTeamColorOr(kNeutralTeamColor));
-        }
+        viewPortPart->ReplaceColor(kMarkerColor, longTeamColor);
 
         proximityRadius = viewPortPart->enclosureRadius << 2;
 


### PR DESCRIPTION
There's probably a better way to test the value of the new color
override property, but std::optional wasn't working for me.