### PR TITLE
Fixed string problem that can load crash

### DIFF
--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -228,7 +228,7 @@ OSErr CAvaraAppImpl::LoadLevel(std::string set, OSType theLevel) {
         if (curLevel->tag == theLevel) {
             std::string rsrcName((char *)curLevel->access + 1, curLevel->access[0]);
             levelName = std::string((char *)curLevel->name + 1, curLevel->name[0]);
-            BlockMoveData(set.c_str(), itsGame->loadedSet, set.size());
+            BlockMoveData(set.c_str(), itsGame->loadedSet, set.size() + 1);
             BlockMoveData(curLevel->name, itsGame->loadedLevel, curLevel->name[0] + 1);
             Handle levelData = GetNamedResource('PICT', rsrcName);
             if (levelData) {


### PR DESCRIPTION
Need to copy the NULL termination character when copying the levelset name string.  This bug would cause problems when loading a longer name levelset followed by a shorter name because then the 2 levelset names would get smushed together and it can't find the misnamed custome BSP resource.