### PR TITLE
output return character during in-game chat

### DIFF
--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -237,6 +237,7 @@ void CPlayerManagerImpl::HandleEvent(SDL_Event &event) {
                     SDL_StartTextInput();
                 }
                 else {
+                    GameKeyPress('\r');    // spit out a return char in-game
                     SDL_StopTextInput();
                 }
             }


### PR DESCRIPTION
This causes a return character to be appended to a chat message during a game and after the player hits enter to return to the game.