### PR TITLE
Fixed adding newline during in-game chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 *.sublime-project
 *.sublime-workspace
 .vscode
+.gdbinit

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -237,7 +237,7 @@ void CPlayerManagerImpl::HandleEvent(SDL_Event &event) {
                     SDL_StartTextInput();
                 }
                 else {
-                    GameKeyPress('\r');    // spit out a return char in-game
+                    inputBuffer.push_back('\r');
                     SDL_StopTextInput();
                 }
             }
@@ -304,13 +304,6 @@ void CPlayerManagerImpl::SendFrame() {
         prevKeyboardActive = keyboardActive;
     }
     else {
-        if (!inputBuffer.empty()) {
-            ff->ft.msgChar = inputBuffer.front();
-            inputBuffer.pop_front();
-        }
-        else {
-            ff->ft.msgChar = 0;
-        }
         ff->ft.down = 0;
         ff->ft.up = 0;
         ff->ft.held = 0;
@@ -318,6 +311,14 @@ void CPlayerManagerImpl::SendFrame() {
             prevKeyboardActive = true;
             ff->ft.down |= 1 << kfuTypeText;
         }
+    }
+    
+    if (!inputBuffer.empty()) {
+        ff->ft.msgChar = inputBuffer.front();
+        inputBuffer.pop_front();
+    }
+    else {
+        ff->ft.msgChar = 0;
     }
 
     ff->ft.mouseDelta.h = mouseX;

--- a/src/level/PICTParser.cpp
+++ b/src/level/PICTParser.cpp
@@ -297,14 +297,16 @@ void PICTParser::Parse(Handle data) {
                 buf->ReadRect(&frame);
                 buf->Skip(size - 10);
                 break;
+
+            case 0x9b: // DirectBitsRgn
+                DirectBitsRgn(buf);
+                break;
+                
             case 0xa0: // ShortComment
                 kind = buf->Short();
                 if (callbacks.commentProc) {
                     callbacks.commentProc(&context, kind, 0, NULL);
                 }
-                break;
-            case 0x9b: // DirectBitsRgn
-                DirectBitsRgn(buf);
                 break;
 
             case 0xa1: // LongComment


### PR DESCRIPTION
Fixed to evaluate inputBuffer even after the keyboard becomes inactive so that it picks up the \r that was added earlier.

Plus a couple housekeeping commits.
 * added .gdbinit to .gitignore
 * put 0x9b opcode where it belongs BEFORE 0xa0.
