### PR TITLE
Detect decals after scaling happens, use glPolygonOffset instead of m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ A typical solution to this problem is to have the second player connect via a VP
 
 ## Known issues
 * There is a bug in networked multiplayer where specific types of lag spikes cause the game to lose track of timing and [play old frames at an advanced rate](https://www.youtube.com/watch?v=zxm1zzFzor0). Thankfully this is somewhat rare during normal play. 
-* [#26](https://github.com/avaraline/Avara/issues/26) Some levels have graphical "z-fighting" issues where geometry is too close to other geometry and our current graphics pipeline does not reconcile this correctly causing moire-like patterns. 
 * [#25](https://github.com/avaraline/Avara/issues/25) Avara's usage of SDL does not play well with PulseAudio on some Linux systems. If you get a segfault when launching, try telling SDL to use ALSA instead with `export SDL_AUDIODRIVER=alsa` 
+
+[See other active bugs](https://github.com/avaraline/Avara/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 
 
 ## Challenges overcome while porting

--- a/shaders/avara_frag.glsl
+++ b/shaders/avara_frag.glsl
@@ -9,7 +9,6 @@ uniform vec3 light2 = vec3(0, 0, 0);
 uniform vec3 light3 = vec3(0, 0, 0);
 uniform float ambient = 0;
 uniform float lights_active = 1.0;
-uniform float decal;
 
 out vec3 color;
 

--- a/src/bsp/CBSPPart.cpp
+++ b/src/bsp/CBSPPart.cpp
@@ -109,13 +109,7 @@ void CBSPPart::IBSPPart(short resId, char* levelsetName) {
     maxBounds.z = ToFixed(doc["bounds"]["max"][2]);
     maxBounds.w = FIX1;
 
-    float sigma = .001f;
-
-    isDecal = (
-        std::abs(maxX - minX) < sigma ||
-        std::abs(maxY - minY) < sigma ||
-        std::abs(maxZ - minZ) < sigma
-    );
+    isDecal = false;
 
     pointTable = (Vector *)NewPtr(pointCount * sizeof(Vector));
     polyTable = (PolyRecord *)NewPtr(polyCount * sizeof(PolyRecord));
@@ -159,6 +153,14 @@ void CBSPPart::IBSPPart(short resId, char* levelsetName) {
 void CBSPPart::PostRender() {}
 
 void CBSPPart::UpdateOpenGLData() {
+    float sigma = .001f;
+
+    isDecal = (
+        std::abs(maxBounds.x - minBounds.x) < sigma ||
+        std::abs(maxBounds.y - minBounds.y) < sigma ||
+        std::abs(maxBounds.z - minBounds.z) < sigma
+    );
+
     if (!AvaraGLIsRendering()) return;
     glDataSize = totalPoints * sizeof(GLData);
     glData = (GLData *)NewPtr(glDataSize);

--- a/src/util/AvaraGL.cpp
+++ b/src/util/AvaraGL.cpp
@@ -67,7 +67,7 @@ float skyboxVertices[] = {
     };
 
 GLuint gProgram;
-GLuint mvLoc, ntLoc, ambLoc, lights_activeLoc, projLoc, viewLoc, decalLoc;
+GLuint mvLoc, ntLoc, ambLoc, lights_activeLoc, projLoc, viewLoc;
 GLuint light0Loc, light1Loc, light2Loc, light3Loc;
 
 GLuint skyProgram;
@@ -196,7 +196,6 @@ void AvaraGLInitContext() {
     ntLoc = glGetUniformLocation(gProgram, "normal_transform");
     ambLoc = glGetUniformLocation(gProgram, "ambient");
     lights_activeLoc = glGetUniformLocation(gProgram, "lights_active");
-    decalLoc = glGetUniformLocation(gProgram, "decal");
     glCheckErrors();
 
 
@@ -217,8 +216,6 @@ void AvaraGLInitContext() {
     groundColorLoc = glGetUniformLocation(skyProgram, "groundColor");
     horizonColorLoc = glGetUniformLocation(skyProgram, "horizonColor");
     skyColorLoc = glGetUniformLocation(skyProgram, "skyColor");
-
-
 }
 
 void AvaraGLDrawPolygons(CBSPPart* part) {
@@ -256,9 +253,10 @@ void AvaraGLDrawPolygons(CBSPPart* part) {
     // if we're drawing something thin
     // give it a little z-buffer push towards
     // the camera by scaling the z-value
-    if (part->isDecal) {
+    bool decal = part->isDecal;
+    if (decal) {
         glEnable(GL_POLYGON_OFFSET_FILL);
-        glPolygonOffset(-.3, 1.0);
+        glPolygonOffset(-1.0, 1.0);
     }
 
     SetTransforms(&part->fullTransform, &part->itsTransform);
@@ -272,7 +270,7 @@ void AvaraGLDrawPolygons(CBSPPart* part) {
     glDisableVertexAttribArray(2);
 
     // reset z-buffer scale
-    if (part->isDecal) {
+    if (decal) {
         glDisable(GL_POLYGON_OFFSET_FILL);
     }
 

--- a/src/util/AvaraGL.cpp
+++ b/src/util/AvaraGL.cpp
@@ -170,11 +170,6 @@ void AvaraGLLightDefaults() {
     AvaraGLSetAmbient(0.4f);
 }
 
-void AvaraGLSetDecal(float active) {
-    glUseProgram(gProgram);
-    glUniform1f(decalLoc, active);
-}
-
 void SetTransforms(Matrix *modelview, Matrix *normal_transform) {
     glUniformMatrix4fv(mvLoc, 1, GL_FALSE, glm::value_ptr(ToFloatMat(modelview)));
     glm::mat3 normal_mat = glm::mat3(1.0f);
@@ -223,6 +218,7 @@ void AvaraGLInitContext() {
     horizonColorLoc = glGetUniformLocation(skyProgram, "horizonColor");
     skyColorLoc = glGetUniformLocation(skyProgram, "skyColor");
 
+
 }
 
 void AvaraGLDrawPolygons(CBSPPart* part) {
@@ -259,9 +255,10 @@ void AvaraGLDrawPolygons(CBSPPart* part) {
 
     // if we're drawing something thin
     // give it a little z-buffer push towards
-    // the camera by scaling down the z-value
+    // the camera by scaling the z-value
     if (part->isDecal) {
-        AvaraGLSetDecal(.9995f);
+        glEnable(GL_POLYGON_OFFSET_FILL);
+        glPolygonOffset(-.3, 1.0);
     }
 
     SetTransforms(&part->fullTransform, &part->itsTransform);
@@ -276,7 +273,7 @@ void AvaraGLDrawPolygons(CBSPPart* part) {
 
     // reset z-buffer scale
     if (part->isDecal) {
-        AvaraGLSetDecal(1.0);
+        glDisable(GL_POLYGON_OFFSET_FILL);
     }
 
     // restore previous lighting state
@@ -295,6 +292,7 @@ void AvaraGLDrawPolygons(CBSPPart* part) {
 
     glBindBuffer(GL_ARRAY_BUFFER, NULL);
     glCheckErrors();
+
 }
 
 


### PR DESCRIPTION
…essing with the depth buffer by hand

To my eyes, it fixes #26, at least I don't see it in all the usual places. This, unlike other things I've tried, does the job without distorting the rendering of ramps and other 'thin' objects that don't really need adjustment. That could also be due to the improvement on how the 'thin' objects are detected, I wasn't waiting until after the geometry had been put into its final scale. glPolygonOffset worked *suspiciously* well to fix this with whatever values I tried in it