### PR TITLE
Specify port via command-line option

### DIFF
--- a/src/Avara.cpp
+++ b/src/Avara.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]) {
         std::string arg = argv[i];
         if (arg == "-p" || arg == "--port") {
             int port = atoi(argv[++i]);  // pre-inc to next arg
-            app->Set(kDefaultUDPPort, port);
+            app->Set(kDefaultClientUDPPort, port);
         } else if (arg == "-n" || arg == "--name") {
             app->Set(kPlayerNameTag, std::string(argv[++i]));
         } else {

--- a/src/Avara.cpp
+++ b/src/Avara.cpp
@@ -71,6 +71,8 @@ int main(int argc, char *argv[]) {
         if (arg == "-p" || arg == "--port") {
             int port = atoi(argv[++i]);  // pre-inc to next arg
             app->Set(kDefaultUDPPort, port);
+        } else if (arg == "-n" || arg == "--name") {
+            app->Set(kPlayerNameTag, std::string(argv[++i]));
         } else {
             SDL_Log("Unknown command-line argument '%s'\n", argv[i]);
             exit(1);

--- a/src/Avara.cpp
+++ b/src/Avara.cpp
@@ -14,6 +14,7 @@
 #include "CBSPPart.h"
 #include "FastMat.h"
 #include "SDL2/SDL.h"
+#include "Preferences.h"
 
 #include <nanogui/nanogui.h>
 #include <string.h>
@@ -63,6 +64,18 @@ int main(int argc, char *argv[]) {
 
     // The Avara application itself.
     CAvaraApp *app = new CAvaraAppImpl();
+
+    // process command-line arguments
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        if (arg == "-p" || arg == "--port") {
+            int port = atoi(argv[++i]);  // pre-inc to next arg
+            app->Set(kDefaultUDPPort, port);
+        } else {
+            SDL_Log("Unknown command-line argument '%s'\n", argv[i]);
+            exit(1);
+        }
+    }
 
     mainloop(app->GetGame()->frameTime / 4);
 

--- a/src/compat/Types.h
+++ b/src/compat/Types.h
@@ -27,6 +27,7 @@ typedef unsigned char Byte;
 typedef signed char SignedByte;
 
 typedef uint32_t ip_addr;
+typedef uint16_t port_num;
 
 struct Rect {
     short top;

--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -27,6 +27,7 @@ CApplication::~CApplication() {}
 void CApplication::Done() {
     prefs[kWindowWidth] = mSize[0];
     prefs[kWindowHeight] = mSize[1];
+    prefs.erase(kDefaultClientUDPPort);  // don't save client port
     WritePrefs(prefs);
 }
 
@@ -60,6 +61,13 @@ std::string CApplication::String(const std::string name) {
 
 long CApplication::Number(const std::string name) {
     return prefs[name];
+}
+
+long CApplication::Number(const std::string name, const long defaultValue) {
+    if (prefs[name].is_number()) {
+        return prefs[name];
+    }
+    return defaultValue;
 }
 
 json CApplication::Get(const std::string name) {

--- a/src/gui/CApplication.h
+++ b/src/gui/CApplication.h
@@ -40,6 +40,7 @@ public:
 
     std::string String(const std::string name);
     long Number(const std::string name);
+    long Number(const std::string name, const long defaultValue);
     json Get(const std::string name);
     void Set(const std::string name, const std::string value);
     void Set(const std::string name, long value);

--- a/src/gui/CPlayerWindow.cpp
+++ b/src/gui/CPlayerWindow.cpp
@@ -8,7 +8,7 @@ CPlayerWindow::CPlayerWindow(CApplication *app) : CWindow(app, "Player") {
     setLayout(new nanogui::BoxLayout(nanogui::Orientation::Vertical, nanogui::Alignment::Fill, 10, 10));
 
     std::string name = app->String(kPlayerNameTag);
-    nanogui::TextBox *nameBox = new nanogui::TextBox(this);
+    nameBox = new nanogui::TextBox(this);
     nameBox->setValue(name);
     nameBox->setEditable(true);
     nameBox->setCallback([app](std::string value) -> bool {
@@ -24,7 +24,7 @@ CPlayerWindow::CPlayerWindow(CApplication *app) : CWindow(app, "Player") {
 
     std::vector<std::string> hullTypes = {"Light", "Medium", "Heavy"};
 
-    nanogui::ComboBox *hullBox = new nanogui::ComboBox(this, hullTypes);
+    hullBox = new nanogui::ComboBox(this, hullTypes);
     hullBox->setCallback([app](int selectedIdx) { app->Set(kHullTypeTag, selectedIdx); });
     hullBox->popup()->setSize(nanogui::Vector2i(180, 140));
     hullBox->setSelectedIndex(app->Number(kHullTypeTag));
@@ -34,4 +34,9 @@ CPlayerWindow::~CPlayerWindow() {}
 
 bool CPlayerWindow::DoCommand(int theCommand) {
     return false;
+}
+
+void CPlayerWindow::PrefChanged(std::string name) {
+    nameBox->setValue(mApplication->String(kPlayerNameTag));
+    hullBox->setSelectedIndex(mApplication->Number(kHullTypeTag));
 }

--- a/src/gui/CPlayerWindow.h
+++ b/src/gui/CPlayerWindow.h
@@ -9,5 +9,11 @@ public:
     virtual ~CPlayerWindow();
 
     // Handles a command broadcasted by CApplication::BroadcastCommand. Returns true if it was actually handled.
-    virtual bool DoCommand(int theCommand);
+    virtual bool DoCommand(int theCommand) override;
+
+    virtual void PrefChanged(std::string name) override;
+    
+protected:
+    nanogui::TextBox *nameBox;
+    nanogui::ComboBox *hullBox;
 };

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -17,6 +17,7 @@ using json = nlohmann::json;
 
 // UDP stuff
 #define kDefaultUDPPort "udpDefaultPort"
+#define kDefaultClientUDPPort "udpDefaultClientPort"
 #define kUDPResendPrefTag "udpResend"
 #define kUDPConnectionSpeedTag "udpConnectionSpeed"
 

--- a/src/net/CCommManager.cpp
+++ b/src/net/CCommManager.cpp
@@ -84,12 +84,12 @@ void CCommManager::Dispose() {
 **	send the packet.
 */
 OSErr CCommManager::SendPacket(short distribution,
-    char command,
-    char p1,
-    short p2,
-    long p3,
-    short dataLen,
-    Ptr dataPtr) {
+                               char command,
+                               char p1,
+                               short p2,
+                               long p3,
+                               short dataLen,
+                               Ptr dataPtr) {
     long len;
     Ptr ps, pd;
 

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -64,8 +64,8 @@ public:
     long lastClock;
     long lastQuotaTime;
 
-    long localIP; //	Just a guess, but that's all we need for the tracker.
-    short localPort;
+    ip_addr localIP; //	Just a guess, but that's all we need for the tracker.
+    port_num localPort;
     UDPsocket stream;
     // char				streamBuffer[UDPSTREAMBUFFERSIZE];
     // char				sendBuffer[UDPSENDBUFFERSIZE];
@@ -105,7 +105,7 @@ public:
     virtual void SendConnectionTable();
     virtual void ReadFromTOC(PacketInfo *thePacket);
 
-    virtual void SendRejectPacket(ip_addr remoteHost, short remotePort, OSErr loginErr);
+    virtual void SendRejectPacket(ip_addr remoteHost, port_num remotePort, OSErr loginErr);
 
     virtual CUDPConnection *DoLogin(PacketInfo *thePacket, UDPpacket *udp);
 
@@ -116,10 +116,10 @@ public:
 
     virtual void ReceivedGoodPacket(PacketInfo *thePacket);
 
-    virtual OSErr CreateStream(short streamPort);
+    virtual OSErr CreateStream(port_num streamPort);
 
     virtual void CreateServer();
-    virtual OSErr ContactServer(ip_addr serverHost, short serverPort);
+    virtual OSErr ContactServer(ip_addr serverHost, port_num serverPort);
 
     virtual Boolean ServerSetupDialog(Boolean disableSome);
 

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -27,13 +27,15 @@
 
 #if DEBUG_AVARA
 void CUDPConnection::DebugPacket(char eType, UDPPacketInfo *p) {
-    SDL_Log("CUDPConnection::DebugPacket(%c) num=%d cmd=%d p1=%d p2=%d p3=%d\n",
+    SDL_Log("CUDPConnection::DebugPacket(%c) num=%d cmd=%d p1=%d p2=%d p3=%d sndr=%x dist=0x%02x\n",
         eType,
         p->serialNumber,
         p->packet.command,
         p->packet.p1,
         p->packet.p2,
-        p->packet.p3);
+        p->packet.p3,
+        p->packet.sender,
+        p->packet.distribution);
 }
 #endif
 
@@ -137,6 +139,9 @@ void CUDPConnection::SendQueuePacket(UDPPacketInfo *thePacket, short theDistribu
 void CUDPConnection::RoutePacket(UDPPacketInfo *thePacket) {
     short extendedRouting = routingMask | (1 << myId);
 
+    #if DEBUG_AVARA
+        DebugPacket('=', thePacket);
+    #endif
     SendQueuePacket(thePacket, thePacket->packet.distribution & extendedRouting);
     thePacket->packet.distribution &= ~extendedRouting;
 }
@@ -597,8 +602,8 @@ void CUDPConnection::OpenNewConnections(CompleteAddress *table) {
         next->OpenNewConnections(origTable);
 }
 
-void CUDPConnection::FreshClient(long remoteHost, short remotePort, long firstReceiveSerial) {
-    SDL_Log("CUDPConnection::FreshClient(%lu, %d)\n", remoteHost, remotePort);
+void CUDPConnection::FreshClient(ip_addr remoteHost, port_num remotePort, long firstReceiveSerial) {
+    SDL_Log("CUDPConnection::FreshClient(%u, %hu)\n", remoteHost, remotePort);
     FlushQueues();
     serialNumber = 0;
     receiveSerial = firstReceiveSerial;

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -30,8 +30,8 @@ typedef struct {
 #pragma pack()
 
 typedef struct {
-    int host;
-    short port;
+    ip_addr host;
+    port_num port;
 } CompleteAddress;
 
 typedef struct {
@@ -60,8 +60,8 @@ public:
 
     long seed;
 
-    int ipAddr;
-    short port;
+    ip_addr ipAddr;
+    port_num port;
 
     short myId;
 
@@ -121,7 +121,7 @@ public:
 
     virtual Boolean AreYouDone();
 
-    virtual void FreshClient(long remoteHost, short remotePort, long firstReceiveSerial);
+    virtual void FreshClient(ip_addr remoteHost, port_num remotePort, long firstReceiveSerial);
 
 #if DEBUG_AVARA
     virtual void DebugPacket(char eType, UDPPacketInfo *p);


### PR DESCRIPTION
The biggest change here is the ability to set the client's port and player name via command-line.  The main use case for this is setting up servers and client for testing all on one box.  For example, I set up a server as Head,

` ./build/Avara -n Head`

And 2 clients that will connect to that server,

`./build/Avara -n Tail -p 19561`
`./build/Avara -n Butt -p 19562`

Then you can connect to the server in each client using `localhost` as the server.  Specifying the IP address of your router can also work somewhat but I found on my router that the 2 clients can't talk to each other.  This might be a good way to test changing the way clients connect to each other.

There are other minor changes here like the creation of a type (`port_num`) to use for port numbers as there was inconsistent use of `int` and `short` for this in the code.  I've also tweaked some of the debug output to include sender, distribution, and sometimes connection host:port.