### PR TITLE
Reduce re-sends and fix hang associated with too many resends

### DIFF
--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -6,6 +6,7 @@
     Created: Monday, January 29, 1996, 13:45
     Modified: Saturday, January 3, 1998, 02:04
 */
+// #include <unistd.h> // for usleep()
 
 #include "CUDPComm.h"
 
@@ -165,8 +166,9 @@ void CUDPComm::WriteAndSignPacket(PacketInfo *thePacket) {
 #if ROUTE_THRU_SERVER
 static void FastForwardComplete(int result, void *userData) {
     CUDPComm *theComm = (CUDPComm *)userData;
-    SDL_Log("... CUDPComm::FastForwardComplete: result = %d\n", result);
-    // do we need to do anything here?
+    #if PACKET_DEBUG > 1
+        SDL_Log("CUDPComm::FastForwardComplete: result = %d\n", result);
+    #endif
 }
 
 void CUDPComm::FastForwardPacket(UDPpacket *udp, int16_t distribution) {
@@ -329,6 +331,7 @@ void CUDPComm::ProcessQueue() {
     //	Check to see if there's something we should write.
     if (turboMode) {
         if (nextWriteTime - GetClock() < 0 && !isClosed) {
+            turboCount = 3; // max messages to send in turboMode
             AsyncWrite();
         }
     } else {
@@ -741,8 +744,8 @@ void CUDPComm::ReadComplete(UDPpacket *packet) {
     }
 
     if (!isClosed) {
-        AsyncRead();
         AsyncWrite();
+        AsyncRead();
     }
 }
 
@@ -759,7 +762,7 @@ void CUDPComm::ReceivedGoodPacket(PacketInfo *thePacket) {
 }
 
 void CUDPComm::WriteComplete(int result) {
-    if (turboMode && !isClosed && result == noErr) {
+    if (turboMode && turboCount-- > 0 && !isClosed && result == noErr) {
         AsyncWrite();
     }
 }
@@ -823,11 +826,11 @@ Boolean CUDPComm::AsyncWrite() {
 
                 if (conn->busyQLen > longestBusyQ) {
                     theConnection = conn;
-                    highestRoundTrip = conn->realRoundTrip;
+                    highestRoundTrip = conn->meanRoundTripTime;
                     longestBusyQ = conn->busyQLen;
-                } else if (conn->busyQLen == longestBusyQ && conn->realRoundTrip > highestRoundTrip) {
+                } else if (conn->busyQLen == longestBusyQ && conn->meanRoundTripTime > highestRoundTrip) {
                     theConnection = conn;
-                    highestRoundTrip = conn->realRoundTrip;
+                    highestRoundTrip = conn->meanRoundTripTime;
                 }
             }
         }
@@ -1011,9 +1014,8 @@ Boolean CUDPComm::AsyncWrite() {
                 packetList->birthDate = curTime;
 
                 if (origCramCount) {
-                    if ((packetList->packet.flags & kpUrgentFlag) &&
-                        urgentResendTime <= theConnection->retransmitTime) {
-                        packetList->nextSendTime = curTime + urgentResendTime;
+                    if (packetList->packet.flags & kpUrgentFlag) {
+                        packetList->nextSendTime = curTime + theConnection->urgentRetransmitTime;
                     } else {
                         packetList->packet.flags &= ~kpUrgentFlag;
                         packetList->nextSendTime = curTime + theConnection->retransmitTime;
@@ -1039,6 +1041,7 @@ Boolean CUDPComm::AsyncWrite() {
                 SDL_Log("   WRITING UDP packet to %s using stream %p\n",
                         FormatAddr(udp->address).c_str(), stream);
             #endif
+            // usleep(30000 + int(10000*float(rand())/RAND_MAX)); // simulate network latencies
             UDPWrite(stream, udp, UDPWriteComplete, this);
             result = true;
         }
@@ -1124,6 +1127,7 @@ void CUDPComm::IUDPComm(short clientCount, short bufferCount, short version, lon
     nextWriteTime = lastQuotaTime;
     isClosing = false;
     turboMode = true; // was set to true
+    turboCount = 0;
 
     localPort = 0;
     localIP = 0;
@@ -1838,8 +1842,8 @@ long CUDPComm::GetMaxRoundTrip(short distribution) {
 
     for (conn = connections; conn; conn = conn->next) {
         if (conn->port && (distribution & (1 << conn->myId))) {
-            if (conn->realRoundTrip > maxTrip)
-                maxTrip = conn->optimistTime;
+            if (conn->meanRoundTripTime > maxTrip)
+                maxTrip = conn->meanRoundTripTime;
         }
     }
 

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -83,6 +83,7 @@ public:
     Boolean isClosed;
     Boolean isClosing;
     Boolean turboMode;
+    long turboCount;
 
     // Boolean				readIsComplete;
     // Boolean				writeIsComplete;

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -21,9 +21,8 @@
 #define kMaxTransmitQueueLength 128 //	128 packets going out...
 #define kMaxReceiveQueueLength 32 //	32 packets...arbitrary guess
 
-#define RTTSMOOTHFACTOR 6
-#define DEVIATIONSMOOTHFACTOR 4
-#define PESSIMISTSMOOTHFACTOR 5
+#define RTTSMOOTHFACTOR_UP 3
+#define RTTSMOOTHFACTOR_DOWN 5
 
 #if PACKET_DEBUG
 void CUDPConnection::DebugPacket(char eType, UDPPacketInfo *p) {
@@ -62,11 +61,9 @@ void CUDPConnection::IUDPConnection(CUDPComm *theOwner) {
     maxValid = -kSerialNumberStepSize;
 
     retransmitTime = kInitialRetransmitTime;
-    roundTripTime = kInitialRoundTripTime;
-    pessimistTime = roundTripTime;
-    optimistTime = roundTripTime;
-    realRoundTrip = roundTripTime;
-    deviation = roundTripTime;
+    urgentRetransmitTime = theOwner->urgentResendTime;
+    meanRoundTripTime = kInitialRoundTripTime;
+    varRoundTripTime = meanRoundTripTime*meanRoundTripTime;
     haveToSendAck = false;
     nextAckTime = 0;
 
@@ -86,6 +83,11 @@ void CUDPConnection::IUDPConnection(CUDPComm *theOwner) {
     quota = 0;
 
     routingMask = 0;
+    
+    #if PACKET_DEBUG
+        totalSent = 0;
+        totalResent = 0;
+    #endif
 }
 
 void CUDPConnection::FlushQueues() {
@@ -128,6 +130,7 @@ void CUDPConnection::SendQueuePacket(UDPPacketInfo *thePacket, short theDistribu
         busyQLen++;
 #if PACKET_DEBUG
         if (thePacket->packet.command == kpKeyAndMouse) {
+            thePacket->serialNumber = -1;  // assigned later
             DebugPacket('>', thePacket);
         }
 #endif
@@ -302,6 +305,13 @@ UDPPacketInfo *CUDPConnection::GetOutPacket(long curTime, long cramTime, long ur
         if (thePacket == kPleaseSendAcknowledge) {
             SDL_Log("CUDPConnection::DebugPacket(S) ACK\n");
         } else {
+            totalSent++;
+            if (thePacket->birthDate != thePacket->nextSendTime) {
+            // if (thePacket->lastSendTime > 0) {
+                totalResent++;
+                SDL_Log("CUDPConnection::GetOutPacket   RESENDING sn=%d, age=%ld, percentResends = %.1f\n",
+                        thePacket->serialNumber, curTime - thePacket->birthDate, 100.0*totalResent/totalSent);
+            }
             DebugPacket('S', thePacket);
         }
 #endif
@@ -320,44 +330,34 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, long when) {
         roundTrip = when - thePacket->birthDate;
 
         if (maxValid == 4) {
-            if (roundTrip < roundTripTime) {
-                roundTripTime = roundTrip;
-                pessimistTime = roundTrip;
-                optimistTime = roundTrip;
-                realRoundTrip = roundTrip;
+            if (roundTrip < meanRoundTripTime) {
+                meanRoundTripTime = roundTrip;
+                varRoundTripTime = roundTrip * roundTrip;  // err on the high side initially
             }
         } else {
-            long difference;
+            // compute an exponential moving average & variance of the roundTrip time
+            // see: https://fanf2.user.srcf.net/hermes/doc/antiforgery/stats.pdf
+            float difference = roundTrip - meanRoundTripTime;
+            // quicker to move up on latency spikes, slower to move down
+            float alpha =  1.0 / (1 << ((difference > 0) ? RTTSMOOTHFACTOR_UP : RTTSMOOTHFACTOR_DOWN));
+            float increment = alpha * difference;
+            meanRoundTripTime = meanRoundTripTime + increment;
+            varRoundTripTime = (1 - alpha) * (varRoundTripTime + difference * increment);
+            float stdevRoundTripTime = sqrt(varRoundTripTime);
 
-            if (roundTrip > roundTripTime) {
-                pessimistTime =
-                    ((pessimistTime << PESSIMISTSMOOTHFACTOR) - pessimistTime + roundTrip) >> PESSIMISTSMOOTHFACTOR;
-            } else {
-                optimistTime =
-                    ((optimistTime << PESSIMISTSMOOTHFACTOR) - optimistTime + roundTrip) >> PESSIMISTSMOOTHFACTOR;
-            }
+            // use +3 sigma(probability 99%) for retransmitTime, +2 sigma (95%) for urgentRetransmitTime
+            // (thought: consider dynamically adjusting the multiplier based on % of resends?)
+            retransmitTime = meanRoundTripTime + (long)(3*stdevRoundTripTime);
+            urgentRetransmitTime = meanRoundTripTime + (long)(2*stdevRoundTripTime);
+            
+            // don't let the retransmit times fall below threshold based on frame rate
+            retransmitTime = std::max(retransmitTime, itsOwner->urgentResendTime);
+            urgentRetransmitTime = std::max(urgentRetransmitTime, itsOwner->urgentResendTime);
 
-            roundTripTime = ((roundTripTime << RTTSMOOTHFACTOR) - roundTripTime + roundTrip) >> RTTSMOOTHFACTOR;
-
-            difference = roundTrip - optimistTime;
-
-            if (difference <= ((optimistTime + deviation) >> 2)) {
-                realRoundTrip = ((realRoundTrip << RTTSMOOTHFACTOR) - realRoundTrip + roundTrip) >> RTTSMOOTHFACTOR;
-            }
-
-            if (difference < 0)
-                difference = -difference;
-
-            if (difference <= optimistTime) {
-                difference <<= 1;
-                deviation = ((deviation << DEVIATIONSMOOTHFACTOR) - deviation + difference) >> DEVIATIONSMOOTHFACTOR;
-            }
-
-            retransmitTime = ((realRoundTrip * 2 + roundTripTime) >> 1) + deviation;
-            if (retransmitTime < itsOwner->urgentResendTime)
-                retransmitTime = itsOwner->urgentResendTime;
-            else if (retransmitTime > kMaxAllowedRetransmitTime)
-                retransmitTime = kMaxAllowedRetransmitTime;
+            #if PACKET_DEBUG
+                SDL_Log("conn=%d, roundTrip = %ld, meanRTT = %.1f, varRTT = %.1f, stdRTT = %.1f, retransmitTime = %ld, urgentRetransmit = %ld\n",
+                        myId, roundTrip, meanRoundTripTime, varRoundTripTime, stdevRoundTripTime, retransmitTime, urgentRetransmitTime);
+            #endif
         }
 
 #if PACKET_DEBUG > 1
@@ -419,7 +419,7 @@ char *CUDPConnection::ValidateReceivedPackets(char *validateInfo, long curTime) 
 
     validTime = curTime;
 
-    #if PACKET_DEBUG > 1
+    #if PACKET_DEBUG
         SDL_Log("ValidateReceivedPackets transmittedSerial=%d, maxValid = %d\n", transmittedSerial, maxValid);
     #endif
     if (maxValid < transmittedSerial) {
@@ -451,7 +451,9 @@ void CUDPConnection::ReceivedPacket(UDPPacketInfo *thePacket) {
     haveToSendAck = true;
 
     if (thePacket->serialNumber < receiveSerial) { //	We already got this one, so just release it.
-
+        // if the sender re-sent a packet we already have, that indicates they didn't get the ACK before
+        // they sent the message
+        
         itsOwner->ReleasePacket((PacketInfo *)thePacket);
     } else {
         if (thePacket->serialNumber ==
@@ -556,6 +558,8 @@ char *CUDPConnection::WriteAcks(char *dest) {
 
     mainAck = (short *)dest;
     dest += sizeof(short);
+    // (receiveSerial - kSerialNumberStepSize) is the last "valid" serial number received
+    // this lets recipient know that they don't need to re-send anything with this serial number or less
     *mainAck = receiveSerial - kSerialNumberStepSize;
 
     if (offsetBufferBusy == NULL && ackBase & 1) {
@@ -629,12 +633,15 @@ void CUDPConnection::FreshClient(ip_addr remoteHost, port_num remotePort, long f
     receiveSerial = firstReceiveSerial;
 
     maxValid = -kSerialNumberStepSize;
+
     retransmitTime = kInitialRetransmitTime;
-    roundTripTime = kInitialRoundTripTime;
-    pessimistTime = roundTripTime;
-    optimistTime = roundTripTime;
-    realRoundTrip = roundTripTime;
-    deviation = roundTripTime;
+    urgentRetransmitTime = itsOwner->urgentResendTime;
+    meanRoundTripTime = kInitialRoundTripTime;
+    varRoundTripTime = meanRoundTripTime*meanRoundTripTime;
+    // pessimistTime = roundTripTime;
+    // optimistTime = roundTripTime;
+    // realRoundTrip = roundTripTime;
+    // deviation = roundTripTime;
 
     cramData = 0;
 
@@ -699,10 +706,10 @@ void CUDPConnection::ReceiveControlPacket(PacketInfo *thePacket) {
 void CUDPConnection::GetConnectionStatus(short slot, UDPConnectionStatus *parms) {
     if (slot == myId) {
         parms->hostIP = ipAddr;
-        parms->estimatedRoundTrip = ((realRoundTrip << 9) + 256) / 125;
-        parms->averageRoundTrip = ((roundTripTime << 9) + 256) / 125;
-        parms->pessimistRoundTrip = ((pessimistTime << 9) + 256) / 125;
-        parms->optimistRoundTrip = ((optimistTime << 9) + 256) / 125;
+        // parms->estimatedRoundTrip = ((realRoundTrip << 9) + 256) / 125;
+        parms->averageRoundTrip = ((((long)meanRoundTripTime) << 9) + 256) / 125;
+        // parms->pessimistRoundTrip = ((pessimistTime << 9) + 256) / 125;
+        // parms->optimistRoundTrip = ((optimistTime << 9) + 256) / 125;
         parms->connectionType = cramData;
     } else {
         if (next)

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -21,6 +21,7 @@ typedef struct {
     PacketInfo packet;
 
     int32_t birthDate;
+    // int32_t lastSendTime;
     int32_t nextSendTime;
     int16_t serialNumber;
 
@@ -73,12 +74,10 @@ public:
 
     long validTime;
 
+    float meanRoundTripTime;
+    float varRoundTripTime;
     long retransmitTime;
-    long roundTripTime;
-    long pessimistTime;
-    long optimistTime;
-    long realRoundTrip;
-    long deviation;
+    long urgentRetransmitTime;
 
     long quota;
     short cramData;
@@ -89,6 +88,9 @@ public:
 #if PACKET_DEBUG
     short dp;
     OSType d[kDebugBufferSize];
+    
+    long totalSent;
+    long totalResent;
 #endif
 
     volatile short *offsetBufferBusy;


### PR DESCRIPTION
tl;dr - This should fix a large number of the hangs that we currently experience.

I noticed that many of the hangs that I was studying were involved with re-sending packets that had already been sent.  So I set out to figure out how that worked and improve it.  The first problem area was the computation of the average round-trip times and the deviation of that time.  These values are used to estimate the nextSendTime so if they are too small it will try to resend it too early.  I found that it was using a form of an exponential moving average, which on the surface is a great thing to do!  Unfortunately, the implementation used a lot of integer divides (with bit shifts) and the result of those calculations biased the results towards zero in a bad way.  For example, if you had an average roundTrip of 20 and got a new value of 19, it would adjust the average down to 19.  But it would've taken a value of 52 in order to adjust that average up to 21!  Ultimately, I chose to use floating point calculations and a more rigorous implementation as described in https://fanf2.user.srcf.net/hermes/doc/antiforgery/stats.pdf
Doing this removed a lot of the hocus-pocus and gives us a more explainable way to compute the next send time using statistics to determine a reasonable estimate of how long to wait for a resend.

The 2nd problem with the old implementation was that it used a fixed value, urgentResendTime (defaults to 64ms), to determine when to re-send "urgent" packets.  And since pretty much ALL game-time packets are considered 'urgent', this can lead to a situation where ALL packets could get re-sent on a laggy connection.  I modified this part of the code to use a similarly dynamically estimated value called urgentRetransmitTime.

Finally, and this is the BIG fix, I discovered that the game can be put into an infinite loop in cases where the resends pile up in such a way that it takes longer to process them than the retransmitTime.  This is in the part of the code where it is checking the turboMode flag and calling AsyncWrite().  This is called in a method that is ultimately called as a byproduct of UDPWrite() which creates an infinite loop.  This results in the program just trying to send the same messages, over and over and over again and never stops to read incoming messages.  That in turn causes all of the other clients to enter similar loops.  To fix this, I just made sure it could be only called a fixed number of times (3 for now).  And it seems to prevent this situation from happening.  YAY!