### PR TITLE
Add latency to roster window

### DIFF
--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -184,7 +184,10 @@ void CRosterWindow::UpdateRoster() {
         for (int i = 0; i < kMaxAvaraPlayers; i++) {
             CPlayerManager *thisPlayer = ((CAvaraAppImpl *)gApplication)->GetNet()->playerTable[i];
 
-            const std::string theName((char *)thisPlayer->PlayerName() + 1, thisPlayer->PlayerName()[0]);
+            std::string theName((char *)thisPlayer->PlayerName() + 1, thisPlayer->PlayerName()[0]);
+            if (i != theNet->itsCommManager->myId && theName.length() > 0) {
+                theName += std::string(" (") + std::to_string(theNet->itsCommManager->GetMaxRoundTrip(1 << i)) + " ms)";
+            }
             short status = thisPlayer->LoadingStatus();
             std::string theStatus = GetStringStatus(status, thisPlayer->WinFrame());
 

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -1626,12 +1626,13 @@ long CUDPComm::GetMaxRoundTrip(short distribution) {
 
     for (conn = connections; conn; conn = conn->next) {
         if (conn->port && (distribution & (1 << conn->myId))) {
-            if (conn->meanRoundTripTime > maxTrip)
-                maxTrip = conn->meanRoundTripTime;
+            if (conn->stableRoundTripTime > maxTrip) {
+                maxTrip = conn->stableRoundTripTime;
+            }
         }
     }
 
-    { maxTrip = ((maxTrip << 9) + 256) / 125; }
+    maxTrip = maxTrip*1000/240;
 
     return maxTrip;
 }

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -77,6 +77,7 @@ public:
     long validTime;
 
     float meanRoundTripTime;
+    float stableRoundTripTime;
     float varRoundTripTime;
     long retransmitTime;
     long urgentRetransmitTime;
@@ -87,7 +88,7 @@ public:
 
     short routingMask;
 
-#if DEBUG_AVARA
+#if PACKET_DEBUG
     short dp;
     OSType d[kDebugBufferSize];
     


### PR DESCRIPTION
This is a quick add of latency to the end of each user's name.  Feel free to modify how this looks.

Also replaced the unnecessary bit-shifting math on the roundTrip calculations so that we can use more than just powers of 2.