### PR TITLE
increase sigma multipliers for resend calculation

### DIFF
--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -6,7 +6,10 @@
     Created: Monday, January 29, 1996, 13:45
     Modified: Saturday, January 3, 1998, 02:04
 */
-// #include <unistd.h> // for usleep()
+#define SIMULATE_LATENCY_ON_CLIENTS 0
+#if SIMULATE_LATENCY_ON_CLIENTS
+#include <unistd.h> // for usleep()
+#endif
 
 #include "CUDPComm.h"
 
@@ -1038,7 +1041,12 @@ Boolean CUDPComm::AsyncWrite() {
                 SDL_Log("   WRITING UDP packet to %s using stream %p\n",
                         FormatAddr(udp->address).c_str(), stream);
             #endif
-            // usleep(30000 + int(10000*float(rand())/RAND_MAX)); // simulate network latencies
+            
+            #if SIMULATE_LATENCY_ON_CLIENTS
+                if (myId >= 1) {
+                    usleep(50000 + int(20000*float(rand())/RAND_MAX)); // simulate network latencies
+                }
+            #endif
             UDPWrite(stream, udp, UDPWriteComplete, this);
             result = true;
         }

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -129,7 +129,7 @@ void CUDPConnection::SendQueuePacket(UDPPacketInfo *thePacket, short theDistribu
 
         Enqueue((QElemPtr)thePacket, &queues[kBusyQ]);
         busyQLen++;
-#if PACKET_DEBUG
+#if PACKET_DEBUG > 1
         if (thePacket->packet.command == kpKeyAndMouse) {
             thePacket->serialNumber = -1;  // assigned later
             DebugPacket('>', thePacket);
@@ -362,10 +362,10 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, long when) {
             // for display purposes, use a more stable slow-moving alpha (TBR)
             stableRoundTripTime = meanRoundTripTime + difference / RTTSMOOTHFACTOR_DOWN;
 
-            // use +3 sigma(probability 99%) for retransmitTime, +2.5 sigma (98%) for urgentRetransmitTime
+            // use +3.5 sigma(probability 99.9%) for retransmitTime, +3 sigma (99.7%) for urgentRetransmitTime
             // (thought: consider dynamically adjusting the multiplier based on % of resends?)
-            retransmitTime = meanRoundTripTime + (long)(3*stdevRoundTripTime);
-            urgentRetransmitTime = meanRoundTripTime + (long)(2.5*stdevRoundTripTime);
+            retransmitTime = meanRoundTripTime + (long)(3.5*stdevRoundTripTime);
+            urgentRetransmitTime = meanRoundTripTime + (long)(3.0*stdevRoundTripTime);
             
             // don't let the retransmit times fall below threshold based on frame rate or go abvoe kMaxAllowedRetransmitTime
             retransmitTime = std::max(retransmitTime, itsOwner->urgentResendTime);


### PR DESCRIPTION
Although I added the SIMULATE_LATENCY_ON_CLIENTS flag to try to simulate latencies for testing, the only actual functional change for this PR is the increase in the sigma multiplier for the retransmitTime and urgentRetransmitTime calculations.  This means that there should be a slightly smaller number of resends.  I'm curious to see how much this will affect the beginnings of laggy games but suspect it will be minimal.

On my next change (tomorrow?) I will experiment with putting a limit on the number of consecutive resends.  Because what's the point in re-sending stuff repeatedly if the receiving client isn't responding?  I think that change will be more meaningful.
