### PR TITLE
avoid resend avalanche

### DIFF
--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -24,6 +24,8 @@
 #define RTTSMOOTHFACTOR_UP 5
 #define RTTSMOOTHFACTOR_DOWN 30
 
+#define MAX_RESENDS_WITHOUT_RECEIVE 2
+
 #if PACKET_DEBUG
 void CUDPConnection::DebugPacket(char eType, UDPPacketInfo *p) {
     SDL_Log("CUDPConnection::DebugPacket(%c) sn=%d cmd=%d p1=%d p2=%d p3=%d flags=0x%02x sndr=%d dist=0x%02x\n",
@@ -85,10 +87,9 @@ void CUDPConnection::IUDPConnection(CUDPComm *theOwner) {
 
     routingMask = 0;
     
-    #if PACKET_DEBUG
-        totalSent = 0;
-        totalResent = 0;
-    #endif
+    totalSent = 0;
+    totalResent = 0;
+    numResendsWithoutReceive = 0;
 }
 
 void CUDPConnection::FlushQueues() {
@@ -183,7 +184,8 @@ UDPPacketInfo *CUDPConnection::FindBestPacket(long curTime, long cramTime, long 
     
     while (bestPacket != NULL) {
         // make sure the we are actually beyond packet's nextSendTime, avoids extra resends
-        if (curTime >= bestPacket->nextSendTime) {
+        if (curTime >= bestPacket->nextSendTime &&
+            (bestPacket->birthDate == bestPacket->nextSendTime || numResendsWithoutReceive < MAX_RESENDS_WITHOUT_RECEIVE)) {
             break;
         }
         bestPacket = (UDPPacketInfo *)bestPacket->packet.qLink;
@@ -229,7 +231,10 @@ UDPPacketInfo *CUDPConnection::FindBestPacket(long curTime, long cramTime, long 
                     SDL_Log(" CUDPConnection::FindBestPacket bestSendTime = %ld\n", bestSendTime);
                     SDL_Log(" CUDPConnection::FindBestPacket theSendTime = %ld\n", theSendTime);
                 #endif
-                if (bestSendTime > theSendTime) {
+                // if this candidate packet has a smaller sendTime AND (it's never been sent OR we haven't reached the resend limit)
+                if (bestSendTime > theSendTime &&
+                    (thePacket->birthDate == thePacket->nextSendTime || numResendsWithoutReceive < MAX_RESENDS_WITHOUT_RECEIVE)) {
+                    // this is the NEW bestPacket
                     bestSendTime = theSendTime;
                     bestPacket = thePacket;
                 }
@@ -302,19 +307,24 @@ UDPPacketInfo *CUDPConnection::GetOutPacket(long curTime, long cramTime, long ur
         nextAckTime = curTime + kAckRetransmitBase + retransmitTime;
         nextWriteTime = curTime + retransmitTime;
 
-#if PACKET_DEBUG
         if (thePacket == kPleaseSendAcknowledge) {
-            SDL_Log("CUDPConnection::DebugPacket(S) ACK\n");
+            #if PACKET_DEBUG
+                SDL_Log("CUDPConnection::DebugPacket(S) ACK\n");
+            #endif
         } else {
             totalSent++;
             if (thePacket->birthDate != thePacket->nextSendTime) {
                 totalResent++;
-                SDL_Log("CUDPConnection::GetOutPacket   RESENDING sn=%d, age=%ld, percentResends = %.1f\n",
-                        thePacket->serialNumber, curTime - thePacket->birthDate, 100.0*totalResent/totalSent);
+                numResendsWithoutReceive++;
+                #if PACKET_DEBUG
+                    SDL_Log("CUDPConnection::GetOutPacket   RESENDING sn=%d, age=%ld, percentResends = %.1f, numResendsWithoutReceive = %ld\n",
+                            thePacket->serialNumber, curTime - thePacket->birthDate, 100.0*totalResent/totalSent, numResendsWithoutReceive);
+                #endif
             }
-            DebugPacket('S', thePacket);
+            #if PACKET_DEBUG
+                DebugPacket('S', thePacket);
+            #endif
         }
-#endif
     }
 
     return thePacket;
@@ -367,7 +377,7 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, long when) {
             retransmitTime = meanRoundTripTime + (long)(3.5*stdevRoundTripTime);
             urgentRetransmitTime = meanRoundTripTime + (long)(3.0*stdevRoundTripTime);
             
-            // don't let the retransmit times fall below threshold based on frame rate or go abvoe kMaxAllowedRetransmitTime
+            // don't let the retransmit times fall below threshold based on frame rate or go above kMaxAllowedRetransmitTime
             retransmitTime = std::max(retransmitTime, itsOwner->urgentResendTime);
             retransmitTime = std::min(retransmitTime, (long)kMaxAllowedRetransmitTime);
             urgentRetransmitTime = std::max(urgentRetransmitTime, itsOwner->urgentResendTime);
@@ -413,6 +423,9 @@ char *CUDPConnection::ValidateReceivedPackets(char *validateInfo, long curTime) 
     short transmittedSerial;
     short dummyStackVar;
     UDPPacketInfo *thePacket, *nextPacket;
+
+    // received something, reset the counter
+    numResendsWithoutReceive = 0;
 
     transmittedSerial = *(short *)validateInfo;
     validateInfo += sizeof(short);

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -14,7 +14,7 @@
 #define kSerialNumberStepSize 2
 #define kNumReceivedOffsets 128
 
-#define PACKET_DEBUG 0   // set to 1 for packet debug outpu, 2 for more detail
+#define PACKET_DEBUG 0   // set to 1 for packet debug output, 2 for extra detail
 
 #pragma pack(1)
 typedef struct {
@@ -89,10 +89,11 @@ public:
 #if PACKET_DEBUG
     short dp;
     OSType d[kDebugBufferSize];
+#endif
     
     long totalSent;
     long totalResent;
-#endif
+    long numResendsWithoutReceive;
 
     volatile short *offsetBufferBusy;
     int32_t ackBitmap;


### PR DESCRIPTION
On some of our laggy game, clients can get stuck resending packets to players who are causing the lag.  It can get out of hand and the laggy player may never catch up to process  the avalanche of resent packets so that the game just spins.

This fix sets an upper limit of 2 on the number of packets that a client may re-send until it gets some sort of reply back from that laggy player.  The theory is that re-sends should be rare and are meant to account for lost packets.  If the receiving client is just slow, then it's better to hold off re-sending to that player.

I'm hoping that this will fix the "resend avalanche" problem and that laggy connections will not kill a game entirely.