### PR TITLE
Kick "Waiting For" Player

### DIFF
--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -510,6 +510,17 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
                     break;
                 }
                 */
+
+                #define KICK_WAITING_FOR_PLAYER 1
+                #if KICK_WAITING_FOR_PLAYER
+                    // kick the offending player from the server so everyone else can continue
+                    AbortRequest();  // clears the player from distribution so they can come back in to the server (not the game)
+                    if (theNetManager->itsCommManager->myId == 0) { // the server kicks the unresponsive player
+                        itsGame->itsApp->AddMessageLine("Kicking unresponsive player: " + std::string((char*)&playerName[1], (size_t)playerName[0]));
+                        theNetManager->itsCommManager->SendPacket(kdEveryone, kpKillConnection, slot, 0, 0, 0, NULL);
+                    }
+                    break;
+                #endif
             }
 
         } while (frameFuncs[i].validFrame != itsGame->frameNumber);

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -656,13 +656,11 @@ void CUDPComm::ReadComplete(UDPpacket *packet) {
                         while (*inData.c++)
                             ;
                     }
-                }
-
-                #if PACKET_DEBUG
-                    if (inData.c == inEnd) {
+                } else if (inData.c == inEnd) {
+                    #if PACKET_DEBUG
                         SDL_Log("     CUDPComm::ReadComplete(R) <ACK> cn=%d rsn=%d\n", conn->myId, conn->maxValid);
-                    }
-                #endif
+                    #endif
+                }
 
                 while (inEnd > inData.c) {
                     PacketInfo *p;

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -654,6 +654,12 @@ void CUDPComm::ReadComplete(UDPpacket *packet) {
                     }
                 }
 
+                #if PACKET_DEBUG
+                    if (inData.c == inEnd) {
+                        SDL_Log("     CUDPComm::ReadComplete(R) <ACK> cn=%d rsn=%d\n", conn->myId, conn->maxValid);
+                    }
+                #endif
+
                 while (inEnd > inData.c) {
                     PacketInfo *p;
                     uint8_t flags;
@@ -967,9 +973,9 @@ Boolean CUDPComm::AsyncWrite() {
             thePacket->packet.qLink = (PacketInfo *)packetList;
             packetList = thePacket;
 
-            #if PACKET_DEBUG
-                SDL_Log("          preparing packet >>> rsn=%d sn=%d cmd=%d p1=%d p2=%d p3=%d flags=0x%02x sndr=%d dist=0x%02x\n",
-                        *(short*)&udp->data[2], thePacket->serialNumber, p->command, p->p1, p->p2, p->p3, p->flags, p->sender, p->distribution);
+            #if PACKET_DEBUG > 1 || ROUTE_THRU_SERVER // to see how flags get changed on ROUTE_THRU_SERVER
+                SDL_Log("          preparing packet >>> cn=%d rsn=%d sn=%d cmd=%d p1=%d p2=%d p3=%d flags=0x%02x sndr=%d dist=0x%02x\n",
+                        myId, *(short*)&udp->data[2], thePacket->serialNumber, p->command, p->p1, p->p2, p->p3, p->flags, p->sender, p->distribution);
             #endif
 
             // See if there are other messages that could be sent in this packet payload
@@ -991,9 +997,9 @@ Boolean CUDPComm::AsyncWrite() {
                 udp->address.host = connections->ipAddr;
                 udp->address.port = connections->port;
             }
+            SDL_Log("           destination host is %s\n", FormatAddr(theConnection).c_str());
         #endif
         #if PACKET_DEBUG
-            SDL_Log("           destination host is %s\n", FormatAddr(theConnection).c_str());
             SDL_Log("     transmitting packet(s) to %s\n", FormatAddr(udp->address).c_str());
         #endif
 


### PR DESCRIPTION
Much of this PR is a bunch of logging fixes mostly for my enjoyment (and trying to help debug future hangs).

But the fun part of this PR is that it will kick the "Waiting For" player so that the game can continue.  I'm hoping the effect of this is that laggy & hung games will be reduced to the minor annoyance of somebody with a laggy connection ending up getting the boot.  Let's try it out and see how it goes.  If it's too annoying then just change KICK_WAITING_FOR_PLAYER to 0.

I also added a #define for RANDOMLY_DROP_PACKETS which is used for testing flaky connections.  It's only for development/testing but I left it in because maybe somebody else will find it useful.