### PR TITLE
Latency2 branch merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ $(BUILD_DIR)/%.mm.o: %.mm
 .PHONY: clean publish
 
 set-version:
-	echo "#define GIT_VERSION \"$(GIT_HASH)\"" > src/util/GitVersion.h
+	grep -q $(GIT_HASH) src/util/GitVersion.h || (echo "#define GIT_VERSION \"$(GIT_HASH)\"" > src/util/GitVersion.h)
 
 build-link: $(BUILD_DIR)/Avara
 	@if [ ! -e build ] || [ -h build ]; then \

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -98,6 +98,7 @@ CNetManager* CAvaraGame::CreateNetManager() {
 
 CAvaraGame::CAvaraGame(int frameTime) {
     this->frameTime = frameTime; // milliseconds
+    this->latencyFrameTime = this->frameTime;
 }
 void CAvaraGame::IAvaraGame(CAvaraApp *theApp) {
     short i;
@@ -875,7 +876,7 @@ bool CAvaraGame::GameTick() {
 
     canPreSend = true;
     //nextScheduledFrame = startTime + frameTime;
-    nextScheduledFrame += frameTime;
+    nextScheduledFrame += latencyFrameTime;
 
     itsDepot->RunSliverActions();
     itsApp->StartFrame(frameNumber);

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -98,6 +98,7 @@ CNetManager* CAvaraGame::CreateNetManager() {
 
 CAvaraGame::CAvaraGame(int frameTime) {
     this->frameTime = frameTime; // milliseconds
+    this->latencyFrameTime = frameTime;
 }
 void CAvaraGame::IAvaraGame(CAvaraApp *theApp) {
     short i;
@@ -878,7 +879,7 @@ bool CAvaraGame::GameTick() {
 
     canPreSend = true;
 
-    nextScheduledFrame = startTime + latencyFrameTime;
+    nextScheduledFrame += latencyFrameTime;
 
     itsDepot->RunSliverActions();
     itsApp->StartFrame(frameNumber);

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1066,7 +1066,7 @@ void CAvaraGame::AdjustFrameTime() {
     // And below that point, we want to keep the game playable as long as possible so the parabolic
     // shape tries to keep the latency as low as possible in the play zone.
 
-    #define LATENCY_DIVISOR 12
+    #define LATENCY_DIVISOR 12.5
     // The LATENCY_DIVISOR constant defines the shape of the latency curve (larger = more playable, smaller = better recovery).
     // Here is a summary how the LATENCY_DIVISOR of 12 affects playability and recoverability:
     //    LT  frameTime(ms) latency(ms)  messages/sec
@@ -1078,10 +1078,16 @@ void CAvaraGame::AdjustFrameTime() {
     //    5   128           640          8    <-- hope to never see LT > 4
     //    6   192           1152         5
     //    7   256           1792         4
-    //    8   336           2688         3    <-- trying to recover!  If it were a horse, I'd shoot it.
+    //    8   320           2560         3    <-- trying to recover!  If it were a horse, I'd shoot it.
 
     #define ATOMIC_TIME_DIVISOR 4  // actual game loop clock time is frameTime/4
     // calculate latencyFrameTime as integer multiple of the "atomic" clock value
     latencyFrameTime = frameTime * std::max(1.0, round(ATOMIC_TIME_DIVISOR * pow(latencyTolerance, 2) / LATENCY_DIVISOR) / ATOMIC_TIME_DIVISOR);
     SDL_Log("*** latencyFrameTime = %ld\n", latencyFrameTime);
+}
+
+
+long CAvaraGame::TimeToFrameCount(long timeInMsec) {
+    // how many frames occur in timeInMsec?
+    return timeInMsec / latencyFrameTime;
 }

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1044,6 +1044,7 @@ void CAvaraGame::SetLatencyTolerance(long newLatency, int maxChange) {
         } else {
             latencyTolerance = std::min(latencyTolerance+maxChange, std::min(newLatency, MAX_LATENCY));
         }
+        gApplication->Set(kLatencyToleranceTag, latencyTolerance);
         SDL_Log("*** LT set to %ld\n", latencyTolerance);
         AdjustFrameTime();
     }

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1026,6 +1026,10 @@ double CAvaraGame::FrameTimeScale(double exponent) {
     return pow(double(frameTime)/CLASSICFRAMETIME, exponent);
 }
 
+double CAvaraGame::LatencyFrameTimeScale() {
+    return double(latencyFrameTime)/frameTime;
+}
+
 
 long CAvaraGame::RoundTripToFrameLatency(long roundTripTime) {
     // half of the roundTripTime in units of frameTime, rounded

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1032,19 +1032,17 @@ long CAvaraGame::RoundTripToFrameLatency(long roundTripTime) {
     return (roundTripTime + frameTime) / (2*frameTime);
 }
 
-
-void CAvaraGame::SetLatencyTolerance(long newLatency, bool limitChange) {
+void CAvaraGame::SetLatencyTolerance(long newLatency, int maxChange) {
     if (latencyTolerance != newLatency) {
         #define MAX_LATENCY ((long)8)
-        #define MAX_LATENCY_CHANGE 2
-        if (limitChange) {
-            if (newLatency < latencyTolerance) {
-                latencyTolerance = std::max(latencyTolerance-MAX_LATENCY_CHANGE, newLatency);
-            } else {
-                latencyTolerance = std::min(latencyTolerance+MAX_LATENCY_CHANGE, std::min(newLatency, MAX_LATENCY));
-            }
+        if (maxChange < 0) {
+            // allow latency to jump to any value
+            maxChange = MAX_LATENCY;
+        }
+        if (newLatency < latencyTolerance) {
+            latencyTolerance = std::max(latencyTolerance-maxChange, std::max(newLatency, (long)0));
         } else {
-            latencyTolerance = newLatency;
+            latencyTolerance = std::min(latencyTolerance+maxChange, std::min(newLatency, MAX_LATENCY));
         }
         SDL_Log("*** LT set to %ld\n", latencyTolerance);
         AdjustFrameTime();

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -98,8 +98,6 @@ CNetManager* CAvaraGame::CreateNetManager() {
 
 CAvaraGame::CAvaraGame(int frameTime) {
     this->frameTime = frameTime; // milliseconds
-    this->latencyTolerance = gApplication->Number(kLatencyToleranceTag);
-    this->AdjustLatencyFrameTime();
 }
 void CAvaraGame::IAvaraGame(CAvaraApp *theApp) {
     short i;
@@ -684,6 +682,8 @@ static Boolean takeShot = false;
 
 void CAvaraGame::ReadGamePrefs() {
     sensitivity = itsApp->Number(kMouseSensitivityTag);
+    latencyTolerance = gApplication->Number(kLatencyToleranceTag);
+    AdjustLatencyFrameTime();
 }
 
 void CAvaraGame::ResumeGame() {

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1069,21 +1069,21 @@ void CAvaraGame::AdjustFrameTime() {
     // And below that point, we want to keep the game playable as long as possible so the parabolic
     // shape tries to keep the latency as low as possible in the play zone.
 
-    #define LATENCY_DIVISOR 12.5
+    #define LATENCY_DIVISOR 16
     // The LATENCY_DIVISOR constant defines the shape of the latency curve (larger = more playable, smaller = better recovery).
     // Here is a summary how the LATENCY_DIVISOR of 12 affects playability and recoverability:
     //    LT  frameTime(ms) latency(ms)  messages/sec
     //    0   64            0            16   <-- most playable (LAN)
     //    1   64            64           16   <-- good internet
     //    2   64            128          16
-    //    3   64            192          16   <-- somewhat playable
-    //    4   80            320          13   <-- barely playable / begin recovering?
-    //    5   128           640          8    <-- hope to never see LT > 4
-    //    6   192           1152         5
-    //    7   256           1792         4
-    //    8   320           2560         3    <-- trying to recover!  If it were a horse, I'd shoot it.
+    //    3   64            192          16 
+    //    4   64            256          16   <-- somewhat playable, laggy
+    //    5   96            480          10   <-- barely playable / begin recovering
+    //    6   144           864          7    <-- hope to never see LT > 5
+    //    7   192           1344         5
+    //    8   256           2048         4    <-- trying to recover!  If it were a horse, I'd shoot it.
 
-    #define ATOMIC_TIME_DIVISOR 4  // actual game loop clock time is frameTime/4
+    #define ATOMIC_TIME_DIVISOR 4.0  // actual game loop clock time is frameTime/4
     // calculate latencyFrameTime as integer multiple of the "atomic" clock value
     latencyFrameTime = frameTime * std::max(1.0, round(ATOMIC_TIME_DIVISOR * pow(latencyTolerance, 2) / LATENCY_DIVISOR) / ATOMIC_TIME_DIVISOR);
     SDL_Log("*** latencyFrameTime = %ld\n", latencyFrameTime);

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -871,7 +871,7 @@ bool CAvaraGame::GameTick() {
 
     itsNet->AutoLatencyControl(frameNumber, longWait);
 
-SDL_Log("latencyTolerance = %ld\n", latencyTolerance);
+    // SDL_Log("latencyTolerance = %ld, latencyFrameTime = %ld\n", latencyTolerance, latencyFrameTime);
     if (latencyTolerance)
         while (frameNumber + latencyTolerance > topSentFrame)
             itsNet->FrameAction();
@@ -1033,14 +1033,18 @@ long CAvaraGame::RoundTripToFrameLatency(long roundTripTime) {
 }
 
 
-void CAvaraGame::AdjustLatencyTolerance(long newLatency) {
+void CAvaraGame::SetLatencyTolerance(long newLatency, bool limitChange) {
     if (latencyTolerance != newLatency) {
         #define MAX_LATENCY ((long)8)
         #define MAX_LATENCY_CHANGE 2
-        if (newLatency < latencyTolerance) {
-            latencyTolerance = std::max(latencyTolerance-MAX_LATENCY_CHANGE, newLatency);
+        if (limitChange) {
+            if (newLatency < latencyTolerance) {
+                latencyTolerance = std::max(latencyTolerance-MAX_LATENCY_CHANGE, newLatency);
+            } else {
+                latencyTolerance = std::min(latencyTolerance+MAX_LATENCY_CHANGE, std::min(newLatency, MAX_LATENCY));
+            }
         } else {
-            latencyTolerance = std::min(latencyTolerance+MAX_LATENCY_CHANGE, std::min(newLatency, MAX_LATENCY));
+            latencyTolerance = newLatency;
         }
         SDL_Log("*** LT set to %ld\n", latencyTolerance);
         AdjustFrameTime();

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1031,9 +1031,10 @@ double CAvaraGame::LatencyFrameTimeScale() {
 }
 
 
-long CAvaraGame::RoundTripToFrameLatency(long roundTripTime) {
+long CAvaraGame::RoundTripToFrameLatency(long roundTrip) {
     // half of the roundTripTime in units of frameTime, rounded
-    return (roundTripTime + frameTime) / (2*frameTime);
+    SDL_Log("CAvaraGame::RoundTripToFrameLatency roundTrip=%ld, LT(unrounded)=%.2lf\n", roundTrip, (roundTrip) / (2.0*frameTime));
+    return (roundTrip + frameTime) / (2*frameTime);
 }
 
 void CAvaraGame::SetLatencyTolerance(long newLatency, int maxChange) {

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -243,6 +243,8 @@ public:
     virtual CPlayerManager *FindPlayerManager(CAbstractPlayer *thePlayer);
 
     virtual double FrameTimeScale(double exponent=1);
+
+    virtual void AdjustLatencyFrameTime();
 };
 
 #ifndef MAINAVARAGAME

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -80,6 +80,7 @@ public:
 
     long topSentFrame;
 
+    long latencyFrameTime; //	In milliseconds.
     long frameTime; //	In milliseconds.
     short gameStatus;
     short statusRequest;

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -245,7 +245,7 @@ public:
     virtual double FrameTimeScale(double exponent=1);
 
     virtual long RoundTripToFrameLatency(long rtt);
-    virtual void SetLatencyTolerance(long newLatency, bool limitChange = true);
+    virtual void SetLatencyTolerance(long newLatency, int maxChange = 2);
     virtual void AdjustFrameTime();
     virtual long TimeToFrameCount(long timeInMsec);
 };

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -244,7 +244,9 @@ public:
 
     virtual double FrameTimeScale(double exponent=1);
 
-    virtual void AdjustLatencyFrameTime();
+    virtual long RoundTripToFrameLatency(long rtt);
+    virtual void AdjustLatencyTolerance(long newLatency);
+    virtual void AdjustFrameTime();
 };
 
 #ifndef MAINAVARAGAME

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -245,7 +245,7 @@ public:
     virtual double FrameTimeScale(double exponent=1);
 
     virtual long RoundTripToFrameLatency(long rtt);
-    virtual void AdjustLatencyTolerance(long newLatency);
+    virtual void SetLatencyTolerance(long newLatency, bool limitChange = true);
     virtual void AdjustFrameTime();
 };
 

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -247,6 +247,7 @@ public:
     virtual long RoundTripToFrameLatency(long rtt);
     virtual void SetLatencyTolerance(long newLatency, bool limitChange = true);
     virtual void AdjustFrameTime();
+    virtual long TimeToFrameCount(long timeInMsec);
 };
 
 #ifndef MAINAVARAGAME

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -243,6 +243,7 @@ public:
     virtual CPlayerManager *FindPlayerManager(CAbstractPlayer *thePlayer);
 
     virtual double FrameTimeScale(double exponent=1);
+    virtual double LatencyFrameTimeScale();
 
     virtual long RoundTripToFrameLatency(long rtt);
     virtual void SetLatencyTolerance(long newLatency, int maxChange = 2);

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -39,7 +39,7 @@
 #if ROUTE_THRU_SERVER
     #define kAvaraNetVersion 7
 #else
-    #define kAvaraNetVersion 6
+    #define kAvaraNetVersion 666
 #endif
 
 #define kMessageBufferMaxAge 90
@@ -692,6 +692,8 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
 
                 if (didChange) {
                     SDL_Log("*** LT set to %ld\n", itsGame->latencyTolerance);
+                    itsGame->latencyFrameTime = itsGame->frameTime * (4 + itsGame->latencyTolerance) / 4;
+                    SDL_Log("*** latencyFrameTime = %ld\n", itsGame->latencyFrameTime);
                     /*
                     if(itsGame->latencyTolerance > 1) {
                         itsGame->latencyTolerance = 1;

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -6,6 +6,7 @@
     Created: Monday, May 15, 1995, 22:25
     Modified: Tuesday, September 17, 1996, 03:21
 */
+#include <algorithm> // std::max
 
 #include "CNetManager.h"
 
@@ -692,7 +693,8 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
 
                 if (didChange) {
                     SDL_Log("*** LT set to %ld\n", itsGame->latencyTolerance);
-                    itsGame->latencyFrameTime = itsGame->frameTime * (4 + itsGame->latencyTolerance) / 4;
+                    // standard frame rate for LT 0-1, increases beyond that
+                    itsGame->latencyFrameTime = itsGame->frameTime * std::max(3 + itsGame->latencyTolerance, (long)4) / 4;
                     SDL_Log("*** latencyFrameTime = %ld\n", itsGame->latencyFrameTime);
                     /*
                     if(itsGame->latencyTolerance > 1) {

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -925,10 +925,10 @@ void CNetManager::DoConfig(short senderSlot) {
 
     if (PermissionQuery(kAllowLatencyBit, 0) || !(activePlayersDistribution & kdServerOnly)) {
         if (itsGame->latencyTolerance < theConfig->latencyTolerance)
-            itsGame->SetLatencyTolerance(theConfig->latencyTolerance, false);
+            itsGame->SetLatencyTolerance(theConfig->latencyTolerance, -1);
     } else {
         if (senderSlot == 0) {
-            itsGame->SetLatencyTolerance(theConfig->latencyTolerance, false);
+            itsGame->SetLatencyTolerance(theConfig->latencyTolerance, -1);
         }
     }
 }

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -685,6 +685,7 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
                         maxFrameLatency, autoLatencyVote, addOneLatency, maxRoundTripLatency, itsGame->frameTime);
 
                 itsGame->SetLatencyTolerance(maxFrameLatency);
+                itsCommManager->frameTimeScale = itsGame->LatencyFrameTimeScale();
             }
 
             autoLatencyVote = 0;
@@ -926,9 +927,11 @@ void CNetManager::DoConfig(short senderSlot) {
     if (PermissionQuery(kAllowLatencyBit, 0) || !(activePlayersDistribution & kdServerOnly)) {
         if (itsGame->latencyTolerance < theConfig->latencyTolerance)
             itsGame->SetLatencyTolerance(theConfig->latencyTolerance, -1);
+            itsCommManager->frameTimeScale = itsGame->LatencyFrameTimeScale();
     } else {
         if (senderSlot == 0) {
             itsGame->SetLatencyTolerance(theConfig->latencyTolerance, -1);
+            itsCommManager->frameTimeScale = itsGame->LatencyFrameTimeScale();
         }
     }
 }

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -41,7 +41,7 @@
 #if ROUTE_THRU_SERVER
     #define kAvaraNetVersion 8
 #else
-    #define kAvaraNetVersion 070  // in honor of Seven and his mighty latency
+    #define kAvaraNetVersion 071  // in honor of Seven and his mighty latency
 #endif
 
 #define kMessageBufferMaxAge 90

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -682,7 +682,7 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
                 SDL_Log("*** maxFrameLatency=%ld autoLatencyVote=%ld addOneLatency=%d maxRoundLatency=%d frameTime=%ld\n",
                         maxFrameLatency, autoLatencyVote, addOneLatency, maxRoundTripLatency, itsGame->frameTime);
 
-                itsGame->AdjustLatencyTolerance(maxFrameLatency);
+                itsGame->SetLatencyTolerance(maxFrameLatency);
             }
 
             autoLatencyVote = 0;
@@ -923,10 +923,10 @@ void CNetManager::DoConfig(short senderSlot) {
 
     if (PermissionQuery(kAllowLatencyBit, 0) || !(activePlayersDistribution & kdServerOnly)) {
         if (itsGame->latencyTolerance < theConfig->latencyTolerance)
-            itsGame->latencyTolerance = theConfig->latencyTolerance;
+            itsGame->SetLatencyTolerance(theConfig->latencyTolerance, false);
     } else {
         if (senderSlot == 0) {
-            itsGame->latencyTolerance = theConfig->latencyTolerance;
+            itsGame->SetLatencyTolerance(theConfig->latencyTolerance, false);
         }
     }
 }

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -32,8 +32,9 @@
 
 #include <string.h>
 
-#define AUTOLATENCYPERIOD 64
-#define AUTOLATENCYDELAY 8
+#define AUTOLATENCYPERIOD 3840  // msec - this number is evenly divisible by every frameTime in CAvaraGame::AdjustFrameTime
+                                // to ensure it happens at a consistent clock time (every 3.84 seconds).  Better safe than sorry.
+#define AUTOLATENCYDELAY  384   // msec 
 #define LOWERLATENCYCOUNT 3
 #define HIGHERLATENCYCOUNT 8
 
@@ -652,8 +653,9 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
         localLatencyNoVote++;
     }
 
-    if (frameNumber >= AUTOLATENCYPERIOD) {
-        if ((frameNumber & (AUTOLATENCYPERIOD - 1)) == 0) {
+    long autoLatencyPeriod = itsGame->TimeToFrameCount(AUTOLATENCYPERIOD);
+    if (frameNumber >= autoLatencyPeriod) {
+        if ((frameNumber & (autoLatencyPeriod - 1)) == 0) {
             long maxRoundLatency;
 
             maxRoundLatency = itsCommManager->GetMaxRoundTrip(activePlayersDistribution);
@@ -662,7 +664,7 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
             SDL_Log("*** localLatencyVote=%ld localLatencyNoVote=%ld\n", localLatencyVote, localLatencyNoVote);
             localLatencyVote = 0;
             localLatencyNoVote = 0;
-        } else if (((frameNumber + AUTOLATENCYDELAY) & (AUTOLATENCYPERIOD - 1)) == 0) {
+        } else if (((frameNumber + itsGame->TimeToFrameCount(AUTOLATENCYDELAY)) & (autoLatencyPeriod - 1)) == 0) {
             if (fragmentDetected) {
                 itsGame->itsApp->MessageLine(kmFragmentAlert, centerAlign);
                 fragmentDetected = false;

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -661,8 +661,10 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
             maxRoundLatency = itsCommManager->GetMaxRoundTrip(activePlayersDistribution);
             itsCommManager->SendUrgentPacket(
                 activePlayersDistribution, kpLatencyVote, localLatencyVote, maxRoundLatency, FRandSeed, 0, NULL);
-            SDL_Log("*** fn=%ld autoLatencyPeriod=%ld, localLatencyVote=%ld localLatencyNoVote=%ld\n",
-                    frameNumber, autoLatencyPeriod,localLatencyVote, localLatencyNoVote);
+            #if LATENCY_DEBUG
+                SDL_Log("*** fn=%ld autoLatencyPeriod=%ld, localLatencyVote=%ld localLatencyNoVote=%ld maxRoundLatency=%ld\n",
+                        frameNumber, autoLatencyPeriod,localLatencyVote, localLatencyNoVote, maxRoundLatency);
+            #endif
             localLatencyVote = 0;
             localLatencyNoVote = 0;
         } else if ((frameNumber % autoLatencyPeriod) == itsGame->TimeToFrameCount(AUTOLATENCYDELAY)) {
@@ -676,14 +678,16 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
 
                 autoLatencyVote /= autoLatencyVoteCount;
 
-                if (autoLatencyVote > HIGHERLATENCYCOUNT) {
-                    addOneLatency = 1;
-                }
+                // if (autoLatencyVote > HIGHERLATENCYCOUNT) {
+                //     addOneLatency = 1;
+                // }
 
                 maxFrameLatency = addOneLatency + itsGame->RoundTripToFrameLatency(maxRoundTripLatency);
 
-                SDL_Log("*** fn=%ld, maxFrameLatency=%ld autoLatencyVote=%ld addOneLatency=%d maxRoundLatency=%d frameTime=%ld\n",
-                        frameNumber, maxFrameLatency, autoLatencyVote, addOneLatency, maxRoundTripLatency, itsGame->frameTime);
+                #if LATENCY_DEBUG
+                    SDL_Log("*** fn=%ld frameTime=%ld maxFrameLatency=%ld autoLatencyVote=%ld addOneLatency=%d maxRoundLatency=%d\n",
+                            frameNumber, itsGame->frameTime, maxFrameLatency, autoLatencyVote, addOneLatency, maxRoundTripLatency);
+                #endif
 
                 itsGame->SetLatencyTolerance(maxFrameLatency);
                 itsCommManager->frameTimeScale = itsGame->LatencyFrameTimeScale();

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -41,7 +41,7 @@
 #if ROUTE_THRU_SERVER
     #define kAvaraNetVersion 8
 #else
-    #define kAvaraNetVersion 071  // in honor of Seven and his mighty latency
+    #define kAvaraNetVersion 7
 #endif
 
 #define kMessageBufferMaxAge 90

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -32,8 +32,8 @@
 
 #include <string.h>
 
-#define AUTOLATENCYPERIOD 3840  // msec - this number is evenly divisible by every frameTime in CAvaraGame::AdjustFrameTime
-                                // to ensure it happens at a consistent clock time (every 3.84 seconds).  Better safe than sorry.
+#define AUTOLATENCYPERIOD 3456  // msec - this number is evenly divisible by every frameTime in CAvaraGame::AdjustFrameTime
+                                // to ensure it happens at a consistent clock time (every 3.456 seconds).  Better safe than sorry.
 #define AUTOLATENCYDELAY  384   // msec 
 #define LOWERLATENCYCOUNT 3
 #define HIGHERLATENCYCOUNT 8

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -655,16 +655,17 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
 
     long autoLatencyPeriod = itsGame->TimeToFrameCount(AUTOLATENCYPERIOD);
     if (frameNumber >= autoLatencyPeriod) {
-        if ((frameNumber & (autoLatencyPeriod - 1)) == 0) {
+        if ((frameNumber % autoLatencyPeriod) == 0) {
             long maxRoundLatency;
 
             maxRoundLatency = itsCommManager->GetMaxRoundTrip(activePlayersDistribution);
             itsCommManager->SendUrgentPacket(
                 activePlayersDistribution, kpLatencyVote, localLatencyVote, maxRoundLatency, FRandSeed, 0, NULL);
-            SDL_Log("*** localLatencyVote=%ld localLatencyNoVote=%ld\n", localLatencyVote, localLatencyNoVote);
+            SDL_Log("*** fn=%ld autoLatencyPeriod=%ld, localLatencyVote=%ld localLatencyNoVote=%ld\n",
+                    frameNumber, autoLatencyPeriod,localLatencyVote, localLatencyNoVote);
             localLatencyVote = 0;
             localLatencyNoVote = 0;
-        } else if (((frameNumber + itsGame->TimeToFrameCount(AUTOLATENCYDELAY)) & (autoLatencyPeriod - 1)) == 0) {
+        } else if ((frameNumber % autoLatencyPeriod) == itsGame->TimeToFrameCount(AUTOLATENCYDELAY)) {
             if (fragmentDetected) {
                 itsGame->itsApp->MessageLine(kmFragmentAlert, centerAlign);
                 fragmentDetected = false;
@@ -681,8 +682,8 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
 
                 maxFrameLatency = addOneLatency + itsGame->RoundTripToFrameLatency(maxRoundTripLatency);
 
-                SDL_Log("*** maxFrameLatency=%ld autoLatencyVote=%ld addOneLatency=%d maxRoundLatency=%d frameTime=%ld\n",
-                        maxFrameLatency, autoLatencyVote, addOneLatency, maxRoundTripLatency, itsGame->frameTime);
+                SDL_Log("*** fn=%ld, maxFrameLatency=%ld autoLatencyVote=%ld addOneLatency=%d maxRoundLatency=%d frameTime=%ld\n",
+                        frameNumber, maxFrameLatency, autoLatencyVote, addOneLatency, maxRoundTripLatency, itsGame->frameTime);
 
                 itsGame->SetLatencyTolerance(maxFrameLatency);
                 itsCommManager->frameTimeScale = itsGame->LatencyFrameTimeScale();

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -99,6 +99,7 @@ public:
 
     Boolean autoLatencyEnabled;
     long localLatencyVote;
+    long localLatencyNoVote;
     long autoLatencyVote;
     long autoLatencyVoteCount;
     short maxRoundTripLatency;

--- a/src/net/CCommManager.h
+++ b/src/net/CCommManager.h
@@ -63,6 +63,8 @@ public:
 
     short genericInfoTextRes;
 
+    double frameTimeScale = 1.0;     // when time is slowed down, this number is > 1
+
     //	For method documentation, see .c-file:
 
     virtual void ICommManager(short packetSpace);

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -1027,8 +1027,7 @@ Boolean CUDPComm::AsyncWrite() {
         while (packetList && packetList != kPleaseSendAcknowledge) {
             thePacket = (UDPPacketInfo *)packetList->packet.qLink;
 
-            if (packetList->birthDate ==
-                packetList->nextSendTime) { //	This was the first time the packet was ever sent out.
+            if (packetList->sendCount++ == 0) {  //	This is the first time to send the packet
 
                 packetList->birthDate = curTime;
 

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -1873,7 +1873,7 @@ void CUDPComm::Reconfigure() {
 }
 
 long CUDPComm::GetMaxRoundTrip(short distribution) {
-    long maxTrip = 0;
+    float maxTrip = 0;
     CUDPConnection *conn;
 
     for (conn = connections; conn; conn = conn->next) {

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -10,6 +10,7 @@
 #pragma once
 #include "AvaraTCP.h"
 #include "CCommManager.h"
+#include "CommDefs.h"
 #include "Types.h"
 
 #include <string>

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -21,8 +21,8 @@
 #define kMaxTransmitQueueLength 128 //	128 packets going out...
 #define kMaxReceiveQueueLength 32 //	32 packets...arbitrary guess
 
-#define RTTSMOOTHFACTOR_UP 5
-#define RTTSMOOTHFACTOR_DOWN 30
+#define RTTSMOOTHFACTOR_UP 10
+#define RTTSMOOTHFACTOR_DOWN 20
 
 #define MAX_RESENDS_WITHOUT_RECEIVE 2
 

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -21,8 +21,8 @@
 #define kMaxTransmitQueueLength 128 //	128 packets going out...
 #define kMaxReceiveQueueLength 32 //	32 packets...arbitrary guess
 
-#define RTTSMOOTHFACTOR_UP 15
-#define RTTSMOOTHFACTOR_DOWN 15
+#define RTTSMOOTHFACTOR_UP 10
+#define RTTSMOOTHFACTOR_DOWN 20
 
 #define MAX_RESENDS_WITHOUT_RECEIVE 2
 

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -10,7 +10,6 @@
 #include "CUDPConnection.h"
 
 #include "CUDPComm.h"
-#include "CommDefs.h"
 #include "System.h"
 
 #define kInitialRetransmitTime 480 //	2	seconds

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -21,8 +21,8 @@
 #define kMaxTransmitQueueLength 128 //	128 packets going out...
 #define kMaxReceiveQueueLength 32 //	32 packets...arbitrary guess
 
-#define RTTSMOOTHFACTOR_UP 10
-#define RTTSMOOTHFACTOR_DOWN 20
+#define RTTSMOOTHFACTOR_UP 15
+#define RTTSMOOTHFACTOR_DOWN 15
 
 #define MAX_RESENDS_WITHOUT_RECEIVE 2
 

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -387,8 +387,8 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, long when) {
             urgentRetransmitTime = std::min(urgentRetransmitTime, (long)kMaxAllowedRetransmitTime);
 
             #if PACKET_DEBUG || LATENCY_DEBUG
-                SDL_Log("                               roundTrip=%ld mean=%.1f std = %.1f retransmitTime=%ld urgentRetransmit=%ld\n",
-                        roundTrip, meanRoundTripTime, stdevRoundTripTime, retransmitTime, urgentRetransmitTime);
+                SDL_Log("                               cn=%d cmd=%d roundTrip=%ld mean=%.1f std = %.1f retransmitTime=%ld urgentRetransmit=%ld\n",
+                        myId, thePacket->packet.command, roundTrip, meanRoundTripTime, stdevRoundTripTime, retransmitTime, urgentRetransmitTime);
             #endif
         }
 

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -21,8 +21,8 @@
 #define kMaxTransmitQueueLength 128 //	128 packets going out...
 #define kMaxReceiveQueueLength 32 //	32 packets...arbitrary guess
 
-#define RTTSMOOTHFACTOR_UP 10
-#define RTTSMOOTHFACTOR_DOWN 20
+#define RTTSMOOTHFACTOR_UP 20
+#define RTTSMOOTHFACTOR_DOWN 40
 
 #define MAX_RESENDS_WITHOUT_RECEIVE 2
 

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -24,6 +24,7 @@ typedef struct {
     // int32_t lastSendTime;
     int32_t nextSendTime;
     int16_t serialNumber;
+    int16_t sendCount;
 
 } UDPPacketInfo;
 #pragma pack()

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -15,6 +15,7 @@
 #define kNumReceivedOffsets 128
 
 #define PACKET_DEBUG 0   // set to 1 for packet debug output, 2 for extra detail
+#define LATENCY_DEBUG 1
 
 #pragma pack(1)
 typedef struct {
@@ -125,7 +126,7 @@ public:
 
     virtual void FreshClient(ip_addr remoteHost, port_num remotePort, long firstReceiveSerial);
 
-#if PACKET_DEBUG
+#if PACKET_DEBUG || LATENCY_DEBUG
     virtual void DebugPacket(char eType, UDPPacketInfo *p);
 #endif
     virtual void CloseSlot(short theId);

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -76,7 +76,6 @@ public:
     long validTime;
 
     float meanRoundTripTime;
-    float stableRoundTripTime;
     float varRoundTripTime;
     long retransmitTime;
     long urgentRetransmitTime;

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -10,12 +10,12 @@
 #pragma once
 #include "CCommManager.h"
 #include "CDirectObject.h"
+#include "CommDefs.h"
 
 #define kSerialNumberStepSize 2
 #define kNumReceivedOffsets 128
 
 #define PACKET_DEBUG 0   // set to 1 for packet debug output, 2 for extra detail
-#define LATENCY_DEBUG 1
 
 #pragma pack(1)
 typedef struct {

--- a/src/net/CommDefs.h
+++ b/src/net/CommDefs.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#define LATENCY_DEBUG 1
+#define LATENCY_DEBUG 0
 
 /*
 **	Communications packet commands:

--- a/src/net/CommDefs.h
+++ b/src/net/CommDefs.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#define LATENCY_DEBUG 1
+
 /*
 **	Communications packet commands:
 */


### PR DESCRIPTION
copying this from my IRC comment...

latency2 was me going back to basic principles. Don't affect the physics by changing frameTime was the first thing. But I still saw the value in slowing the game down for higher values of LT (>4) because that allows the game to catch up when things get bad and it avoids the chipmunk mode. I iterated a couple of times on this but ended up with an N^2 equation for frameTime that kept it at the original frameTime all the way through LT=4 and then started to degrade after that. This gives a nice balance of playability all the way up through LT=4 and recoverability as LT goes above LT=5 and the rate of packets drops by a factor of 4 at LT=8 (at the expense of playability).

In addition, after I got all that working, I "tuned" the smoothing factors for roundTripTime calculations which feeds into the LT calculation so that they don't change too quickly.  In a game with Seven I noticed it was jerking us around pretty quickly as it adjusted to the correct LT.  So my goal there was, for an LT jump of 2 frames, to have it increase by LT+=1 after the first 4 seconds, and not jump to the next value until about 8 seconds have passed.  Conversely, on the way DOWN, LT values decrease approximately half as fast so that it goes up a little quicker than it goes down.  Hopefully this will keep things feeling a little more stable, even in the face of a laggy connection (which is why I've been trying to get Seven to test given his connection issues).