### PR TITLE
Fix serial number rollover hang

### DIFF
--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -39,9 +39,9 @@
 #define HIGHERLATENCYCOUNT 8
 
 #if ROUTE_THRU_SERVER
-    #define kAvaraNetVersion 8
+    #define kAvaraNetVersion 666
 #else
-    #define kAvaraNetVersion 7
+    #define kAvaraNetVersion 8
 #endif
 
 #define kMessageBufferMaxAge 90

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -754,7 +754,7 @@ void CUDPComm::ReadComplete(UDPpacket *packet) {
                             #endif
 
                         } else {
-                            if (isServing && thePacket->serialNumber == 0 &&
+                            if (isServing && thePacket->serialNumber == INITIAL_SERIAL_NUMBER &&
                                 thePacket->packet.command == kpPacketProtocolLogin) {
                                 conn = DoLogin((PacketInfo *)thePacket, packet);
                             }

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -925,7 +925,7 @@ Boolean CUDPComm::AsyncWrite() {
 
             p = &thePacket->packet;
 
-            *outData.w++ = thePacket->serialNumber;
+            *outData.uw++ = thePacket->serialNumber;
             fp = outData.c++;
 
             *outData.c++ = p->command;

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -16,7 +16,7 @@
 #include <string>
 
 // #define INITIAL_SERIAL_NUMBER     0
-#define INITIAL_SERIAL_NUMBER     (std::numeric_limits<short>::max() - 401)  // must be even
+#define INITIAL_SERIAL_NUMBER     (std::numeric_limits<uint16_t>::max() - 401)  // must be even
 
 #define ROUTE_THRU_SERVER 0  // non-zero to route all messages through the server
 

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -15,8 +15,7 @@
 
 #include <string>
 
-// #define INITIAL_SERIAL_NUMBER     0
-#define INITIAL_SERIAL_NUMBER     (std::numeric_limits<uint16_t>::max() - 401)  // must be even
+#define INITIAL_SERIAL_NUMBER     0  // must be even
 
 #define ROUTE_THRU_SERVER 0  // non-zero to route all messages through the server
 

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -15,6 +15,9 @@
 
 #include <string>
 
+// #define INITIAL_SERIAL_NUMBER     0
+#define INITIAL_SERIAL_NUMBER     (std::numeric_limits<short>::max() - 401)  // must be even
+
 #define ROUTE_THRU_SERVER 0  // non-zero to route all messages through the server
 
 #define CRAMTIME 5000 //	About 20 seconds.

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -60,9 +60,9 @@ void CUDPConnection::IUDPConnection(CUDPComm *theOwner) {
         queues[i].qTail = 0;
     }
 
-    serialNumber = 0;
-    receiveSerial = 0;
-    maxValid = -kSerialNumberStepSize;
+    serialNumber = INITIAL_SERIAL_NUMBER;
+    receiveSerial = INITIAL_SERIAL_NUMBER;
+    maxValid = INITIAL_SERIAL_NUMBER-kSerialNumberStepSize;
 
     retransmitTime = kInitialRetransmitTime;
     urgentRetransmitTime = kInitialRoundTripTime;
@@ -667,10 +667,10 @@ void CUDPConnection::OpenNewConnections(CompleteAddress *table) {
 void CUDPConnection::FreshClient(ip_addr remoteHost, port_num remotePort, long firstReceiveSerial) {
     SDL_Log("CUDPConnection::FreshClient(%u, %hu)\n", remoteHost, remotePort);
     FlushQueues();
-    serialNumber = 0;
-    receiveSerial = firstReceiveSerial;
+    serialNumber = INITIAL_SERIAL_NUMBER;
+    receiveSerial = serialNumber + firstReceiveSerial;
 
-    maxValid = -kSerialNumberStepSize;
+    maxValid = INITIAL_SERIAL_NUMBER-kSerialNumberStepSize;
 
     retransmitTime = kInitialRetransmitTime;
     urgentRetransmitTime = itsOwner->urgentResendTime;

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -30,8 +30,8 @@ void CUDPConnection::DebugPacket(char eType, UDPPacketInfo *p) {
     SDL_Log("CUDPConnection::DebugPacket(%c) cn=%d rsn=%d sn=%d #=%d cmd=%d p1=%d p2=%d p3=%d flags=0x%02x sndr=%d dist=0x%02x\n",
         eType,
         myId,
-        receiveSerial,
-        p->serialNumber,
+        (uint16_t)receiveSerial,
+        (uint16_t)p->serialNumber,
         p->sendCount,
         p->packet.command,
         p->packet.p1,
@@ -133,7 +133,7 @@ void CUDPConnection::SendQueuePacket(UDPPacketInfo *thePacket, short theDistribu
         busyQLen++;
 #if PACKET_DEBUG > 1
         if (thePacket->packet.command == kpKeyAndMouse) {
-            thePacket->serialNumber = -1;  // assigned later
+            thePacket->serialNumber = INITIAL_SERIAL_NUMBER-1;  // assigned later
             DebugPacket('>', thePacket);
         }
 #endif
@@ -400,7 +400,7 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, long when) {
 #endif
         itsOwner->ReleasePacket((PacketInfo *)thePacket);
     } else {
-        SDL_Log("ERROR dequeueing packet (sn=%d) from kTransmitQ\n", thePacket->serialNumber);
+        SDL_Log("ERROR dequeueing packet (sn=%d) from kTransmitQ\n", (uint16_t)thePacket->serialNumber);
     }
 }
 
@@ -423,7 +423,7 @@ void CUDPConnection::RunValidate() {
 }
 
 char *CUDPConnection::ValidateReceivedPackets(char *validateInfo, long curTime) {
-    short transmittedSerial;
+    SerialNumber transmittedSerial;
     short dummyStackVar;
     UDPPacketInfo *thePacket, *nextPacket;
 
@@ -664,13 +664,13 @@ void CUDPConnection::OpenNewConnections(CompleteAddress *table) {
         next->OpenNewConnections(origTable);
 }
 
-void CUDPConnection::FreshClient(ip_addr remoteHost, port_num remotePort, long firstReceiveSerial) {
+void CUDPConnection::FreshClient(ip_addr remoteHost, port_num remotePort, uint16_t firstReceiveSerial) {
     SDL_Log("CUDPConnection::FreshClient(%u, %hu)\n", remoteHost, remotePort);
     FlushQueues();
     serialNumber = INITIAL_SERIAL_NUMBER;
     receiveSerial = serialNumber + firstReceiveSerial;
 
-    maxValid = INITIAL_SERIAL_NUMBER-kSerialNumberStepSize;
+    maxValid = INITIAL_SERIAL_NUMBER - kSerialNumberStepSize;
 
     retransmitTime = kInitialRetransmitTime;
     urgentRetransmitTime = itsOwner->urgentResendTime;

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -11,9 +11,12 @@
 #include "CCommManager.h"
 #include "CDirectObject.h"
 #include "CommDefs.h"
+#include "RolloverCounter.h"
 
 #define kSerialNumberStepSize 2
 #define kNumReceivedOffsets 128
+
+typedef RolloverCounter<uint16_t> SerialNumber;
 
 #define PACKET_DEBUG 0   // set to 1 for packet debug output, 2 for extra detail
 
@@ -24,7 +27,7 @@ typedef struct {
     int32_t birthDate;
     // int32_t lastSendTime;
     int32_t nextSendTime;
-    int16_t serialNumber;
+    SerialNumber serialNumber;
     int16_t sendCount;
 
 } UDPPacketInfo;
@@ -66,9 +69,9 @@ public:
 
     short myId;
 
-    short serialNumber;
-    short receiveSerial;
-    short maxValid;
+    SerialNumber serialNumber;
+    SerialNumber receiveSerial;
+    SerialNumber maxValid;
 
     Boolean haveToSendAck;
     long nextAckTime;
@@ -98,7 +101,7 @@ public:
 
     volatile short *offsetBufferBusy;
     int32_t ackBitmap;
-    short ackBase;
+    SerialNumber ackBase;
 
     Boolean killed;
 
@@ -124,7 +127,7 @@ public:
 
     virtual Boolean AreYouDone();
 
-    virtual void FreshClient(ip_addr remoteHost, port_num remotePort, long firstReceiveSerial);
+    virtual void FreshClient(ip_addr remoteHost, port_num remotePort, uint16_t firstReceiveSerial);
 
 #if PACKET_DEBUG || LATENCY_DEBUG
     virtual void DebugPacket(char eType, UDPPacketInfo *p);

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -128,7 +128,7 @@ public:
     virtual OSErr LoadLevel(std::string set, OSType theLevel) { return noErr; }
     virtual void ComposeParamLine(StringPtr destStr, short index, StringPtr param1, StringPtr param2) {}
     virtual void NotifyUser() {}
-    virtual json Get(const std::string name) {}
+    virtual json Get(const std::string name) { return json(); }
     virtual void Set(const std::string name, const std::string value) {}
     virtual void Set(const std::string name, long value) {}
     virtual void Set(const std::string name, json value) {}

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -13,6 +13,8 @@
 #include "CGrenade.h"
 #include "AvaraGL.h"
 
+#include "CUDPConnection.h"
+
 #include <iostream>
 using namespace std;
 
@@ -351,6 +353,44 @@ TEST(GRENADE, Trajectory) {
     for (int i = 0; i < min(at16ms.size(), at64ms.size()); i++) {
         ASSERT_LT(VecStructDist(at64ms[i], at16ms[i]), 1) << "not close enough after " << i << " ticks.";
     }
+}
+
+template<typename T, typename TMember>
+void test_rollover(string counterName, T x, T y, TMember counter) {
+    // quick test using signed int16_t max value in case somebody changes the type...
+    x.*counter = std::numeric_limits<int16_t>::max();
+    y.*counter = x.*counter + 2;
+    EXPECT_LT(x.*counter, y.*counter)     << counterName << " failed (x < y) test for INT16_MAX";
+    EXPECT_EQ(y.*counter - x.*counter, 2) << counterName << " failed (y - x) test for INT16_MAX";
+
+    // ...but most tests should be for uint16_t
+    x.*counter = std::numeric_limits<uint16_t>::max();
+    y.*counter = x.*counter + 2;
+    // Don't use googletest operator macros such as EXPECT_LT because we are testing the operators themselves
+    EXPECT_TRUE(x.*counter < y.*counter)   << counterName << " failed (x < y) test for UINT16_MAX";
+    EXPECT_TRUE(y.*counter > x.*counter)   << counterName << " failed (y > x) test for UINT16_MAX";
+    EXPECT_TRUE(x.*counter <= y.*counter)  << counterName << " failed (x <= y) test for UINT16_MAX";
+    EXPECT_TRUE(y.*counter >= x.*counter)  << counterName << " failed (y >= x) test for UINT16_MAX";
+    EXPECT_TRUE(x.*counter != y.*counter)  << counterName << " failed (x != y) test for UINT16_MAX";
+    EXPECT_EQ(y.*counter - x.*counter, 2)  << counterName << " failed (y - x) test for UINT16_MAX";
+    EXPECT_EQ(x.*counter - y.*counter, -2) << counterName << " failed (x - y) test for UINT16_MAX";
+
+    y.*counter = x.*counter;
+    EXPECT_TRUE(x.*counter == y.*counter)  << counterName << " failed (x == y) test for equal values";
+    EXPECT_TRUE(x.*counter <= y.*counter)  << counterName << " failed (x <= y) test for equal values";
+    EXPECT_TRUE(y.*counter >= x.*counter)  << counterName << " failed (x >= y) test for equal values";
+}
+
+TEST(SERIAL_NUMBER, Rollover) {
+    // tests all instance of variable serialNumber and any field used as a serial number proxy
+    UDPPacketInfo packet1, packet2;
+    test_rollover("UDPPacketInfo::serialNumber", packet1, packet2, &UDPPacketInfo::serialNumber);
+
+    CUDPConnection conn1, conn2;
+    test_rollover("CUDPConnection::serialNumber", conn1, conn2, &CUDPConnection::serialNumber);
+    test_rollover("CUDPConnection::receiveSerial", conn1, conn2, &CUDPConnection::receiveSerial);
+    test_rollover("CUDPConnection::maxValid", conn1, conn2, &CUDPConnection::maxValid);
+    test_rollover("CUDPConnection::ackBase", conn1, conn2, &CUDPConnection::ackBase);
 }
 
 int main(int argc, char **argv) {

--- a/src/util/RolloverCounter.h
+++ b/src/util/RolloverCounter.h
@@ -1,0 +1,123 @@
+/*
+    Copyright ©2020, Tom Anderson (tra on github)
+    All rights reserved.
+
+    File: RolloverCounter.h
+*/
+
+#include <limits>
+#include <iostream>
+
+template<class T>
+class RolloverCounter {
+private:
+    T counter;
+
+    const static T halfMax = std::numeric_limits<T>::max() / 2;
+
+    int diff(T x, T y) {
+        // This is the crux of this class.
+        // Integer subtraction across a rollover point will give a positive result if the
+        // operands are cast (i.e. T(x-y)) because the C standard defines it as a modulo behavior.
+        // It should be noted that *unsigned* integers have this well-defined behavior:
+        //     https://en.wikipedia.org/wiki/Integer_overflow
+        // But *signed* integers may or may not have this behavior so it's best to
+        // template this class with an unsigned integer type even though it will probably
+        // work fine with signed integers too.
+        int diff = 0;
+        if (x > y) {
+            if ((x - y) <= halfMax) {
+                diff = (x - y);
+            } else {
+                diff = -T(y - x);
+            }
+        } else if (x < y) {
+            if ((y - x) < halfMax) {
+                diff = (x - y);
+            } else {
+                diff = T(x - y);
+            }
+        }
+        return diff;
+    }
+
+public:
+    RolloverCounter(T initialValue = 0) {
+        counter = initialValue;
+    }
+
+    // casting operator so you can assign to a variable of type T
+    operator T()   const { return counter; }
+
+
+    RolloverCounter<T>& operator++() {  // ++prefix
+        counter++;
+        return *this;
+    }
+
+    RolloverCounter<T> operator++(int) {  // postfix++
+        RolloverCounter<T> temp(counter);
+        counter++;
+        return temp;  // return temp copy
+    }
+
+    RolloverCounter<T>& operator+=(T increment) {
+        counter += increment;
+        return *this;
+    }
+    // the 'int' version makes it easier to += any number/constant/enum
+    RolloverCounter<T>& operator+=(int increment) {
+        counter += increment;
+        return *this;
+    }
+    
+    // when adding a value, assumed to be a small delta and that you want a RolloverCounter object returned
+    RolloverCounter<T> operator+(T value) {
+        return RolloverCounter<T>(counter + value);
+    }
+    RolloverCounter<T> operator+(int value) {
+        return RolloverCounter<T>(counter + value);
+    }
+
+    // when subtracting a value, assumed to be a small-ish delta and that you want a RolloverCounter object returned
+    RolloverCounter<T> operator-(T value) {
+        return RolloverCounter<T>(diff(counter, value));
+    }
+    RolloverCounter<T> operator-(int value) {
+        return RolloverCounter<T>(diff(counter, value));
+    }
+    
+    // when subtracting another RolloverCounter<T>, it is comparing 2 RolloverCounter objects so return value of type int (can be negative)
+    int operator-(const RolloverCounter<T>& that) {
+        return diff(counter, that.counter);
+    }
+
+    bool operator>(const T value) { return diff(counter, value) > 0; }
+
+    bool operator>=(const T value) { return !(*this < value); }
+
+    bool operator<(const T value) { return diff(counter, value) < 0; }
+
+    bool operator<=(const T value) { return !(*this > value); }
+
+    bool operator==(const T value) { return (counter == value); }
+    bool operator==(const int value) { return (counter == value); }
+
+    T operator&(T value) { return counter & value; }
+    T operator&(int value) { return counter & value; }
+    
+    T operator&=(T value) { return (counter &= value); }
+    T operator&=(int value) { return (counter &= value); }
+    
+    // so you can do things like: cout << "my counter = " << rc << endl;
+    friend std::ostream& operator<<(std::ostream& os, const RolloverCounter<T>& rc)
+    {
+        if (sizeof(T) == 1) {
+            // want chars to print as numbers
+            os << (int)rc.counter;
+        } else {
+            os << rc.counter;
+        }
+        return os;
+    }
+};


### PR DESCRIPTION
Previously, when serial numbers hit the max value of 32768, the client would hang.  This is because the rollover wasn't being handled properly.  This fix creates a simple new class RolloverCounter<type> that handles the rollover of the underlying data <type> (now uint16_t for serial numbers).  The RolloverCounter class has all the operators (+-><=& etc.) needed so that it still behaves pretty much the same as the underlying type but it rolls over gracefully at the max value.  All variables that hold serial numbers were changed to use this class.