### PR TITLE
Add clang and directfb to req'd packages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Building on Windows 10 requires the [MSYS2](https://www.msys2.org/) environment.
 ### Linux
 On Debian based distributions of Linux, you can install the needed dependencies for building by running the following in a terminal:
 
-`apt-get -yq install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libegl1-mesa-dev libgles2-mesa-dev libsdl2-net-dev`
+`apt-get -yq install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libegl1-mesa-dev libgles2-mesa-dev libsdl2-net-dev clang libdirectfb-dev`
 
 ### Apple macOS
 Avara can be built using [Xcode](https://developer.apple.com/xcode/features/) development tools or [Homebrew](https://brew.sh/). You must install SDL and ensure the libraries are available in either `/Library/Frameworks` or `~/Library/Frameworks`.


### PR DESCRIPTION
On Debian testing, clang and directfb must be installed in order to compile.