### PR TITLE
Another FixedMath bug fix

### DIFF
--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -291,7 +291,7 @@ TEST(HECTOR, Gravity) {
     vector<Fixed> at64ms = DropHector(50, 1, FIX(200), 64);
     vector<Fixed> at32ms = DropHector(50, 2, FIX(200), 32);
     vector<Fixed> at16ms = DropHector(50, 4, FIX(200), 16);
-    ASSERT_EQ(at64ms.back(), 6126784) << "64ms simulation fell wrong amount";
+    ASSERT_EQ(at64ms.back(), 6125961) << "64ms simulation fell wrong amount";
     ASSERT_EQ(at64ms.size(), at32ms.size()) << "DropHector didn't do ticks right";
     for (int i = 0; i < at64ms.size(); i++) {
         double f64 = ToFloat(at64ms[i]);
@@ -317,13 +317,13 @@ TEST(HECTOR, TurnSpeed) {
     vector<Fixed> at64ms = TurnHector(50, 1, 64);
     vector<Fixed> at32ms = TurnHector(50, 2, 32);
     vector<Fixed> at16ms = TurnHector(50, 4, 16);
-    ASSERT_EQ(at64ms.back(), -30592) << "64ms simulation turned wrong amount";
+    ASSERT_EQ(at64ms.back(), -30542) << "64ms simulation turned wrong amount";
     ASSERT_EQ(at64ms.size(), at32ms.size()) << "TurnHector didn't do ticks right";
     for (int i = 0; i < at64ms.size(); i++) {
-        ASSERT_LE(at64ms[i] > at32ms[i] ? at64ms[i] - at32ms[i] : at32ms[i] - at64ms[i], 170) << "not close enough after " << i << " ticks.";
+        ASSERT_LE(at64ms[i] > at32ms[i] ? at64ms[i] - at32ms[i] : at32ms[i] - at64ms[i], 220) << "not close enough after " << i << " ticks.";
     }
     for (int i = 0; i < at64ms.size(); i++) {
-        ASSERT_LE(at64ms[i] > at16ms[i] ? at64ms[i] - at16ms[i] : at16ms[i] - at64ms[i], 210) << "not close enough after " << i << " ticks.";
+        ASSERT_LE(at64ms[i] > at16ms[i] ? at64ms[i] - at16ms[i] : at16ms[i] - at64ms[i], 342) << "not close enough after " << i << " ticks.";
     }
 }
 
@@ -346,7 +346,7 @@ TEST(GRENADE, Trajectory) {
     vector<VectorStruct> at64ms = FireGrenade(20, 50, 1, 64);
     vector<VectorStruct> at32ms = FireGrenade(20, 50, 2, 32);
     vector<VectorStruct> at16ms = FireGrenade(20, 50, 4, 16);
-    ASSERT_EQ(at64ms.back().theVec[1], 59420) << "64ms simulation is wrong";
+    ASSERT_EQ(at64ms.back().theVec[1], 59384) << "64ms simulation is wrong";
     for (int i = 0; i < min(at32ms.size(), at64ms.size()); i++) {
         ASSERT_LT(VecStructDist(at64ms[i], at32ms[i]), 0.7) << "not close enough after " << i << " ticks.";
     }

--- a/src/util/FastMat.cpp
+++ b/src/util/FastMat.cpp
@@ -27,11 +27,11 @@ static unsigned short *arcTanOneTable = 0;
 /* FixMath */
 
 Fixed FixMul(Fixed a, Fixed b) {
-    return ((int64_t)a * (int64_t)b) >> 16;
+    return ((int64_t)a * (int64_t)b) / (1 << 16);
 }
 
 Fixed FixDiv(Fixed a, Fixed b) {
-    return ToFixed(ToFloat(a) / ToFloat(b));
+    return ((int64_t)a * (1 << 16)) / b;
 }
 
 Fixed FixATan2(Fixed x, Fixed y) {


### PR DESCRIPTION
Remove `ToFloat` calls from `FixDiv` (should be more accurate). Cast both arguments of `FixMul` to `int64_t` and divide by `1 << 16` to prevent losing accuracy in intermediate values. _Fixes UFOs!!_