### PR TITLE
Issue #114 (latency settings moved to server window/etc)

### DIFF
--- a/src/gui/CNetworkWindow.cpp
+++ b/src/gui/CNetworkWindow.cpp
@@ -30,7 +30,24 @@ CNetworkWindow::CNetworkWindow(CApplication *app) : CWindow(app, "Network") {
     latencyBox->setValue(std::to_string(app->Number(kLatencyToleranceTag)));
     latencyBox->setEditable(true);
     latencyBox->setCallback([app](std::string value) -> bool {
-        app->Set(kLatencyToleranceTag, std::stoi(value));
+        // make sure this string is really an integer...
+        char * p;
+        strtol(value.c_str(), &p, 10);
+
+        if (*p != 0)
+            return false;
+
+        // determining the min/max latency values from CAvaraGame::SetLatencyTolerance()
+        long maxLT = 8;
+        long newLT = std::stoi(value);
+
+        if (newLT > maxLT)
+            newLT = maxLT;
+
+        if (newLT < 0)
+            newLT = 0;
+
+        app->Set(kLatencyToleranceTag, newLT);
         return true;
     });
 

--- a/src/gui/CNetworkWindow.cpp
+++ b/src/gui/CNetworkWindow.cpp
@@ -25,49 +25,12 @@ CNetworkWindow::CNetworkWindow(CApplication *app) : CWindow(app, "Network") {
         else
             avara->GetNet()->ChangeNet(kClientNet, this->addressBox->value());
     });
-
-    latencyBox = new nanogui::TextBox(this);
-    latencyBox->setValue(std::to_string(app->Number(kLatencyToleranceTag)));
-    latencyBox->setEditable(true);
-    latencyBox->setCallback([app](std::string value) -> bool {
-        // make sure this string is really an integer...
-        char * p;
-        strtol(value.c_str(), &p, 10);
-
-        if (*p != 0)
-            return false;
-
-        // determining the min/max latency values from CAvaraGame::SetLatencyTolerance()
-        long maxLT = 8;
-        long newLT = std::stoi(value);
-
-        if (newLT > maxLT)
-            newLT = maxLT;
-
-        if (newLT < 0)
-            newLT = 0;
-
-        app->Set(kLatencyToleranceTag, newLT);
-        return true;
-    });
-
-    nanogui::CheckBox *autoLatencyBox = new nanogui::CheckBox(this, "Auto Latency", [app](bool checked) {
-        long options = app->Number(kServerOptionsTag);
-        if (checked)
-            options |= 1 << kUseAutoLatencyBit;
-        else
-            options &= ~(long)(1 << kUseAutoLatencyBit);
-        app->Set(kServerOptionsTag, options);
-        ((CAvaraAppImpl *)app)->GetNet()->ChangedServerOptions(options);
-    });
-    bool autoLatency = app->Number(kServerOptionsTag) & (1 << kUseAutoLatencyBit);
-    autoLatencyBox->setChecked(autoLatency);
 }
 
 CNetworkWindow::~CNetworkWindow() {}
 
 bool CNetworkWindow::editing() {
-    return addressBox->focused() || latencyBox->focused();
+    return addressBox->focused();
 }
 
 bool CNetworkWindow::DoCommand(int theCommand) {
@@ -92,8 +55,4 @@ bool CNetworkWindow::DoCommand(int theCommand) {
             break;
     }
     return false;
-}
-
-void CNetworkWindow::PrefChanged(std::string name) {
-    latencyBox->setValue(std::to_string(mApplication->Number(kLatencyToleranceTag)));
 }

--- a/src/gui/CNetworkWindow.h
+++ b/src/gui/CNetworkWindow.h
@@ -10,12 +10,9 @@ public:
 
     virtual bool DoCommand(int theCommand) override;
 
-    virtual void PrefChanged(std::string name) override;
-
     virtual bool editing() override;
     
 protected:
 	nanogui::TextBox *addressBox;
-    nanogui::TextBox *latencyBox;
     nanogui::Button *connectBtn;
 };

--- a/src/gui/CServerWindow.cpp
+++ b/src/gui/CServerWindow.cpp
@@ -7,7 +7,7 @@
 
 CServerWindow::CServerWindow(CApplication *app) : CWindow(app, "Server") {
     setLayout(new nanogui::BoxLayout(nanogui::Orientation::Vertical, nanogui::Alignment::Fill, 10, 10));
-   
+
     std::string description = app->String(kServerDescription);
     descriptionBox = new nanogui::TextBox(this);
     descriptionBox->setPlaceholder("Server Message");
@@ -27,16 +27,16 @@ CServerWindow::CServerWindow(CApplication *app) : CWindow(app, "Server") {
         app->Set(kServerPassword, value);
         return true;
     });
-    
+
     startBtn = new nanogui::Button(this, "Start Hosting");
     startBtn->setCallback([app] {
         CAvaraAppImpl *avara = (CAvaraAppImpl *)app;
-        if(avara->GetNet()->netStatus == kServerNet)
+        if (avara->GetNet()->netStatus == kServerNet)
             avara->GetNet()->ChangeNet(kNullNet, "");
         else
             avara->GetNet()->ChangeNet(kServerNet, "");
     });
-    
+
     nanogui::CheckBox *registerBox = new nanogui::CheckBox(this, "Register With Tracker:", [this, app](bool checked) {
         this->trackerBox->setEditable(checked);
         this->trackerBox->setEnabled(checked);
@@ -52,12 +52,50 @@ CServerWindow::CServerWindow(CApplication *app) : CWindow(app, "Server") {
         app->Set(kTrackerRegisterAddress, value);
         return true;
     });
+
+    latencyBox = new nanogui::TextBox(this);
+    latencyBox->setValue(std::to_string(app->Number(kLatencyToleranceTag)));
+    latencyBox->setEditable(false);
+    latencyBox->setEnabled(false);
+    latencyBox->setCallback([app](std::string value) -> bool {
+        char * pointer;
+        long newLT = strtol(value.c_str(), &pointer, 10);
+
+        // determining the min/max LT values from CAvaraGame::AdjustFrameTime()
+        long maxLT = 8;
+
+        // make sure the provided value is an integer
+        if (*pointer != 0)
+            return false;
+
+        if (newLT > maxLT)
+            newLT = maxLT;
+
+        if (newLT < 0)
+            newLT = 0;
+
+        app->Set(kLatencyToleranceTag, newLT);
+        return true;
+    });
+
+    autoLatencyBox = new nanogui::CheckBox(this, "Auto Latency", [app](bool checked) {
+        long options = app->Number(kServerOptionsTag);
+        if (checked)
+            options |= 1 << kUseAutoLatencyBit;
+        else
+            options &= ~(long)(1 << kUseAutoLatencyBit);
+        app->Set(kServerOptionsTag, options);
+        ((CAvaraAppImpl *)app)->GetNet()->ChangedServerOptions(options);
+    });
+    bool autoLatency = app->Number(kServerOptionsTag) & (1 << kUseAutoLatencyBit);
+    autoLatencyBox->setChecked(autoLatency);
+    autoLatencyBox->setEnabled(false);
 }
 
 CServerWindow::~CServerWindow() {}
 
 bool CServerWindow::editing() {
-    return descriptionBox->focused() || passwordBox->focused() || trackerBox->focused();
+    return descriptionBox->focused() || passwordBox->focused() || trackerBox->focused() || latencyBox->focused();
 }
 
 bool CServerWindow::DoCommand(int theCommand) {
@@ -68,16 +106,29 @@ bool CServerWindow::DoCommand(int theCommand) {
                 case kNullNet:
                     startBtn->setEnabled(true);
                     startBtn->setCaption("Start Hosting");
+                    this->EnableLatencyOptions(false);
                     break;
                 case kClientNet:
                     startBtn->setEnabled(false);
+                    this->EnableLatencyOptions(false);
                     break;
                 case kServerNet:
                     startBtn->setCaption("Stop Hosting");
+                    this->EnableLatencyOptions(true);
                     break;
             }
             break;
     }
     return false;
+}
+
+void CServerWindow::PrefChanged(std::string name) {
+    latencyBox->setValue(std::to_string(mApplication->Number(kLatencyToleranceTag)));
+}
+
+void CServerWindow::EnableLatencyOptions(bool enable) {
+    this->latencyBox->setEditable(enable);
+    this->latencyBox->setEnabled(enable);
+    this->autoLatencyBox->setEnabled(enable);
 }
 

--- a/src/gui/CServerWindow.h
+++ b/src/gui/CServerWindow.h
@@ -8,15 +8,21 @@ public:
 
     virtual bool DoCommand(int theCommand) override;
 
+    virtual void PrefChanged(std::string name) override;
+
+    void EnableLatencyOptions(bool enable);
+
     virtual ~CServerWindow();
-    
+
     virtual bool editing() override;
-    
+
 protected:
 
     nanogui::TextBox *trackerBox;
     nanogui::TextBox *descriptionBox;
     nanogui::TextBox *passwordBox;
     nanogui::Button *startBtn;
+    nanogui::TextBox *latencyBox;
+    nanogui::CheckBox *autoLatencyBox;
 
 };

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -70,7 +70,7 @@ static json defaultPrefs = {
         {"fire", "E"},
         {"boost", "Left Shift"},
         {"verticalMotion", "Left Ctrl"},
-        {"viewRange", "T"},
+        {"viewRange", ""},
         {"aimForward", "2"},
         {"lookLeft", "1"},
         {"lookRight", "3"},


### PR DESCRIPTION
Moved the latency settings to the Server window, added bounds/sanity checking for the manual latency tolerance input, disabling both settings by default and only enabling them as a host.