### PR TITLE
Add `invertYAxis` setting, start `joystickMode`

### DIFF
--- a/src/game/CAvaraApp.h
+++ b/src/game/CAvaraApp.h
@@ -44,6 +44,7 @@ public:
     virtual void BrightBox(long frameNum, short position) = 0;
     virtual void LevelReset() = 0;
     virtual long Number(const std::string name) = 0;
+    virtual bool Boolean(const std::string name) = 0;
     virtual OSErr LoadLevel(std::string set, OSType theLevel) = 0;
     virtual OSErr LoadSVGLevel(std::string set, OSType theLevel) = 0;
     virtual void ComposeParamLine(StringPtr destStr, short index, StringPtr param1, StringPtr param2) = 0;
@@ -121,6 +122,7 @@ public:
     virtual void Set(const std::string name, json value) override { CApplication::Set(name, value); }
     virtual SDL_Window* sdlWindow() override { return CApplication::sdlWindow(); }
     virtual long Number(const std::string name) override { return CApplication::Number(name); }
+    virtual bool Boolean(const std::string name) override { return CApplication::Boolean(name); }
 
     void TrackerUpdate();
     std::string TrackerPayload();

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -682,6 +682,15 @@ void CAvaraGame::SendStartCommand() {
 static Boolean takeShot = false;
 
 void CAvaraGame::ReadGamePrefs() {
+    moJoOptions = 0;
+    /*
+    if (itsApp->Boolean(kJoystickModeTag)) {
+        moJoOptions += kJoystickMode;
+    }
+    */
+    if (itsApp->Boolean(kInvertYAxisTag)) {
+        moJoOptions += kFlipAxis;
+    }
     sensitivity = itsApp->Number(kMouseSensitivityTag);
     latencyTolerance = gApplication->Number(kLatencyToleranceTag);
     AdjustFrameTime();
@@ -907,22 +916,22 @@ void CAvaraGame::ViewControl() {
 bool CAvaraGame::canBeSpectated(CAbstractPlayer *player) {
     if(player == NULL)
         return false;
-    
+
     if(player->isInLimbo == false) {
         return true;
     }
-    
+
     if(player == GetLocalPlayer() && player->scoutView == true && player->lives == 0) {
         return true;
     }
-    
+
     return false;
 }
 
 void CAvaraGame::SpectateNext() {
     if(spectatePlayer == NULL)
         spectatePlayer = GetLocalPlayer();
-    
+
     CAbstractPlayer *nextPlayer = NULL;
     CAbstractPlayer *firstPlayer = NULL;
     CAbstractPlayer *currentPlayer = NULL;
@@ -941,7 +950,7 @@ void CAvaraGame::SpectateNext() {
             }
         }
     }
-    
+
     spectatePlayer = nextPlayer;
     if(spectatePlayer == NULL)
         spectatePlayer = firstPlayer;
@@ -968,7 +977,7 @@ void CAvaraGame::SpectatePrevious() {
             }
         }
     }
-    
+
     if(!found && previousPlayer != NULL)
         spectatePlayer = previousPlayer;
 }
@@ -977,7 +986,7 @@ CPlayerManager *CAvaraGame::FindPlayerManager(CAbstractPlayer *thePlayer) {
     for (int i = 0; i < kMaxAvaraPlayers; i++)
         if(itsNet->playerTable[i] != NULL && itsNet->playerTable[i]->GetPlayer() == thePlayer)
             return itsNet->playerTable[i];
-    
+
     return NULL;
 }
 
@@ -1007,7 +1016,7 @@ void CAvaraGame::Render(NVGcontext *ctx) {
         AvaraGLSetDepthTest(false);
         hudWorld->Render(itsView);
         hud->Render(itsView, ctx);
-        AvaraGLSetDepthTest(true);        
+        AvaraGLSetDepthTest(true);
     }
 }
 
@@ -1052,7 +1061,7 @@ void CAvaraGame::SetLatencyTolerance(long newLatency, int maxChange, const char*
         }
         gApplication->Set(kLatencyToleranceTag, latencyTolerance);
         SDL_Log("*** LT set to %ld\n", latencyTolerance);
-        
+
         if (slowPlayer != nullptr) {
             std::ostringstream oss;
             std::time_t t = std::time(nullptr);
@@ -1083,7 +1092,7 @@ void CAvaraGame::AdjustFrameTime() {
         1.00,  //  0  64            0            16   <-- most playable (LAN)
         1.00,  //  1  64            64           16   <-- good internet
         1.00,  //  2  64            128          16
-        1.00,  //  3  64            192          16 
+        1.00,  //  3  64            192          16
         1.00,  //  4  64            256          16   <-- somewhat playable, laggy
         1.25,  //  5  80            400          13   <-- barely playable / begin recovering
         1.50,  //  6  96            576          10   <-- hope to never see LT > 5
@@ -1104,7 +1113,7 @@ long CAvaraGame::TimeToFrameCount(long timeInMsec) {
 long CAvaraGame::NextFrameForPeriod(long period, long referenceFrame) {
     // Jump forward to the next full period.
     // For example, if we are changing latencies such that we start with 48 frames/period
-    // and we're moving to 60 frames/period, and we're on frame 48, we want to 
+    // and we're moving to 60 frames/period, and we're on frame 48, we want to
     // move forward to frame 120 and NOT frame 60.
     long periodFrames = TimeToFrameCount(period);
     return periodFrames * ceil(double(referenceFrame + periodFrames) / periodFrames);

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -33,7 +33,7 @@
 #include <string.h>
 
 #define AUTOLATENCYPERIOD 3840  // msec - this number is evenly divisible by every frameTime in CAvaraGame::AdjustFrameTime
-#define AUTOLATENCYDELAY  480   // msec 
+#define AUTOLATENCYDELAY  480   // msec
 #define LOWERLATENCYCOUNT 3
 #define HIGHERLATENCYCOUNT 8
 
@@ -576,7 +576,7 @@ void CNetManager::ResumeGame() {
 
     thePlayerManager = playerTable[itsCommManager->myId];
     if (thePlayerManager->GetPlayer()) {
-        thePlayerManager->DoMouseControl(&tempPoint, true);
+        thePlayerManager->DoMouseControl(&tempPoint, !(itsGame->moJoOptions & kJoystickMode));
 
         PlayerConfigRecord copy;
         BlockMoveData(&config, &copy, sizeof(PlayerConfigRecord));

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -129,6 +129,9 @@ uint32_t CPlayerManagerImpl::DoMouseControl(Point *deltaMouse, Boolean doCenter)
         deltaMouse->h >>= -itsGame->sensitivity;
         deltaMouse->v >>= -itsGame->sensitivity;
     }
+    if (itsGame->moJoOptions & kFlipAxis) {
+        deltaMouse->v = -deltaMouse->v;
+	}
     SDL_WarpMouseInWindow(itsGame->itsApp->sdlWindow(), mouseCenterPosition.h, mouseCenterPosition.v);
     return state;
 }
@@ -284,6 +287,9 @@ void CPlayerManagerImpl::HandleEvent(SDL_Event &event) {
                 xrel >>= -itsGame->sensitivity;
                 yrel >>= -itsGame->sensitivity;
             }
+            if (itsGame->moJoOptions & kFlipAxis) {
+                yrel = -yrel;
+            }
             mouseX += xrel;
             mouseY += yrel;
             break;
@@ -314,7 +320,7 @@ void CPlayerManagerImpl::SendFrame() {
             ff->ft.down |= 1 << kfuTypeText;
         }
     }
-    
+
     if (!inputBuffer.empty()) {
         ff->ft.msgChar = inputBuffer.front();
         inputBuffer.pop_front();
@@ -732,7 +738,7 @@ void CPlayerManagerImpl::RosterMessageText(short len, char *c) {
             case 13:
                 // ¬
                 ((CAvaraAppImpl*)itsGame->itsApp)->rosterWindow->NewChatLine(playerName, GetChatLine());
-                
+
                 lineBuffer.insert(lineBuffer.end(), lThing_utf8, lThing_utf8 + 3);
                 // FlushMessageText(true);
                 break;
@@ -769,7 +775,7 @@ std::string CPlayerManagerImpl::GetChatLine() {
         found = 0;
     else
         found += 2;
-    
+
     return theChat.substr(found);
 }
 

--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -80,6 +80,10 @@ long CApplication::Number(const std::string name, const long defaultValue) {
     return defaultValue;
 }
 
+bool CApplication::Boolean(const std::string name) {
+    return prefs[name];
+}
+
 json CApplication::Get(const std::string name) {
     return prefs[name];
 }

--- a/src/gui/CApplication.h
+++ b/src/gui/CApplication.h
@@ -42,6 +42,7 @@ public:
     std::string String(const std::string name);
     long Number(const std::string name);
     long Number(const std::string name, const long defaultValue);
+    bool Boolean(const std::string name);
     json Get(const std::string name);
     void Set(const std::string name, const std::string value);
     void Set(const std::string name, long value);

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -9,6 +9,8 @@ using json = nlohmann::json;
 
 #define kYonPrefTag "shortYon"
 #define kMouseSensitivityTag "mouseSensitivity"
+// #define kJoystickModeTag "joystickMode"
+#define kInvertYAxisTag "invertYAxis"
 #define kLatencyToleranceTag "latencyTolerance"
 #define kHullTypeTag "hull"
 
@@ -50,6 +52,8 @@ using json = nlohmann::json;
 // Key names are from https://wiki.libsdl.org/SDL_Scancode
 static json defaultPrefs = {
     {kYonPrefTag, 0},
+    // {kJoystickModeTag, false},
+    {kInvertYAxisTag, false},
     {kMouseSensitivityTag, 0},
     {kLatencyToleranceTag, 1},
     {kHullTypeTag, 0}, // 0 = light, 1 = medium, 2 = heavy
@@ -143,7 +147,7 @@ static void WritePrefs(json prefs) {
     try {
         std::ostringstream oss;
         oss << std::setw(4) << prefs << std::endl;
-        
+
         std::ofstream out(PrefPath());
         out << oss.str();
     }

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -96,7 +96,7 @@ public:
     virtual void IncrementAskAgainTime(int) {}
     virtual void SetShowScoreboard(bool b) {}
     virtual bool GetShowScoreboard() { return false; }
-    
+
 private:
     FunctionTable *ft;
     CAvaraGame *itsGame;
@@ -124,6 +124,7 @@ public:
     virtual void BrightBox(long frameNum, short position) {}
     virtual void LevelReset() {}
     virtual long Number(const std::string name) { return 0; }
+    virtual bool Boolean(const std::string name) { return false; }
     virtual OSErr LoadSVGLevel(std::string set, OSType theLevel) { return noErr; }
     virtual OSErr LoadLevel(std::string set, OSType theLevel) { return noErr; }
     virtual void ComposeParamLine(StringPtr destStr, short index, StringPtr param1, StringPtr param2) {}


### PR DESCRIPTION
The setting for `joystickMode` will apply correctly if the relevant code
blocks are uncommented, however, I'm unsure what `joystickMode` is
actually supposed to do and looking at Juri's original source did not
illuminate this much for me. All I know is that it flips the `doCenter`
parameter on `DoMouseControl`. Thus, I've left this for somebody else to
finish up when the need arises. It should probably be a separate issue,
anyway.

Fixes #160