### PR TITLE
QoL Interface changes

### DIFF
--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -668,15 +668,15 @@ void CAbstractPlayer::KeyboardControl(FunctionTable *ft) {
         }
 
         if (itsManager->IsLocalPlayer()) {
-            if(TESTFUNC(kfuScoreboard, ft->held))
-                itsManager->SetShowScoreboard(true);
-            else
-                itsManager->SetShowScoreboard(false);
+            if(TESTFUNC(kfuScoreboard, ft->down))
+                itsManager->SetShowScoreboard(!itsManager->GetShowScoreboard());
         }
         
         if (TESTFUNC(kfuPauseGame, ft->down)) {
-            itsGame->statusRequest = kPauseStatus;
-            itsGame->pausePlayer = itsManager->Slot();
+            if(lives > 0) {
+                itsGame->statusRequest = kPauseStatus;
+                itsGame->pausePlayer = itsManager->Slot();
+            }
         }
         if (TESTFUNC(kfuAbortGame, ft->down)) {
             if (limboCount > 0 || lives == 0) {

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -233,7 +233,7 @@ OSErr CAvaraAppImpl::LoadSVGLevel(std::string set, OSType theLevel) {
 }
 
 
-OSErr CAvaraAppImpl::LoadLevel(std::string set, OSType theLevel) {
+OSErr CAvaraAppImpl::LoadLevel(std::string set, OSType theLevel, CPlayerManager *sendingPlayer) {
     SDL_Log("LOADING LEVEL %d FROM %s\n", theLevel, set.c_str());
     itsGame->LevelReset(false);
     itsGame->loadedTag = theLevel;
@@ -266,7 +266,11 @@ OSErr CAvaraAppImpl::LoadLevel(std::string set, OSType theLevel) {
     levels->Dispose();
 
     if (wasLoaded) {
-        AddMessageLine("Loaded \"" + levelName + "\" from \"" + set + "\".");
+        std::string msgPrefix = "Loaded";
+        if(sendingPlayer != NULL)
+            msgPrefix = sendingPlayer->GetPlayerName() + " loaded";
+
+        AddMessageLine(msgPrefix + " \"" + levelName + "\" from \"" + set + "\".");
         levelWindow->SelectLevel(set, levelName);
         Fixed pt[3];
         itsGame->itsWorld->OverheadPoint(pt);

--- a/src/game/CAvaraApp.h
+++ b/src/game/CAvaraApp.h
@@ -44,7 +44,7 @@ public:
     virtual void BrightBox(long frameNum, short position) = 0;
     virtual void LevelReset() = 0;
     virtual long Number(const std::string name) = 0;
-    virtual OSErr LoadLevel(std::string set, OSType theLevel) = 0;
+    virtual OSErr LoadLevel(std::string set, OSType theLevel, CPlayerManager *sendingPlayer) = 0;
     virtual OSErr LoadSVGLevel(std::string set, OSType theLevel) = 0;
     virtual void ComposeParamLine(StringPtr destStr, short index, StringPtr param1, StringPtr param2) = 0;
     virtual void NotifyUser() = 0;
@@ -95,7 +95,7 @@ public:
     virtual bool handleSDLEvent(SDL_Event &event) override;
     virtual void drawAll() override;
     OSErr LoadSVGLevel(std::string set, OSType theLevel) override;
-    OSErr LoadLevel(std::string set, OSType theLevel) override;
+    OSErr LoadLevel(std::string set, OSType theLevel, CPlayerManager *sendingPlayer) override;
     void NotifyUser() override;
     virtual void AddMessageLine(std::string line) override;
     virtual void GameStarted(std::string set, std::string level) override;

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -673,7 +673,10 @@ void CAvaraGame::SendStartCommand() {
     if (gameStatus == kReadyStatus) {
         itsNet->SendStartCommand();
     } else if (gameStatus == kPauseStatus) {
-        itsNet->SendResumeCommand();
+        CAbstractPlayer *player = GetLocalPlayer();
+        if(player != NULL && player->lives > 0) {
+            itsNet->SendResumeCommand();
+        }
     }
 }
 

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -437,9 +437,10 @@ void CNetManager::ReceiveLoadLevel(short senderSlot, void *theDir, OSType theTag
     short crc = 0;
 
     if (!isPlaying) {
+        CPlayerManager *sendingPlayer = playerTable[senderSlot];
         std::string set((char *)theDir);
         theApp = itsGame->itsApp;
-        iErr = theApp->LoadLevel(set, theTag);
+        iErr = theApp->LoadLevel(set, theTag, sendingPlayer);
         if (iErr) {
             itsCommManager->SendPacket(kdEveryone, kpLevelLoadErr, 0, iErr, theTag, 0, 0);
         } else {


### PR DESCRIPTION
Thanks to @blenkush for these changes!

- Fully dead players can no longer pause the game
- Added parameter to `LoadLevel` that allows displaying who loaded the current level
- Scoreboard key is now a throw switch instead of momentary (no longer need to hold key)