### PR TITLE
Colorblind mode

### DIFF
--- a/src/compat/Types.h
+++ b/src/compat/Types.h
@@ -73,26 +73,6 @@ struct QHdr {
 typedef struct QHdr QHdr;
 typedef QHdr *QHdrPtr;
 
-struct RGBColor {
-    unsigned short red;
-    unsigned short green;
-    unsigned short blue;
-};
-typedef struct RGBColor RGBColor;
-struct ColorSpec {
-    short value;
-    RGBColor rgb;
-};
-typedef struct ColorSpec ColorSpec;
-typedef ColorSpec CSpecArray[1];
-struct ColorTable {
-    long ctSeed;
-    short ctFlags;
-    short ctSize;
-    CSpecArray ctTable;
-};
-typedef struct ColorTable ColorTable;
-
 // From QuickDraw
 enum { kQDGrafVerbFrame = 0, kQDGrafVerbPaint = 1, kQDGrafVerbErase = 2, kQDGrafVerbInvert = 3, kQDGrafVerbFill = 4 };
 

--- a/src/game/AvaraDefines.h
+++ b/src/game/AvaraDefines.h
@@ -12,18 +12,6 @@
 #define kMaxAvaraPlayers 8
 #define kMaxTeamColors 8
 
-#define kNeutralTeamColor 0x00ffffff
-#define kGreenTeamColor 0x00006600
-#define kYellowTeamColor 0x00cccc00
-#define kRedTeamColor 0x00cc0000
-#define kPinkTeamColor 0x00cc0099
-#define kPurpleTeamColor 0x009900cc
-#define kBlueTeamColor 0x000099cc
-#define kOrangeTeamColor 0x00FFA500
-#define kLimeTeamColor 0x0089C4C7
-#define kSpecialBlackColor 0x00303030
-#define kSpecialWhiteColor 0x00e0e0e0
-
 #define STANDARDMISSILERANGE FIX(100)
 #define LONGYON FIX(180)
 

--- a/src/game/CAbstractActor.cpp
+++ b/src/game/CAbstractActor.cpp
@@ -8,6 +8,7 @@
 */
 
 #include "CAbstractActor.h"
+#include "CColorManager.h"
 
 #include "CDepot.h"
 #include "CScaledBSP.h"
@@ -1155,38 +1156,8 @@ short CAbstractActor::GetPlayerPosition() {
     return -1; //	Not a player, as far as we know, so return -1 (invalid position)
 }
 
-long CAbstractActor::GetLongTeamColorOr(long defaultColor) {
-    long longTeamColor;
-    switch (teamColor) {
-        case kGreenTeam:
-            longTeamColor = kGreenTeamColor;
-            break;
-        case kYellowTeam:
-            longTeamColor = kYellowTeamColor;
-            break;
-        case kRedTeam:
-            longTeamColor = kRedTeamColor;
-            break;
-        case kPinkTeam:
-            longTeamColor = kPinkTeamColor;
-            break;
-        case kPurpleTeam:
-            longTeamColor = kPurpleTeamColor;
-            break;
-        case kBlueTeam:
-            longTeamColor = kBlueTeamColor;
-            break;
-        case kOrangeTeam:
-            longTeamColor = kOrangeTeamColor;
-            break;
-        case kLimeTeam:
-            longTeamColor = kLimeTeamColor;
-            break;
-        default:
-            longTeamColor = defaultColor;
-            break;
-    }
-    return longTeamColor;
+uint32_t CAbstractActor::GetTeamColorOr(uint32_t defaultColor) {
+    return CColorManager::getTeamColor(teamColor).value_or(defaultColor);
 }
 
 short CAbstractActor::GetBallSnapPoint(long theGroup,

--- a/src/game/CAbstractActor.h
+++ b/src/game/CAbstractActor.h
@@ -8,7 +8,6 @@
 */
 
 #pragma once
-#include "AvaraDefines.h"
 #include "CAvaraGame.h"
 #include "CDirectObject.h"
 #include "CSoundHub.h"
@@ -208,7 +207,7 @@ public:
     virtual void RayTestWithGround(RayHitRecord *hitRec, MaskType testMask);
     virtual short GetPlayerPosition();
 
-    long GetLongTeamColorOr(long defaultColor);
+    uint32_t GetTeamColorOr(uint32_t defaultColor);
 
     virtual short GetBallSnapPoint(long theGroup,
         Fixed *ballLocation,

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -55,6 +55,7 @@ void CAbstractPlayer::LoadHUDParts() {
     for (i = 0; i < 2; i++) {
         targetOns[i] = new CBSPPart;
         targetOns[i]->IBSPPart(kTargetOk);
+        targetOns[i]->ReplaceColor(0x00ff0000, CColorManager::getPlasmaSightsOnColor());
         targetOns[i]->privateAmbient = SIGHTSAMBIENT;
         targetOns[i]->yon = LONGYON * 2;
         targetOns[i]->usesPrivateYon = true;
@@ -64,6 +65,7 @@ void CAbstractPlayer::LoadHUDParts() {
 
         targetOffs[i] = new CBSPPart;
         targetOffs[i]->IBSPPart(kTargetOff);
+        targetOffs[i]->ReplaceColor(0x00008000, CColorManager::getPlasmaSightsOffColor());
         targetOffs[i]->privateAmbient = SIGHTSAMBIENT;
         targetOffs[i]->yon = LONGYON * 2;
         targetOffs[i]->usesPrivateYon = true;

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -77,6 +77,7 @@ void CAbstractPlayer::LoadHUDParts() {
     dirArrowHeight = FIX3(750);
     dirArrow = new CBSPPart;
     dirArrow->IBSPPart(kDirIndBSP);
+    dirArrow->ReplaceColor(0x00000000, CColorManager::getLookForwardColor());
     dirArrow->ignoreDirectionalLights = true;
     dirArrow->isTransparent = true;
     hudWorld->AddPart(dirArrow);

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -170,7 +170,7 @@ void CAbstractPlayer::LoadScout() {
     scoutCommand = kScoutNullCommand;
 
     itsScout = new CScout;
-    itsScout->IScout(this, teamColor, GetTeamColorOr(CColorManager::getTeamColor(0).value()));
+    itsScout->IScout(this, teamColor, GetTeamColorOr(CColorManager::getDefaultTeamColor()));
     itsScout->BeginScript();
     FreshCalc();
     itsScout->EndScript();
@@ -178,7 +178,7 @@ void CAbstractPlayer::LoadScout() {
 
 void CAbstractPlayer::ReplacePartColors() {
     teamMask = 1 << teamColor;
-    longTeamColor = GetTeamColorOr(CColorManager::getTeamColor(0).value());
+    longTeamColor = GetTeamColorOr(CColorManager::getDefaultTeamColor());
 
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
         (*thePart)->ReplaceColor(kMarkerColor, longTeamColor);

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -12,6 +12,7 @@
 #include "AvaraDefines.h"
 #include "CBSPWorld.h"
 #include "CDepot.h"
+#include "CColorManager.h"
 #include "CPlayerManager.h"
 #include "CPlayerMissile.h"
 #include "CScout.h"
@@ -169,7 +170,7 @@ void CAbstractPlayer::LoadScout() {
     scoutCommand = kScoutNullCommand;
 
     itsScout = new CScout;
-    itsScout->IScout(this, teamColor, GetLongTeamColorOr(kNeutralTeamColor));
+    itsScout->IScout(this, teamColor, GetTeamColorOr(CColorManager::getTeamColor(0).value()));
     itsScout->BeginScript();
     FreshCalc();
     itsScout->EndScript();
@@ -177,7 +178,7 @@ void CAbstractPlayer::LoadScout() {
 
 void CAbstractPlayer::ReplacePartColors() {
     teamMask = 1 << teamColor;
-    longTeamColor = GetLongTeamColorOr(kNeutralTeamColor);
+    longTeamColor = GetTeamColorOr(CColorManager::getTeamColor(0).value());
 
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
         (*thePart)->ReplaceColor(kMarkerColor, longTeamColor);
@@ -671,7 +672,7 @@ void CAbstractPlayer::KeyboardControl(FunctionTable *ft) {
             if(TESTFUNC(kfuScoreboard, ft->down))
                 itsManager->SetShowScoreboard(!itsManager->GetShowScoreboard());
         }
-        
+
         if (TESTFUNC(kfuPauseGame, ft->down)) {
             if(lives > 0) {
                 itsGame->statusRequest = kPauseStatus;
@@ -776,7 +777,7 @@ void CAbstractPlayer::KeyboardControl(FunctionTable *ft) {
         if (fieldOfView > maxFOV)
             fieldOfView = maxFOV;
 
-        if (itsManager->IsLocalPlayer() && 
+        if (itsManager->IsLocalPlayer() &&
             (TESTFUNC(kfuZoomOut, ft->held) || TESTFUNC(kfuZoomIn, ft->held)))
             AvaraGLSetFOV(ToFloat(fieldOfView));
 

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -17,6 +17,7 @@
 #include "CAvaraGame.h"
 #include "CBSPWorld.h"
 #include "CharWordLongPointer.h"
+#include "CColorManager.h"
 #include "CNetManager.h"
 #include "CRC.h"
 #include "CSoundMixer.h"

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -17,7 +17,6 @@
 #include "CAvaraGame.h"
 #include "CBSPWorld.h"
 #include "CharWordLongPointer.h"
-#include "CColorManager.h"
 #include "CNetManager.h"
 #include "CRC.h"
 #include "CSoundMixer.h"

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -48,10 +48,7 @@
 #include "CHUD.h"
 #include "Preferences.h"
 #include "Resource.h"
-#include "csscolorparser.hpp"
 #include "RGBAColor.h"
-
-#include <optional>
 
 #define kHighShadeCount 12
 
@@ -582,8 +579,7 @@ void CAvaraGame::LevelReset(Boolean clearReset) {
 
 void CAvaraGame::EndScript() {
     short i;
-    std::optional<CSSColorParser::Color> ambientLightColor, color;
-    uint32_t longColor;
+    uint32_t lightColor;
     Fixed intensity, angle1, angle2;
     Fixed x, y, z;
 
@@ -592,11 +588,9 @@ void CAvaraGame::EndScript() {
     worldShader->Apply();
 
     itsView->ambientLight = ReadFixedVar(iAmbient);
-    ambientLightColor = CSSColorParser::parse(ReadStringVar(iAmbientColor));
-    itsView->ambientLightColor = (ambientLightColor)
-       ? RGBAToLong(*ambientLightColor)
-       : DEFAULT_LIGHT_COLOR;
-    AvaraGLSetAmbient(ToFloat(ReadFixedVar(iAmbient)), itsView->ambientLightColor);
+    itsView->ambientLightColor = ParseColor(ReadStringVar(iAmbientColor))
+        .value_or(DEFAULT_LIGHT_COLOR);
+    AvaraGLSetAmbient(ToFloat(itsView->ambientLight), itsView->ambientLightColor);
 
     for (i = 0; i < 4; i++) {
         intensity = ReadFixedVar(iLightsTable + 4 * i);
@@ -604,22 +598,20 @@ void CAvaraGame::EndScript() {
         if (intensity >= 2048) {
             angle1 = ReadFixedVar(iLightsTable + 1 + 4 * i);
             angle2 = ReadFixedVar(iLightsTable + 2 + 4 * i);
-            color = CSSColorParser::parse(ReadStringVar(iLightsTable + 3 + 4 * i));
 
             x = FMul(FDegCos(angle1), intensity);
             y = FMul(FDegSin(-angle1), intensity);
             z = FMul(FDegCos(angle2), x);
             x = FMul(FDegSin(-angle2), x);
-            longColor = (color)
-                ? RGBAToLong(*color)
-                : DEFAULT_LIGHT_COLOR;
+            lightColor = ParseColor(ReadStringVar(iLightsTable + 3 + 4 * i))
+                .value_or(DEFAULT_LIGHT_COLOR);
 
             itsView->SetLightValues(i, x, y, z, kLightGlobalCoordinates);
             SDL_Log("Light from light table - idx: %d i: %f a: %f b: %f c: %x",
-                    i, ToFloat(intensity), ToFloat(angle1), ToFloat(angle2), longColor);
+                    i, ToFloat(intensity), ToFloat(angle1), ToFloat(angle2), lightColor);
 
             //The b angle is the compass reading and the a angle is the angle from the horizon.
-            AvaraGLSetLight(i, ToFloat(intensity), ToFloat(angle1), ToFloat(angle2), longColor);
+            AvaraGLSetLight(i, ToFloat(intensity), ToFloat(angle1), ToFloat(angle2), lightColor);
         } else {
             itsView->SetLightValues(i, 0, 0, 0, kLightOff);
             AvaraGLSetLight(i, 0, 0, 0, DEFAULT_LIGHT_COLOR);

--- a/src/game/CBall.cpp
+++ b/src/game/CBall.cpp
@@ -210,10 +210,10 @@ void CBall::ChangeOwnership(short ownerId, short ownerTeamColor) {
     teamMask = 1 << teamColor;
     ownerScoringId = ownerId;
 
-    uint32_t teamColor = GetTeamColorOr(origLongColor);
+    uint32_t longTeamColor = GetTeamColorOr(origLongColor);
 
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
-        (*thePart)->ReplaceColor(kMarkerColor, teamColor);
+        (*thePart)->ReplaceColor(kMarkerColor, longTeamColor);
     }
 }
 

--- a/src/game/CBall.cpp
+++ b/src/game/CBall.cpp
@@ -210,10 +210,10 @@ void CBall::ChangeOwnership(short ownerId, short ownerTeamColor) {
     teamMask = 1 << teamColor;
     ownerScoringId = ownerId;
 
-    long longTeamColor = GetLongTeamColorOr(origLongColor);
+    uint32_t teamColor = GetTeamColorOr(origLongColor);
 
     for (CSmartPart **thePart = partList; *thePart; thePart++) {
-        (*thePart)->ReplaceColor(kMarkerColor, longTeamColor);
+        (*thePart)->ReplaceColor(kMarkerColor, teamColor);
     }
 }
 

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -481,9 +481,57 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
                 {g2X4 + (g2s * 4), g2Y4 - (g2s * 4)},
                 {g2X4 + (g2s * 3), g2Y4 - (g2s * 5)}}}};
     NVGcolor g1c[] = {
-        nvgRGBA(0, 143, 0, 255), nvgRGBA(163, 54, 0, 255), nvgRGBA(255, 54, 0, 255), nvgRGBA(0, 61, 165, 255)};
+        nvgRGBA(
+            LongToR(CColorManager::getEnergyGaugeColor()),
+            LongToG(CColorManager::getEnergyGaugeColor()),
+            LongToB(CColorManager::getEnergyGaugeColor()),
+            LongToA(CColorManager::getEnergyGaugeColor())
+        ),
+        nvgRGBA(
+            LongToR(CColorManager::getPlasmaGauge1Color()),
+            LongToG(CColorManager::getPlasmaGauge1Color()),
+            LongToB(CColorManager::getPlasmaGauge1Color()),
+            LongToA(CColorManager::getPlasmaGauge1Color())
+        ),
+        nvgRGBA(
+            LongToR(CColorManager::getPlasmaGauge2Color()),
+            LongToG(CColorManager::getPlasmaGauge2Color()),
+            LongToB(CColorManager::getPlasmaGauge2Color()),
+            LongToA(CColorManager::getPlasmaGauge2Color())
+        ),
+        nvgRGBA(
+            LongToR(CColorManager::getShieldGaugeColor()),
+            LongToG(CColorManager::getShieldGaugeColor()),
+            LongToB(CColorManager::getShieldGaugeColor()),
+            LongToA(CColorManager::getShieldGaugeColor())
+        )
+    };
     NVGcolor g2c[] = {
-        nvgRGBA(30, 30, 102, 255), nvgRGBA(30, 30, 153, 255), nvgRGBA(30, 30, 204, 255), nvgRGBA(30, 30, 255, 255)};
+        nvgRGBA(
+            LongToR(CColorManager::getPinwheel1Color()),
+            LongToG(CColorManager::getPinwheel1Color()),
+            LongToB(CColorManager::getPinwheel1Color()),
+            LongToA(CColorManager::getPinwheel1Color())
+        ),
+        nvgRGBA(
+            LongToR(CColorManager::getPinwheel2Color()),
+            LongToG(CColorManager::getPinwheel2Color()),
+            LongToB(CColorManager::getPinwheel2Color()),
+            LongToA(CColorManager::getPinwheel2Color())
+        ),
+        nvgRGBA(
+            LongToR(CColorManager::getPinwheel3Color()),
+            LongToG(CColorManager::getPinwheel3Color()),
+            LongToB(CColorManager::getPinwheel3Color()),
+            LongToA(CColorManager::getPinwheel3Color())
+        ),
+        nvgRGBA(
+            LongToR(CColorManager::getPinwheel4Color()),
+            LongToG(CColorManager::getPinwheel4Color()),
+            LongToB(CColorManager::getPinwheel4Color()),
+            LongToA(CColorManager::getPinwheel4Color())
+        )
+    };
     for (i = 0; i < 4; i++) { // referred to as GrafPanel in original Avara
         nvgBeginPath(ctx);
         nvgMoveTo(ctx, g1[i][0][0], g1[i][0][1]);
@@ -517,13 +565,23 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
     if (itsGame->veryLongWait) {
         nvgBeginPath(ctx);
         nvgRect(ctx, g1X, gY, 8.0, 8.0);
-        nvgFillColor(ctx, nvgRGBA(255, 255, 0, 255));
+        nvgFillColor(ctx, nvgRGBA(
+            LongToR(CColorManager::getNetDelay2Color()),
+            LongToG(CColorManager::getNetDelay2Color()),
+            LongToB(CColorManager::getNetDelay2Color()),
+            LongToA(CColorManager::getNetDelay2Color())
+        ));
         nvgFill(ctx);
     }
     if (itsGame->longWait) {
         nvgBeginPath(ctx);
         nvgRect(ctx, g1X + 4, gY + 4, 8.0, 8.0);
-        nvgFillColor(ctx, nvgRGBA(255, 192, 0, 255));
+        nvgFillColor(ctx, nvgRGBA(
+            LongToR(CColorManager::getNetDelay1Color()),
+            LongToG(CColorManager::getNetDelay1Color()),
+            LongToB(CColorManager::getNetDelay1Color()),
+            LongToA(CColorManager::getNetDelay1Color())
+        ));
         nvgFill(ctx);
     }
     nvgFillColor(ctx, nvgRGBA(255, 255, 255, 255));

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -310,8 +310,13 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
         nvgBeginPath(ctx);
 
         //highlight player if spectating
-        if(spectatePlayer != NULL && thisPlayer->GetPlayer() == spectatePlayer) {
-            textColor = nvgRGBA(0, 0, 0, 255);
+        if (spectatePlayer != NULL && thisPlayer->GetPlayer() == spectatePlayer) {
+            textColor = nvgRGBA(
+                LongToR(CColorManager::getTeamTextColor(net->teamColors[i] + 1).value()),
+                LongToG(CColorManager::getTeamTextColor(net->teamColors[i] + 1).value()),
+                LongToB(CColorManager::getTeamTextColor(net->teamColors[i] + 1).value()),
+                LongToA(CColorManager::getTeamTextColor(net->teamColors[i] + 1).value())
+            );
             colorBoxWidth = 150.0;
         }
 

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -301,7 +301,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
         if (playerName.length() < 1) continue;
         pY = (bufferHeight - chudHeight + 8) + (11 * i);
         longTeamColor = CColorManager::getTeamColor(net->teamColors[i] + 1).value();
-        LongToRGBA(longTeamColor, teamColorRGB, 3);\
+        LongToRGBA(longTeamColor, teamColorRGB, 3);
         std::string playerChat = thisPlayer->GetChatString(CHAT_CHARS);
 
         //player color box

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -10,6 +10,7 @@
 #include "CPlayerManager.h"
 
 #include "CAbstractPlayer.h"
+#include "CColorManager.h"
 #include "CCommManager.h"
 #include "CIncarnator.h"
 #include "CNetManager.h"
@@ -292,7 +293,7 @@ void CPlayerManagerImpl::HandleEvent(SDL_Event &event) {
                 buttonStatus |= kbuWentDown;
                 buttonStatus |= kbuIsDown;
             }
-            
+
             break;
         case SDL_MOUSEBUTTONUP:
             if(event.button.button == SDL_BUTTON_RIGHT) {
@@ -1202,10 +1203,10 @@ void CPlayerManagerImpl::SpecialColorControl() {
 
         switch (spaceCount) {
             case 2:
-                repColor = kSpecialBlackColor;
+                repColor = CColorManager::getSpecialBlackColor();
                 break;
             case 3:
-                repColor = kSpecialWhiteColor;
+                repColor = CColorManager::getSpecialWhiteColor();
                 break;
         }
 

--- a/src/game/CScout.cpp
+++ b/src/game/CScout.cpp
@@ -26,7 +26,7 @@
 
 #define FOLLOWRADIUS 10
 
-void CScout::IScout(CAbstractPlayer *thePlayer, short theTeam, long longTeamColor) {
+void CScout::IScout(CAbstractPlayer *thePlayer, short theTeam, uint32_t longTeamColor) {
     IAbstractActor();
 
     mass = FIX(20);

--- a/src/game/CScout.h
+++ b/src/game/CScout.h
@@ -33,7 +33,7 @@ public:
     short action;
     Boolean nextRotateFlag;
 
-    virtual void IScout(CAbstractPlayer *thePlayer, short theTeam, long longTeamColor);
+    virtual void IScout(CAbstractPlayer *thePlayer, short theTeam, uint32_t longTeamColor);
     virtual void PlaceParts();
     virtual void FrameAction();
     virtual void ControlViewPoint();

--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -2,6 +2,7 @@
 #include "CApplication.h"
 
 #include "AvaraGL.h"
+#include "CColorManager.h"
 #include "Preferences.h"
 #include "Types.h"
 
@@ -20,6 +21,8 @@ nanogui::Screen(nanogui::Vector2i(prefs[kWindowWidth], prefs[kWindowHeight]), ti
     gApplication = this;
     AvaraGLInitContext();
     setResizeCallback([this](nanogui::Vector2i newSize) { this->WindowResized(newSize.x, newSize.y); });
+
+    CColorManager::setColorBlind(CApplication::Get(kColorBlindMode));
 }
 
 CApplication::~CApplication() {}

--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -4,7 +4,6 @@
 #include "AvaraGL.h"
 #include "CColorManager.h"
 #include "Preferences.h"
-#include "Types.h"
 
 #include <SDL2/SDL.h>
 #include <fstream>

--- a/src/gui/CApplication.h
+++ b/src/gui/CApplication.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "CWindow.h"
-#include "Types.h"
 
 #include <SDL2/SDL.h>
 #include <json.hpp>

--- a/src/gui/CColorManager.cpp
+++ b/src/gui/CColorManager.cpp
@@ -10,6 +10,8 @@ uint32_t CColorManager::pinwheel3Color = 0xff1e1ecc;
 uint32_t CColorManager::pinwheel4Color = 0xff1e1eff;
 uint32_t CColorManager::plasmaGauge1Color = 0xffa33600;
 uint32_t CColorManager::plasmaGauge2Color = 0xffff3600;
+uint32_t CColorManager::plasmaSightsOffColor = 0xff008000;
+uint32_t CColorManager::plasmaSightsOnColor = 0xffff0000;
 uint32_t CColorManager::shieldGaugeColor = 0xff003da5;
 uint32_t CColorManager::specialBlackColor = 0xff303030;
 uint32_t CColorManager::specialWhiteColor = 0xffe0e0e0;
@@ -50,6 +52,8 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::pinwheel4Color = 0xff1e1eff;
             CColorManager::plasmaGauge1Color = 0xffa33600;
             CColorManager::plasmaGauge2Color = 0xffff3600;
+            CColorManager::plasmaSightsOffColor = 0xff008000;
+            CColorManager::plasmaSightsOnColor = 0xffff0000;
             CColorManager::shieldGaugeColor = 0xff003da5;
             CColorManager::specialBlackColor = 0xff303030;
             CColorManager::specialWhiteColor = 0xffe0e0e0;
@@ -82,6 +86,8 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::pinwheel4Color = 0xff1e1eff;
             CColorManager::plasmaGauge1Color = 0xffa33600;
             CColorManager::plasmaGauge2Color = 0xffff3600;
+            CColorManager::plasmaSightsOffColor = 0xff008055;
+            CColorManager::plasmaSightsOnColor = 0xffff5500;
             CColorManager::shieldGaugeColor = 0xff0000a5;
             CColorManager::specialBlackColor = 0xff303030;
             CColorManager::specialWhiteColor = 0xffe0e0e0;
@@ -114,6 +120,8 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::pinwheel4Color = 0xff1e1eff;
             CColorManager::plasmaGauge1Color = 0xffa33600;
             CColorManager::plasmaGauge2Color = 0xffff3600;
+            CColorManager::plasmaSightsOffColor = 0xff008055;
+            CColorManager::plasmaSightsOnColor = 0xffff5500;
             CColorManager::shieldGaugeColor = 0xff0000a5;
             CColorManager::specialBlackColor = 0xff303030;
             CColorManager::specialWhiteColor = 0xffe0e0e0;
@@ -146,6 +154,8 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::pinwheel4Color = 0xff1e1eff;
             CColorManager::plasmaGauge1Color = 0xffa33600;
             CColorManager::plasmaGauge2Color = 0xffff3600;
+            CColorManager::plasmaSightsOffColor = 0xff008000;
+            CColorManager::plasmaSightsOnColor = 0xffff0000;
             CColorManager::shieldGaugeColor = 0xff003da5;
             CColorManager::specialBlackColor = 0xff303030;
             CColorManager::specialWhiteColor = 0xffe0e0e0;

--- a/src/gui/CColorManager.cpp
+++ b/src/gui/CColorManager.cpp
@@ -27,15 +27,15 @@ uint32_t CColorManager::teamColors[kMaxTeamColors + 1] = {
 };
 
 uint32_t CColorManager::teamTextColors[kMaxTeamColors + 1] = {
-    0xff000000,
+    0xff333333,
     0xffffffff,
-    0xff000000,
+    0xff333333,
     0xffffffff,
     0xffffffff,
     0xffffffff,
-    0xff000000,
-    0xff000000,
-    0xff000000
+    0xff333333,
+    0xff333333,
+    0xff333333
 };
 
 void CColorManager::setColorBlind(ColorBlindMode mode) {
@@ -62,15 +62,15 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamColors[6] = 0xff0099cc;
             CColorManager::teamColors[7] = 0xffffa500;
             CColorManager::teamColors[8] = 0xff89c4c7;
-            CColorManager::teamTextColors[0] = 0xff000000;
+            CColorManager::teamTextColors[0] = 0xff333333;
             CColorManager::teamTextColors[1] = 0xffffffff;
-            CColorManager::teamTextColors[2] = 0xff000000;
+            CColorManager::teamTextColors[2] = 0xff333333;
             CColorManager::teamTextColors[3] = 0xffffffff;
             CColorManager::teamTextColors[4] = 0xffffffff;
             CColorManager::teamTextColors[5] = 0xffffffff;
-            CColorManager::teamTextColors[6] = 0xff000000;
-            CColorManager::teamTextColors[7] = 0xff000000;
-            CColorManager::teamTextColors[8] = 0xff000000;
+            CColorManager::teamTextColors[6] = 0xff333333;
+            CColorManager::teamTextColors[7] = 0xff333333;
+            CColorManager::teamTextColors[8] = 0xff333333;
             break;
         case Deuteranopia:
             CColorManager::energyGaugeColor = 0xff008f8f;
@@ -94,15 +94,15 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamColors[6] = 0xff0099cc;
             CColorManager::teamColors[7] = 0xfff5daa3;
             CColorManager::teamColors[8] = 0xff89c4c7;
-            CColorManager::teamTextColors[0] = 0xff000000;
+            CColorManager::teamTextColors[0] = 0xff333333;
             CColorManager::teamTextColors[1] = 0xffffffff;
-            CColorManager::teamTextColors[2] = 0xff000000;
+            CColorManager::teamTextColors[2] = 0xff333333;
             CColorManager::teamTextColors[3] = 0xffffffff;
             CColorManager::teamTextColors[4] = 0xffffffff;
             CColorManager::teamTextColors[5] = 0xffffffff;
             CColorManager::teamTextColors[6] = 0xffffffff;
-            CColorManager::teamTextColors[7] = 0xff000000;
-            CColorManager::teamTextColors[8] = 0xff000000;
+            CColorManager::teamTextColors[7] = 0xff333333;
+            CColorManager::teamTextColors[8] = 0xff333333;
             break;
         case Protanopia:
             CColorManager::energyGaugeColor = 0xff008f8f;
@@ -126,15 +126,15 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamColors[6] = 0xff0099cc;
             CColorManager::teamColors[7] = 0xfff5daa3;
             CColorManager::teamColors[8] = 0xff89c4c7;
-            CColorManager::teamTextColors[0] = 0xff000000;
+            CColorManager::teamTextColors[0] = 0xff333333;
             CColorManager::teamTextColors[1] = 0xffffffff;
-            CColorManager::teamTextColors[2] = 0xff000000;
+            CColorManager::teamTextColors[2] = 0xff333333;
             CColorManager::teamTextColors[3] = 0xffffffff;
             CColorManager::teamTextColors[4] = 0xffffffff;
             CColorManager::teamTextColors[5] = 0xffffffff;
             CColorManager::teamTextColors[6] = 0xffffffff;
-            CColorManager::teamTextColors[7] = 0xff000000;
-            CColorManager::teamTextColors[8] = 0xff000000;
+            CColorManager::teamTextColors[7] = 0xff333333;
+            CColorManager::teamTextColors[8] = 0xff333333;
             break;
         case Tritanopia:
             CColorManager::energyGaugeColor = 0xff008f00;
@@ -158,15 +158,15 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamColors[6] = 0xff0099cc;
             CColorManager::teamColors[7] = 0xffffa500;
             CColorManager::teamColors[8] = 0xff89c4c7;
-            CColorManager::teamTextColors[0] = 0xff000000;
+            CColorManager::teamTextColors[0] = 0xff333333;
             CColorManager::teamTextColors[1] = 0xffffffff;
-            CColorManager::teamTextColors[2] = 0xff000000;
+            CColorManager::teamTextColors[2] = 0xff333333;
             CColorManager::teamTextColors[3] = 0xffffffff;
             CColorManager::teamTextColors[4] = 0xffffffff;
             CColorManager::teamTextColors[5] = 0xffffffff;
             CColorManager::teamTextColors[6] = 0xffffffff;
-            CColorManager::teamTextColors[7] = 0xff000000;
-            CColorManager::teamTextColors[8] = 0xff000000;
+            CColorManager::teamTextColors[7] = 0xff333333;
+            CColorManager::teamTextColors[8] = 0xff333333;
             break;
     }
     CColorManager::colorBlindMode = mode;

--- a/src/gui/CColorManager.cpp
+++ b/src/gui/CColorManager.cpp
@@ -29,13 +29,13 @@ uint32_t CColorManager::teamColors[kMaxTeamColors + 1] = {
 uint32_t CColorManager::teamTextColors[kMaxTeamColors + 1] = {
     0xff000000,
     0xffffffff,
+    0xff000000,
     0xffffffff,
     0xffffffff,
     0xffffffff,
-    0xffffffff,
-    0xffffffff,
-    0xffffffff,
-    0xffffffff
+    0xff000000,
+    0xff000000,
+    0xff000000
 };
 
 void CColorManager::setColorBlind(ColorBlindMode mode) {
@@ -63,11 +63,11 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamColors[7] = 0xffffa500;
             CColorManager::teamColors[8] = 0xff89c4c7;
             CColorManager::teamTextColors[0] = 0xff000000;
-            CColorManager::teamTextColors[1] = 0xff000000;
+            CColorManager::teamTextColors[1] = 0xffffffff;
             CColorManager::teamTextColors[2] = 0xff000000;
-            CColorManager::teamTextColors[3] = 0xff000000;
-            CColorManager::teamTextColors[4] = 0xff000000;
-            CColorManager::teamTextColors[5] = 0xff000000;
+            CColorManager::teamTextColors[3] = 0xffffffff;
+            CColorManager::teamTextColors[4] = 0xffffffff;
+            CColorManager::teamTextColors[5] = 0xffffffff;
             CColorManager::teamTextColors[6] = 0xff000000;
             CColorManager::teamTextColors[7] = 0xff000000;
             CColorManager::teamTextColors[8] = 0xff000000;
@@ -95,12 +95,12 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamColors[7] = 0xfff5daa3;
             CColorManager::teamColors[8] = 0xff89c4c7;
             CColorManager::teamTextColors[0] = 0xff000000;
-            CColorManager::teamTextColors[1] = 0xff000000;
+            CColorManager::teamTextColors[1] = 0xffffffff;
             CColorManager::teamTextColors[2] = 0xff000000;
-            CColorManager::teamTextColors[3] = 0xff000000;
-            CColorManager::teamTextColors[4] = 0xff000000;
-            CColorManager::teamTextColors[5] = 0xff000000;
-            CColorManager::teamTextColors[6] = 0xff000000;
+            CColorManager::teamTextColors[3] = 0xffffffff;
+            CColorManager::teamTextColors[4] = 0xffffffff;
+            CColorManager::teamTextColors[5] = 0xffffffff;
+            CColorManager::teamTextColors[6] = 0xffffffff;
             CColorManager::teamTextColors[7] = 0xff000000;
             CColorManager::teamTextColors[8] = 0xff000000;
             break;
@@ -127,12 +127,12 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamColors[7] = 0xfff5daa3;
             CColorManager::teamColors[8] = 0xff89c4c7;
             CColorManager::teamTextColors[0] = 0xff000000;
-            CColorManager::teamTextColors[1] = 0xff000000;
+            CColorManager::teamTextColors[1] = 0xffffffff;
             CColorManager::teamTextColors[2] = 0xff000000;
-            CColorManager::teamTextColors[3] = 0xff000000;
-            CColorManager::teamTextColors[4] = 0xff000000;
-            CColorManager::teamTextColors[5] = 0xff000000;
-            CColorManager::teamTextColors[6] = 0xff000000;
+            CColorManager::teamTextColors[3] = 0xffffffff;
+            CColorManager::teamTextColors[4] = 0xffffffff;
+            CColorManager::teamTextColors[5] = 0xffffffff;
+            CColorManager::teamTextColors[6] = 0xffffffff;
             CColorManager::teamTextColors[7] = 0xff000000;
             CColorManager::teamTextColors[8] = 0xff000000;
             break;
@@ -159,12 +159,12 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamColors[7] = 0xffffa500;
             CColorManager::teamColors[8] = 0xff89c4c7;
             CColorManager::teamTextColors[0] = 0xff000000;
-            CColorManager::teamTextColors[1] = 0xff000000;
+            CColorManager::teamTextColors[1] = 0xffffffff;
             CColorManager::teamTextColors[2] = 0xff000000;
-            CColorManager::teamTextColors[3] = 0xff000000;
-            CColorManager::teamTextColors[4] = 0xff000000;
-            CColorManager::teamTextColors[5] = 0xff000000;
-            CColorManager::teamTextColors[6] = 0xff000000;
+            CColorManager::teamTextColors[3] = 0xffffffff;
+            CColorManager::teamTextColors[4] = 0xffffffff;
+            CColorManager::teamTextColors[5] = 0xffffffff;
+            CColorManager::teamTextColors[6] = 0xffffffff;
             CColorManager::teamTextColors[7] = 0xff000000;
             CColorManager::teamTextColors[8] = 0xff000000;
             break;

--- a/src/gui/CColorManager.cpp
+++ b/src/gui/CColorManager.cpp
@@ -1,5 +1,17 @@
 #include "CColorManager.h"
 
+ColorBlindMode CColorManager::colorBlindMode = Off;
+uint32_t CColorManager::energyGaugeColor = 0xff008f00;
+uint32_t CColorManager::netDelay1Color = 0xffffc000;
+uint32_t CColorManager::netDelay2Color = 0xffffff00;
+uint32_t CColorManager::pinwheel1Color = 0xff1e1e66;
+uint32_t CColorManager::pinwheel2Color = 0xff1e1e99;
+uint32_t CColorManager::pinwheel3Color = 0xff1e1ecc;
+uint32_t CColorManager::pinwheel4Color = 0xff1e1eff;
+uint32_t CColorManager::plasmaGauge1Color = 0xffa33600;
+uint32_t CColorManager::plasmaGauge2Color = 0xffff3600;
+uint32_t CColorManager::shieldGaugeColor = 0xff003da5;
+
 uint32_t CColorManager::teamColors[kMaxTeamColors + 1] = {
     0xffffffff,
     0xff006600,
@@ -14,19 +26,29 @@ uint32_t CColorManager::teamColors[kMaxTeamColors + 1] = {
 
 uint32_t CColorManager::teamTextColors[kMaxTeamColors + 1] = {
     0xff000000,
-    0xff000000,
-    0xff000000,
-    0xff000000,
-    0xff000000,
-    0xff000000,
-    0xff000000,
-    0xff000000,
-    0xff000000
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff,
+    0xffffffff
 };
 
 void CColorManager::setColorBlind(ColorBlindMode mode) {
     switch (mode) {
         case Off:
+            CColorManager::energyGaugeColor = 0xff008f00;
+            CColorManager::netDelay1Color = 0xffffc000;
+            CColorManager::netDelay2Color = 0xffffff00;
+            CColorManager::pinwheel1Color = 0xff1e1e66;
+            CColorManager::pinwheel2Color = 0xff1e1e99;
+            CColorManager::pinwheel3Color = 0xff1e1ecc;
+            CColorManager::pinwheel4Color = 0xff1e1eff;
+            CColorManager::plasmaGauge1Color = 0xffa33600;
+            CColorManager::plasmaGauge2Color = 0xffff3600;
+            CColorManager::shieldGaugeColor = 0xff003da5;
             CColorManager::teamColors[0] = 0xffffffff;
             CColorManager::teamColors[1] = 0xff006600;
             CColorManager::teamColors[2] = 0xffcccc00;
@@ -47,14 +69,24 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamTextColors[8] = 0xff000000;
             break;
         case Deuteranopia:
+            CColorManager::energyGaugeColor = 0xff008f8f;
+            CColorManager::netDelay1Color = 0xffffe080;
+            CColorManager::netDelay2Color = 0xffffff00;
+            CColorManager::pinwheel1Color = 0xff1e1e66;
+            CColorManager::pinwheel2Color = 0xff1e1e99;
+            CColorManager::pinwheel3Color = 0xff1e1ecc;
+            CColorManager::pinwheel4Color = 0xff1e1eff;
+            CColorManager::plasmaGauge1Color = 0xffa33600;
+            CColorManager::plasmaGauge2Color = 0xffff3600;
+            CColorManager::shieldGaugeColor = 0xff0000a5;
             CColorManager::teamColors[0] = 0xffffffff;
-            CColorManager::teamColors[1] = 0xff006600;
+            CColorManager::teamColors[1] = 0xff006655;
             CColorManager::teamColors[2] = 0xffcccc00;
-            CColorManager::teamColors[3] = 0xffcc0000;
+            CColorManager::teamColors[3] = 0xffcc5500;
             CColorManager::teamColors[4] = 0xffcc0099;
             CColorManager::teamColors[5] = 0xff9900cc;
             CColorManager::teamColors[6] = 0xff0099cc;
-            CColorManager::teamColors[7] = 0xffffa500;
+            CColorManager::teamColors[7] = 0xfff5daa3;
             CColorManager::teamColors[8] = 0xff89c4c7;
             CColorManager::teamTextColors[0] = 0xff000000;
             CColorManager::teamTextColors[1] = 0xff000000;
@@ -67,14 +99,24 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamTextColors[8] = 0xff000000;
             break;
         case Protanopia:
+            CColorManager::energyGaugeColor = 0xff008f8f;
+            CColorManager::netDelay1Color = 0xffffe080;
+            CColorManager::netDelay2Color = 0xffffff00;
+            CColorManager::pinwheel1Color = 0xff1e1e66;
+            CColorManager::pinwheel2Color = 0xff1e1e99;
+            CColorManager::pinwheel3Color = 0xff1e1ecc;
+            CColorManager::pinwheel4Color = 0xff1e1eff;
+            CColorManager::plasmaGauge1Color = 0xffa33600;
+            CColorManager::plasmaGauge2Color = 0xffff3600;
+            CColorManager::shieldGaugeColor = 0xff0000a5;
             CColorManager::teamColors[0] = 0xffffffff;
-            CColorManager::teamColors[1] = 0xff006600;
+            CColorManager::teamColors[1] = 0xff006655;
             CColorManager::teamColors[2] = 0xffcccc00;
-            CColorManager::teamColors[3] = 0xffcc0000;
+            CColorManager::teamColors[3] = 0xffcc5500;
             CColorManager::teamColors[4] = 0xffcc0099;
             CColorManager::teamColors[5] = 0xff9900cc;
             CColorManager::teamColors[6] = 0xff0099cc;
-            CColorManager::teamColors[7] = 0xffffa500;
+            CColorManager::teamColors[7] = 0xfff5daa3;
             CColorManager::teamColors[8] = 0xff89c4c7;
             CColorManager::teamTextColors[0] = 0xff000000;
             CColorManager::teamTextColors[1] = 0xff000000;
@@ -87,6 +129,16 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamTextColors[8] = 0xff000000;
             break;
         case Tritanopia:
+            CColorManager::energyGaugeColor = 0xff008f00;
+            CColorManager::netDelay1Color = 0xffffc000;
+            CColorManager::netDelay2Color = 0xffffff00;
+            CColorManager::pinwheel1Color = 0xff1e1e66;
+            CColorManager::pinwheel2Color = 0xff1e1e99;
+            CColorManager::pinwheel3Color = 0xff1e1ecc;
+            CColorManager::pinwheel4Color = 0xff1e1eff;
+            CColorManager::plasmaGauge1Color = 0xffa33600;
+            CColorManager::plasmaGauge2Color = 0xffff3600;
+            CColorManager::shieldGaugeColor = 0xff003da5;
             CColorManager::teamColors[0] = 0xffffffff;
             CColorManager::teamColors[1] = 0xff006600;
             CColorManager::teamColors[2] = 0xffcccc00;
@@ -107,4 +159,5 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::teamTextColors[8] = 0xff000000;
             break;
     }
+    CColorManager::colorBlindMode = mode;
 }

--- a/src/gui/CColorManager.cpp
+++ b/src/gui/CColorManager.cpp
@@ -1,0 +1,110 @@
+#include "CColorManager.h"
+
+uint32_t CColorManager::teamColors[kMaxTeamColors + 1] = {
+    0xffffffff,
+    0xff006600,
+    0xffcccc00,
+    0xffcc0000,
+    0xffcc0099,
+    0xff9900cc,
+    0xff0099cc,
+    0xffffa500,
+    0xff89c4c7
+};
+
+uint32_t CColorManager::teamTextColors[kMaxTeamColors + 1] = {
+    0xff000000,
+    0xff000000,
+    0xff000000,
+    0xff000000,
+    0xff000000,
+    0xff000000,
+    0xff000000,
+    0xff000000,
+    0xff000000
+};
+
+void CColorManager::setColorBlind(ColorBlindMode mode) {
+    switch (mode) {
+        case Off:
+            CColorManager::teamColors[0] = 0xffffffff;
+            CColorManager::teamColors[1] = 0xff006600;
+            CColorManager::teamColors[2] = 0xffcccc00;
+            CColorManager::teamColors[3] = 0xffcc0000;
+            CColorManager::teamColors[4] = 0xffcc0099;
+            CColorManager::teamColors[5] = 0xff9900cc;
+            CColorManager::teamColors[6] = 0xff0099cc;
+            CColorManager::teamColors[7] = 0xffffa500;
+            CColorManager::teamColors[8] = 0xff89c4c7;
+            CColorManager::teamTextColors[0] = 0xff000000;
+            CColorManager::teamTextColors[1] = 0xff000000;
+            CColorManager::teamTextColors[2] = 0xff000000;
+            CColorManager::teamTextColors[3] = 0xff000000;
+            CColorManager::teamTextColors[4] = 0xff000000;
+            CColorManager::teamTextColors[5] = 0xff000000;
+            CColorManager::teamTextColors[6] = 0xff000000;
+            CColorManager::teamTextColors[7] = 0xff000000;
+            CColorManager::teamTextColors[8] = 0xff000000;
+            break;
+        case Deuteranopia:
+            CColorManager::teamColors[0] = 0xffffffff;
+            CColorManager::teamColors[1] = 0xff006600;
+            CColorManager::teamColors[2] = 0xffcccc00;
+            CColorManager::teamColors[3] = 0xffcc0000;
+            CColorManager::teamColors[4] = 0xffcc0099;
+            CColorManager::teamColors[5] = 0xff9900cc;
+            CColorManager::teamColors[6] = 0xff0099cc;
+            CColorManager::teamColors[7] = 0xffffa500;
+            CColorManager::teamColors[8] = 0xff89c4c7;
+            CColorManager::teamTextColors[0] = 0xff000000;
+            CColorManager::teamTextColors[1] = 0xff000000;
+            CColorManager::teamTextColors[2] = 0xff000000;
+            CColorManager::teamTextColors[3] = 0xff000000;
+            CColorManager::teamTextColors[4] = 0xff000000;
+            CColorManager::teamTextColors[5] = 0xff000000;
+            CColorManager::teamTextColors[6] = 0xff000000;
+            CColorManager::teamTextColors[7] = 0xff000000;
+            CColorManager::teamTextColors[8] = 0xff000000;
+            break;
+        case Protanopia:
+            CColorManager::teamColors[0] = 0xffffffff;
+            CColorManager::teamColors[1] = 0xff006600;
+            CColorManager::teamColors[2] = 0xffcccc00;
+            CColorManager::teamColors[3] = 0xffcc0000;
+            CColorManager::teamColors[4] = 0xffcc0099;
+            CColorManager::teamColors[5] = 0xff9900cc;
+            CColorManager::teamColors[6] = 0xff0099cc;
+            CColorManager::teamColors[7] = 0xffffa500;
+            CColorManager::teamColors[8] = 0xff89c4c7;
+            CColorManager::teamTextColors[0] = 0xff000000;
+            CColorManager::teamTextColors[1] = 0xff000000;
+            CColorManager::teamTextColors[2] = 0xff000000;
+            CColorManager::teamTextColors[3] = 0xff000000;
+            CColorManager::teamTextColors[4] = 0xff000000;
+            CColorManager::teamTextColors[5] = 0xff000000;
+            CColorManager::teamTextColors[6] = 0xff000000;
+            CColorManager::teamTextColors[7] = 0xff000000;
+            CColorManager::teamTextColors[8] = 0xff000000;
+            break;
+        case Tritanopia:
+            CColorManager::teamColors[0] = 0xffffffff;
+            CColorManager::teamColors[1] = 0xff006600;
+            CColorManager::teamColors[2] = 0xffcccc00;
+            CColorManager::teamColors[3] = 0xffcc0000;
+            CColorManager::teamColors[4] = 0xffcc0099;
+            CColorManager::teamColors[5] = 0xff9900cc;
+            CColorManager::teamColors[6] = 0xff0099cc;
+            CColorManager::teamColors[7] = 0xffffa500;
+            CColorManager::teamColors[8] = 0xff89c4c7;
+            CColorManager::teamTextColors[0] = 0xff000000;
+            CColorManager::teamTextColors[1] = 0xff000000;
+            CColorManager::teamTextColors[2] = 0xff000000;
+            CColorManager::teamTextColors[3] = 0xff000000;
+            CColorManager::teamTextColors[4] = 0xff000000;
+            CColorManager::teamTextColors[5] = 0xff000000;
+            CColorManager::teamTextColors[6] = 0xff000000;
+            CColorManager::teamTextColors[7] = 0xff000000;
+            CColorManager::teamTextColors[8] = 0xff000000;
+            break;
+    }
+}

--- a/src/gui/CColorManager.cpp
+++ b/src/gui/CColorManager.cpp
@@ -2,6 +2,7 @@
 
 ColorBlindMode CColorManager::colorBlindMode = Off;
 uint32_t CColorManager::energyGaugeColor = 0xff008f00;
+uint32_t CColorManager::lookForwardColor = 0xff000000;
 uint32_t CColorManager::netDelay1Color = 0xffffc000;
 uint32_t CColorManager::netDelay2Color = 0xffffff00;
 uint32_t CColorManager::pinwheel1Color = 0xff1e1e66;
@@ -44,6 +45,7 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
     switch (mode) {
         case Off:
             CColorManager::energyGaugeColor = 0xff008f00;
+            CColorManager::lookForwardColor = 0xff000000;
             CColorManager::netDelay1Color = 0xffffc000;
             CColorManager::netDelay2Color = 0xffffff00;
             CColorManager::pinwheel1Color = 0xff1e1e66;
@@ -78,6 +80,7 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             break;
         case Deuteranopia:
             CColorManager::energyGaugeColor = 0xff008f8f;
+            CColorManager::lookForwardColor = 0xff000000;
             CColorManager::netDelay1Color = 0xffffe080;
             CColorManager::netDelay2Color = 0xffffff00;
             CColorManager::pinwheel1Color = 0xff1e1e66;
@@ -112,6 +115,7 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             break;
         case Protanopia:
             CColorManager::energyGaugeColor = 0xff008f8f;
+            CColorManager::lookForwardColor = 0xff000000;
             CColorManager::netDelay1Color = 0xffffe080;
             CColorManager::netDelay2Color = 0xffffff00;
             CColorManager::pinwheel1Color = 0xff1e1e66;
@@ -146,6 +150,7 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             break;
         case Tritanopia:
             CColorManager::energyGaugeColor = 0xff008f00;
+            CColorManager::lookForwardColor = 0xff000000;
             CColorManager::netDelay1Color = 0xffffc000;
             CColorManager::netDelay2Color = 0xffffff00;
             CColorManager::pinwheel1Color = 0xff1e1e66;

--- a/src/gui/CColorManager.cpp
+++ b/src/gui/CColorManager.cpp
@@ -11,6 +11,8 @@ uint32_t CColorManager::pinwheel4Color = 0xff1e1eff;
 uint32_t CColorManager::plasmaGauge1Color = 0xffa33600;
 uint32_t CColorManager::plasmaGauge2Color = 0xffff3600;
 uint32_t CColorManager::shieldGaugeColor = 0xff003da5;
+uint32_t CColorManager::specialBlackColor = 0xff303030;
+uint32_t CColorManager::specialWhiteColor = 0xffe0e0e0;
 
 uint32_t CColorManager::teamColors[kMaxTeamColors + 1] = {
     0xffffffff,
@@ -49,6 +51,8 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::plasmaGauge1Color = 0xffa33600;
             CColorManager::plasmaGauge2Color = 0xffff3600;
             CColorManager::shieldGaugeColor = 0xff003da5;
+            CColorManager::specialBlackColor = 0xff303030;
+            CColorManager::specialWhiteColor = 0xffe0e0e0;
             CColorManager::teamColors[0] = 0xffffffff;
             CColorManager::teamColors[1] = 0xff006600;
             CColorManager::teamColors[2] = 0xffcccc00;
@@ -79,6 +83,8 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::plasmaGauge1Color = 0xffa33600;
             CColorManager::plasmaGauge2Color = 0xffff3600;
             CColorManager::shieldGaugeColor = 0xff0000a5;
+            CColorManager::specialBlackColor = 0xff303030;
+            CColorManager::specialWhiteColor = 0xffe0e0e0;
             CColorManager::teamColors[0] = 0xffffffff;
             CColorManager::teamColors[1] = 0xff006655;
             CColorManager::teamColors[2] = 0xffcccc00;
@@ -109,6 +115,8 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::plasmaGauge1Color = 0xffa33600;
             CColorManager::plasmaGauge2Color = 0xffff3600;
             CColorManager::shieldGaugeColor = 0xff0000a5;
+            CColorManager::specialBlackColor = 0xff303030;
+            CColorManager::specialWhiteColor = 0xffe0e0e0;
             CColorManager::teamColors[0] = 0xffffffff;
             CColorManager::teamColors[1] = 0xff006655;
             CColorManager::teamColors[2] = 0xffcccc00;
@@ -139,6 +147,8 @@ void CColorManager::setColorBlind(ColorBlindMode mode) {
             CColorManager::plasmaGauge1Color = 0xffa33600;
             CColorManager::plasmaGauge2Color = 0xffff3600;
             CColorManager::shieldGaugeColor = 0xff003da5;
+            CColorManager::specialBlackColor = 0xff303030;
+            CColorManager::specialWhiteColor = 0xffe0e0e0;
             CColorManager::teamColors[0] = 0xffffffff;
             CColorManager::teamColors[1] = 0xff006600;
             CColorManager::teamColors[2] = 0xffcccc00;

--- a/src/gui/CColorManager.h
+++ b/src/gui/CColorManager.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "AvaraDefines.h"
+
+#include <optional>
+#include <stdint.h>
+
+enum ColorBlindMode { Off, Deuteranopia, Protanopia, Tritanopia };
+
+class CColorManager {
+public:
+    static inline std::optional<uint32_t> getTeamColor(uint8_t num) {
+        if (num <= kMaxTeamColors) {
+            return teamColors[num];
+        }
+        return {};
+    };
+
+    static inline std::optional<uint32_t> getTeamTextColor(uint8_t num) {
+        if (num <= kMaxTeamColors) {
+            return teamTextColors[num];
+        }
+        return {};
+    };
+
+    static void setColorBlind(ColorBlindMode mode);
+private:
+    CColorManager() {}
+
+    static uint32_t teamColors[kMaxTeamColors + 1];
+    static uint32_t teamTextColors[kMaxTeamColors + 1];
+};

--- a/src/gui/CColorManager.h
+++ b/src/gui/CColorManager.h
@@ -17,6 +17,10 @@ public:
         return energyGaugeColor;
     }
 
+    static inline uint32_t getLookForwardColor() {
+        return lookForwardColor;
+    }
+
     static inline uint32_t getNetDelay1Color() {
         return netDelay1Color;
     }
@@ -87,6 +91,7 @@ private:
 
     static ColorBlindMode colorBlindMode;
     static uint32_t energyGaugeColor;
+    static uint32_t lookForwardColor;
     static uint32_t netDelay1Color;
     static uint32_t netDelay2Color;
     static uint32_t pinwheel1Color;

--- a/src/gui/CColorManager.h
+++ b/src/gui/CColorManager.h
@@ -49,6 +49,14 @@ public:
         return plasmaGauge2Color;
     }
 
+    static inline uint32_t getPlasmaSightsOffColor() {
+        return plasmaSightsOffColor;
+    }
+
+    static inline uint32_t getPlasmaSightsOnColor() {
+        return plasmaSightsOnColor;
+    }
+
     static inline uint32_t getShieldGaugeColor() {
         return shieldGaugeColor;
     }
@@ -87,6 +95,8 @@ private:
     static uint32_t pinwheel4Color;
     static uint32_t plasmaGauge1Color;
     static uint32_t plasmaGauge2Color;
+    static uint32_t plasmaSightsOffColor;
+    static uint32_t plasmaSightsOnColor;
     static uint32_t shieldGaugeColor;
     static uint32_t specialBlackColor;
     static uint32_t specialWhiteColor;

--- a/src/gui/CColorManager.h
+++ b/src/gui/CColorManager.h
@@ -9,24 +9,77 @@ enum ColorBlindMode { Off, Deuteranopia, Protanopia, Tritanopia };
 
 class CColorManager {
 public:
+    static inline uint32_t getDefaultTeamColor() {
+        return teamColors[0];
+    }
+
+    static inline uint32_t getEnergyGaugeColor() {
+        return energyGaugeColor;
+    }
+
+    static inline uint32_t getNetDelay1Color() {
+        return netDelay1Color;
+    }
+
+    static inline uint32_t getNetDelay2Color() {
+        return netDelay2Color;
+    }
+
+    static inline uint32_t getPinwheel1Color() {
+        return pinwheel1Color;
+    }
+
+    static inline uint32_t getPinwheel2Color() {
+        return pinwheel2Color;
+    }
+
+    static inline uint32_t getPinwheel3Color() {
+        return pinwheel3Color;
+    }
+
+    static inline uint32_t getPinwheel4Color() {
+        return pinwheel4Color;
+    }
+
+    static inline uint32_t getPlasmaGauge1Color() {
+        return plasmaGauge1Color;
+    }
+
+    static inline uint32_t getPlasmaGauge2Color() {
+        return plasmaGauge2Color;
+    }
+
+    static inline uint32_t getShieldGaugeColor() {
+        return shieldGaugeColor;
+    }
+
     static inline std::optional<uint32_t> getTeamColor(uint8_t num) {
-        if (num <= kMaxTeamColors) {
-            return teamColors[num];
-        }
-        return {};
-    };
+        return (num <= kMaxTeamColors)
+            ? teamColors[num]
+            : std::optional<uint32_t>{};
+    }
 
     static inline std::optional<uint32_t> getTeamTextColor(uint8_t num) {
-        if (num <= kMaxTeamColors) {
-            return teamTextColors[num];
-        }
-        return {};
-    };
+        return (num <= kMaxTeamColors)
+            ? teamTextColors[num]
+            : std::optional<uint32_t>{};
+    }
 
     static void setColorBlind(ColorBlindMode mode);
 private:
     CColorManager() {}
 
+    static ColorBlindMode colorBlindMode;
+    static uint32_t energyGaugeColor;
+    static uint32_t netDelay1Color;
+    static uint32_t netDelay2Color;
+    static uint32_t pinwheel1Color;
+    static uint32_t pinwheel2Color;
+    static uint32_t pinwheel3Color;
+    static uint32_t pinwheel4Color;
+    static uint32_t plasmaGauge1Color;
+    static uint32_t plasmaGauge2Color;
+    static uint32_t shieldGaugeColor;
     static uint32_t teamColors[kMaxTeamColors + 1];
     static uint32_t teamTextColors[kMaxTeamColors + 1];
 };

--- a/src/gui/CColorManager.h
+++ b/src/gui/CColorManager.h
@@ -53,6 +53,14 @@ public:
         return shieldGaugeColor;
     }
 
+    static inline uint32_t getSpecialBlackColor() {
+        return specialBlackColor;
+    }
+
+    static inline uint32_t getSpecialWhiteColor() {
+        return specialWhiteColor;
+    }
+
     static inline std::optional<uint32_t> getTeamColor(uint8_t num) {
         return (num <= kMaxTeamColors)
             ? teamColors[num]
@@ -80,6 +88,8 @@ private:
     static uint32_t plasmaGauge1Color;
     static uint32_t plasmaGauge2Color;
     static uint32_t shieldGaugeColor;
+    static uint32_t specialBlackColor;
+    static uint32_t specialWhiteColor;
     static uint32_t teamColors[kMaxTeamColors + 1];
     static uint32_t teamTextColors[kMaxTeamColors + 1];
 };

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -8,6 +8,7 @@
 #include "CPlayerManager.h"
 #include "CScoreKeeper.h"
 #include "Preferences.h"
+#include "RGBAColor.h"
 
 #include <nanogui/colorcombobox.h>
 #include <nanogui/layout.h>
@@ -206,6 +207,12 @@ void CRosterWindow::UpdateRoster() {
             statuses[i]->setValue(theStatus.c_str());
             chats[i]->setValue(theChat.c_str());
             colors[i]->setSelectedIndex(theNet->teamColors[i]);
+            colors[i]->setTextColor(nanogui::Color(
+                LongToR(CColorManager::getTeamTextColor(theNet->teamColors[i] + 1).value()),
+                LongToG(CColorManager::getTeamTextColor(theNet->teamColors[i] + 1).value()),
+                LongToB(CColorManager::getTeamTextColor(theNet->teamColors[i] + 1).value()),
+                LongToA(CColorManager::getTeamTextColor(theNet->teamColors[i] + 1).value())
+            ));
             colors[i]->setCaption(theName.c_str());
             colors[i]->popup()->setAnchorPos(nanogui::Vector2i(235, 68 + 60 * i));
         }

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -3,6 +3,7 @@
 #include "AvaraDefines.h"
 #include "CAbstractPlayer.h"
 #include "CAvaraApp.h"
+#include "CColorManager.h"
 #include "CNetManager.h"
 #include "CPlayerManager.h"
 #include "CScoreKeeper.h"
@@ -12,11 +13,9 @@
 #include <nanogui/layout.h>
 #include <numeric>
 #include <sstream>
+#include <stdint.h>
 #include <nanogui/tabwidget.h>
 using namespace nanogui;
-
-std::vector<long> player_colors =
-    {kGreenTeamColor, kYellowTeamColor, kRedTeamColor, kPinkTeamColor, kPurpleTeamColor, kBlueTeamColor, kOrangeTeamColor, kLimeTeamColor};
 
 std::vector<Text *> statuses;
 std::vector<Text *> chats;
@@ -47,7 +46,7 @@ CRosterWindow::CRosterWindow(CApplication *app) : CWindow(app, "Roster") {
     setFixedWidth(470);
 
     tabWidget = add<TabWidget>();
-    
+
     //players tab
     Widget *playersLayer = tabWidget->createTab("Players");
 
@@ -59,6 +58,17 @@ CRosterWindow::CRosterWindow(CApplication *app) : CWindow(app, "Roster") {
     auto panel = playersLayer->add<Widget>();
     panel->setLayout(layout);
     theNet = ((CAvaraAppImpl *)gApplication)->GetNet();
+    std::vector<long> player_colors = {
+        CColorManager::getTeamColor(1).value_or(CColorManager::getDefaultTeamColor()),
+        CColorManager::getTeamColor(2).value_or(CColorManager::getDefaultTeamColor()),
+        CColorManager::getTeamColor(3).value_or(CColorManager::getDefaultTeamColor()),
+        CColorManager::getTeamColor(4).value_or(CColorManager::getDefaultTeamColor()),
+        CColorManager::getTeamColor(5).value_or(CColorManager::getDefaultTeamColor()),
+        CColorManager::getTeamColor(6).value_or(CColorManager::getDefaultTeamColor()),
+        CColorManager::getTeamColor(7).value_or(CColorManager::getDefaultTeamColor()),
+        CColorManager::getTeamColor(8).value_or(CColorManager::getDefaultTeamColor())
+    };
+
     for (int i = 0; i < kMaxAvaraPlayers; i++) {
         layout->appendRow(1, 1);
         layout->appendCol(1, 1);
@@ -107,20 +117,20 @@ CRosterWindow::CRosterWindow(CApplication *app) : CWindow(app, "Roster") {
     //chat tab
     Widget *chatTab = tabWidget->createTab("Chat");
     chatTab->setLayout(new GridLayout(Orientation::Horizontal, 1, Alignment::Minimum, 0, 0));
-    
+
     VScrollPanel *scrollPanel = new VScrollPanel(chatTab);
     scrollPanel->setFixedWidth(ROSTER_WINDOW_WIDTH);
     scrollPanel->setFixedHeight(500);
-    
+
     chatPanel = new Widget(scrollPanel);
     AdvancedGridLayout *chatLayout = new AdvancedGridLayout();
     chatPanel->setLayout(chatLayout);
-    
+
     //placeholder lines for now
     for (int i = 0; i < 20; i++) {
         chatLayout->appendRow(1, 0.1);
         chatLayout->appendCol(1, 1);
-        
+
         auto chatLine = chatPanel->add<Label>("");
         chatLine->setFontSize(ROSTER_FONT_SIZE + 2);
         chatLine->setFont("mono");
@@ -137,7 +147,7 @@ CRosterWindow::CRosterWindow(CApplication *app) : CWindow(app, "Roster") {
     chatInput->setFont("mono");
     chatInput->setFixedWidth(ROSTER_WINDOW_WIDTH - 20);
     chatInput->setFixedHeight(70);
-    
+
     //scores tab
     Widget *scoreLayer = tabWidget->createTab("Scores");
     scoreLayer->setLayout(new GridLayout(Orientation::Horizontal, 6, Alignment::Minimum, 0, 0));
@@ -172,7 +182,7 @@ CRosterWindow::CRosterWindow(CApplication *app) : CWindow(app, "Roster") {
     currentLevel = ((CAvaraAppImpl *)gApplication)->GetGame()->loadedTag;
 
     UpdateRoster();
-    
+
     requestFocus();
 }
 
@@ -299,11 +309,11 @@ void CRosterWindow::ChatLineDelete() {
 void CRosterWindow::NewChatLine(Str255 playerName, std::string message) {
     std::string name = std::string((char *)playerName + 1, playerName[0]);
     std::string chatLine = name + ": " +  message;
- 
+
     AdvancedGridLayout *gridLayout = (AdvancedGridLayout*) chatPanel->layout();
     gridLayout->appendRow(1, 0.1);
     gridLayout->appendCol(1, 1);
-    
+
     auto chatLabel = chatPanel->add<Label>(chatLine);
     chatLabel->setFontSize(ROSTER_FONT_SIZE + 2);
     chatLabel->setFont("mono");
@@ -316,7 +326,7 @@ void CRosterWindow::NewChatLine(Str255 playerName, std::string message) {
     NVGcontext* context = screen->nvgContext();
     chatLabel->parent()->performLayout(context);
     chatInput->setCaption(theName + ": ");
-    
+
     VScrollPanel *scroll = (VScrollPanel*)chatPanel->parent();
     scroll->setScroll(1);
 }
@@ -332,13 +342,13 @@ bool CRosterWindow::handleSDLEvent(SDL_Event &event) {
         return true;
     } else if (event.type == SDL_KEYDOWN) {
         //SDL_Log("CRosterWindow::handleSDLEvent SDL_KEYDOWN");
-        
+
         switch (event.key.keysym.sym) {
             case SDLK_BACKSPACE:
                 SendRosterMessage(1, backspace);
                 ChatLineDelete();
                 //SDL_Log("CRosterWindow::handleSDLEvent BACK");
-                
+
                 return true;
             case SDLK_RETURN:
                 SendRosterMessage(1, endline);
@@ -347,7 +357,7 @@ bool CRosterWindow::handleSDLEvent(SDL_Event &event) {
             case SDLK_DELETE:
                 SendRosterMessage(1, clearline);
                 //SDL_Log("CRosterWindow::handleSDLEvent CLEAR");
-                
+
                 return true;
             case SDLK_g:
                 if (SDL_GetModState() & KMOD_CTRL) {

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -59,14 +59,14 @@ CRosterWindow::CRosterWindow(CApplication *app) : CWindow(app, "Roster") {
     panel->setLayout(layout);
     theNet = ((CAvaraAppImpl *)gApplication)->GetNet();
     std::vector<long> player_colors = {
-        CColorManager::getTeamColor(1).value_or(CColorManager::getDefaultTeamColor()),
-        CColorManager::getTeamColor(2).value_or(CColorManager::getDefaultTeamColor()),
-        CColorManager::getTeamColor(3).value_or(CColorManager::getDefaultTeamColor()),
-        CColorManager::getTeamColor(4).value_or(CColorManager::getDefaultTeamColor()),
-        CColorManager::getTeamColor(5).value_or(CColorManager::getDefaultTeamColor()),
-        CColorManager::getTeamColor(6).value_or(CColorManager::getDefaultTeamColor()),
-        CColorManager::getTeamColor(7).value_or(CColorManager::getDefaultTeamColor()),
-        CColorManager::getTeamColor(8).value_or(CColorManager::getDefaultTeamColor())
+        (long) CColorManager::getTeamColor(1).value_or(CColorManager::getDefaultTeamColor()),
+        (long) CColorManager::getTeamColor(2).value_or(CColorManager::getDefaultTeamColor()),
+        (long) CColorManager::getTeamColor(3).value_or(CColorManager::getDefaultTeamColor()),
+        (long) CColorManager::getTeamColor(4).value_or(CColorManager::getDefaultTeamColor()),
+        (long) CColorManager::getTeamColor(5).value_or(CColorManager::getDefaultTeamColor()),
+        (long) CColorManager::getTeamColor(6).value_or(CColorManager::getDefaultTeamColor()),
+        (long) CColorManager::getTeamColor(7).value_or(CColorManager::getDefaultTeamColor()),
+        (long) CColorManager::getTeamColor(8).value_or(CColorManager::getDefaultTeamColor())
     };
 
     for (int i = 0; i < kMaxAvaraPlayers; i++) {

--- a/src/gui/CWindow.h
+++ b/src/gui/CWindow.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Types.h"
-
 #include <SDL2/SDL.h>
 #include <nanogui/nanogui.h>
 #include <string>
@@ -20,7 +18,7 @@ public:
 
     // Called when an applcation preference value changes.
     virtual void PrefChanged(std::string name) {}
-    
+
     virtual bool editing() { return false; }
 
     virtual void restoreState();

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -35,6 +35,10 @@ using json = nlohmann::json;
 #define kFullScreenTag "fullscreen"
 #define kFOV "fov"
 
+// Other graphics settings
+#define kColorBlindMode "colorBlindMode"
+#define kWeaponSightAlpha "weaponSightAlpha"
+
 // Network & Tracker
 #define kLastAddress "lastAddress"
 #define kServerDescription "serverDescription"
@@ -95,6 +99,8 @@ static json defaultPrefs = {
     {kWindowHeight, 768},
     {kFullScreenTag, false},
     {kFOV, 50.0},
+    {kColorBlindMode, 0},
+    {kWeaponSightAlpha, 1.0},
     {kLastAddress, ""},
     {kServerDescription, ""},
     {kServerPassword, ""},

--- a/src/level/LevelLoader.cpp
+++ b/src/level/LevelLoader.cpp
@@ -17,13 +17,14 @@
 #include "Parser.h"
 #include "Resource.h"
 #include "pugixml.hpp"
-#include "csscolorparser.hpp"
+#include "RGBAColor.h"
 
 #include <SDL2/SDL.h>
 
 #include <algorithm>
 #include <sstream>
 #include <fstream>
+#include <optional>
 #include <streambuf>
 #include <regex>
 
@@ -49,7 +50,7 @@ static short lastDomeAngle;
 static short lastDomeSpan;
 static Fixed lastDomeRadius;
 
-static RGBColor fillColor, frameColor;
+static uint32_t fillColor, frameColor;
 
 
 Fixed GetDome(Fixed *theLoc, Fixed *startAngle, Fixed *spanAngle) {
@@ -62,12 +63,12 @@ Fixed GetDome(Fixed *theLoc, Fixed *startAngle, Fixed *spanAngle) {
     return lastDomeRadius;
 }
 
-int GetPixelColor() {
-    return ((((int)fillColor.red) << 8) & 0xFF0000) | (fillColor.green & 0xFF00) | (fillColor.blue >> 8);
+uint32_t GetPixelColor() {
+    return fillColor;
 }
 
-int GetOtherPixelColor() {
-    return ((((int)frameColor.red) << 8) & 0xFF0000) | (frameColor.green & 0xFF00) | (frameColor.blue >> 8);
+uint32_t GetOtherPixelColor() {
+    return frameColor;
 }
 
 void GetLastArcLocation(Fixed *theLoc) {
@@ -174,20 +175,16 @@ struct ALFWalker: pugi::xml_tree_walker {
         gLastBoxRounding = h.empty() ? 0 : ToFixed(std::stod(h));
 
         if (!fill.empty()) {
-            const auto color = CSSColorParser::parse(fill);
+            const std::optional<uint32_t> color = ParseColor(fill);
             if (color) {
-                fillColor.red = color->r * 257;
-                fillColor.green = color->g * 257;
-                fillColor.blue = color->b * 257;
+                fillColor = color.value();
             }
         }
 
         if (!frame.empty()) {
-            const auto color = CSSColorParser::parse(frame);
+            const std::optional<uint32_t> color = ParseColor(frame);
             if (color) {
-                frameColor.red = color->r * 257;
-                frameColor.green = color->g * 257;
-                frameColor.blue = color->b * 257;
+                frameColor = color.value();
             }
         }
 

--- a/src/level/LevelLoader.h
+++ b/src/level/LevelLoader.h
@@ -9,6 +9,7 @@
 
 #pragma once
 #include "Types.h"
+#include <stdint.h>
 #include <string>
 #include <vector>
 
@@ -318,6 +319,6 @@ bool LoadALF(std::string levelName);
 void GetLastArcLocation(Fixed *theLoc);
 Fixed GetLastArcDirection();
 Fixed GetDome(Fixed *theLoc, Fixed *startAngle, Fixed *spanAngle);
-int GetPixelColor();
-int GetOtherPixelColor();
+uint32_t GetPixelColor();
+uint32_t GetOtherPixelColor();
 Fixed GetLastOval(Fixed *theLoc);

--- a/src/util/RGBAColor.h
+++ b/src/util/RGBAColor.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "CColorManager.h"
 #include "csscolorparser.hpp"
 
 #include <optional>
+#include <regex>
 #include <SDL2/SDL.h>
 #include <stdint.h>
 
@@ -15,18 +17,34 @@ static uint32_t RGBAToLong(CSSColorParser::Color rgba) {
     );
 }
 
+static inline uint8_t LongToR(uint32_t in) {
+    return ((in >> 16) & 0xFF);
+}
+
+static inline uint8_t LongToG(uint32_t in) {
+    return ((in >> 8) & 0xFF);
+}
+
+static inline uint8_t LongToB(uint32_t in) {
+    return (in & 0xFF);
+}
+
+static inline uint8_t LongToA(uint32_t in) {
+    return (in >> 24);
+}
+
 static void LongToRGBA(uint32_t in, float *out, int n = 4) {
     if (n < 3 || n > 4) {
         SDL_Log("n must be 3 (for RGB) or 4 (for RGBA)");
         exit(69);
     }
 
-    out[0] = ((in >> 16) & 0xFF) / 255.0;
-    out[1] = ((in >> 8) & 0xFF) / 255.0;
-    out[2] = (in & 0xFF) / 255.0;
+    out[0] = LongToR(in) / 255.0;
+    out[1] = LongToG(in) / 255.0;
+    out[2] = LongToB(in) / 255.0;
 
     if (n == 4) {
-        out[3] = (in >> 24) / 255.0;
+        out[3] = LongToA(in) / 255.0;
     }
 }
 
@@ -35,6 +53,22 @@ static std::optional<uint32_t> ParseColor(const std::string& str) {
 
     if (color) {
         return RGBAToLong(*color);
+    }
+
+    std::string tmp = str;
+
+    // Remove all whitespace.
+    tmp.erase(std::remove(tmp.begin(), tmp.end(), ' '), tmp.end());
+
+    // Convert to lowercase.
+    std::transform(tmp.begin(), tmp.end(), tmp.begin(), ::tolower);
+
+    std::regex search("^team\\((\\d+)\\)$");
+    std::smatch match;
+    if (std::regex_search(tmp, match, search)) {
+        return CColorManager::getTeamColor(
+            strtoll(match[1].str().c_str(), nullptr, 10)
+        );
     }
 
     return {};

--- a/src/util/RGBAColor.h
+++ b/src/util/RGBAColor.h
@@ -2,11 +2,11 @@
 
 #include "csscolorparser.hpp"
 
+#include <optional>
 #include <SDL2/SDL.h>
 #include <stdint.h>
 
-static uint32_t RGBAToLong(CSSColorParser::Color rgba)
-{
+static uint32_t RGBAToLong(CSSColorParser::Color rgba) {
     return (
         (static_cast<int>((rgba.a * 255.0) + 0.5) << 24) +
         (rgba.r << 16) +
@@ -15,8 +15,7 @@ static uint32_t RGBAToLong(CSSColorParser::Color rgba)
     );
 }
 
-static void LongToRGBA(uint32_t in, float *out, int n = 4)
-{
+static void LongToRGBA(uint32_t in, float *out, int n = 4) {
     if (n < 3 || n > 4) {
         SDL_Log("n must be 3 (for RGB) or 4 (for RGBA)");
         exit(69);
@@ -29,4 +28,14 @@ static void LongToRGBA(uint32_t in, float *out, int n = 4)
     if (n == 4) {
         out[3] = (in >> 24) / 255.0;
     }
+}
+
+static std::optional<uint32_t> ParseColor(const std::string& str) {
+    std::optional<CSSColorParser::Color> color = CSSColorParser::parse(str);
+
+    if (color) {
+        return RGBAToLong(*color);
+    }
+
+    return {};
 }


### PR DESCRIPTION
Addresses #54, requires review, feedback, and insights by actual color-impaired people. Tritanopia mode currently doesn't do anything, for example.

We also are currently not doing anything with teamTextColors, which I intend to be used to control the text color in the CRosterWindow (for example) when used on a "layer" above the teamColor.

Finally, I'd like to control weapon sight colors as well.