### PR TITLE
fixed jumping bug

### DIFF
--- a/src/game/CWalkerActor.cpp
+++ b/src/game/CWalkerActor.cpp
@@ -638,18 +638,18 @@ void CWalkerActor::KeyboardControl(FunctionTable *ft) {
                 stance = MINHEADHEIGHT;
         }
 
+        if (TESTFUNC(kfuJump, ft->up) && tractionFlag) {
+            speed[1] >>= 1;
+            speed[1] += FMulDivNZ((crouch >> 1) + jumpBasePower, baseMass, GetTotalMass());
+            jumpFlag = true;
+        }
+
         if (TESTFUNC(kfuJump, ft->down)) {
             crouch += (stance - crouch - MINHEADHEIGHT) >> 3;
         } else if (TESTFUNC(kfuJump, ft->held)) {
             crouch += (stance - crouch - MINHEADHEIGHT) >> 2;
         } else {
             crouch >>= 1;
-        }
-
-        if (TESTFUNC(kfuJump, ft->up) && tractionFlag) {
-            speed[1] >>= 1;
-            speed[1] += FMulDivNZ((crouch >> 1) + jumpBasePower, baseMass, GetTotalMass());
-            jumpFlag = true;
         }
     }
 }


### PR DESCRIPTION
Sometimes you could get a kfuJump UP and a kfuJump DOWN in the same frame resulting in a big jump (maximum crouch).  But, if you only detected the kfuJump UP in a single frame, it would cut the crouch in half before calculating the jump velocity.   The fix is simple, execute the UP handler first before the crouch can be cut in half.