### PR TITLE
Add method to query team color name

### DIFF
--- a/src/gui/CColorManager.cpp
+++ b/src/gui/CColorManager.cpp
@@ -49,6 +49,18 @@ uint32_t CColorManager::teamTextColors[kMaxTeamColors + 1] = {
     0xff333333
 };
 
+std::string CColorManager::teamColorNames[kMaxTeamColors + 1] = {
+    "Neutral",
+    "Green",
+    "Yellow",
+    "Red",
+    "Pink",
+    "Purple",
+    "Blue",
+    "Orange",
+    "Teal"
+};
+
 void CColorManager::setColorBlind(ColorBlindMode mode) {
     switch (mode) {
         case Off:

--- a/src/gui/CColorManager.h
+++ b/src/gui/CColorManager.h
@@ -4,6 +4,7 @@
 
 #include <optional>
 #include <stdint.h>
+#include <string>
 
 enum ColorBlindMode { Off, Deuteranopia, Protanopia, Tritanopia };
 
@@ -105,6 +106,12 @@ public:
             : std::optional<uint32_t>{};
     }
 
+    static inline std::optional<std::string> getTeamColorName(uint8_t num) {
+        return (num <= kMaxTeamColors)
+            ? teamColorNames[num]
+            : std::optional<std::string>{};
+    }
+
     static void setColorBlind(ColorBlindMode mode);
     static void setHudAlpha(float alpha);
 private:
@@ -135,4 +142,5 @@ private:
     static uint32_t specialWhiteColor;
     static uint32_t teamColors[kMaxTeamColors + 1];
     static uint32_t teamTextColors[kMaxTeamColors + 1];
+    static std::string teamColorNames[kMaxTeamColors + 1];
 };


### PR DESCRIPTION
Closes #54 at long last. We never got a CVD individual to test, but the functionality is stable and has seen extensive testing by now. Tweaks to colors (if necessary) will be trivial.