### PR TITLE
Fail gracefully when a BSP is not found

### DIFF
--- a/src/bsp/CBSPPart.cpp
+++ b/src/bsp/CBSPPart.cpp
@@ -60,6 +60,8 @@ void CBSPPart::IBSPPart(short resId) {
     std::ifstream infile(bspName);
     if (infile.fail()) {
         SDL_Log("*** Failed to load BSP %d\n", resId);
+        polyCount = 0;
+        pointCount = 0;
         return;
     }
 
@@ -444,6 +446,10 @@ void CBSPPart::BuildBoundingVolumes() {
 }
 
 void CBSPPart::Dispose() {
+    if(polyCount < 1) {
+        CDirectObject::Dispose();
+        return;
+    }
     for (int i = 0; i < polyCount; i++) {
         DisposePtr((Ptr)polyTable[i].triPoints);
     }


### PR DESCRIPTION
- Set `CBSPPart::polyCount` and `CBSPPart::pointCount` to be 0 when we can't find the BSP file.
- This causes the `CBSPPart::UpdateOpenGLData` method to be skipped (correctly), fixing a crash.
- This is now checked for in the destructor so that we do not attempt to free memory allocated to the `point/polyTable` arrays, fixing a crash.