### PR TITLE
fix auto-pause by not doing it

### DIFF
--- a/src/compat/System.cpp
+++ b/src/compat/System.cpp
@@ -10,7 +10,7 @@ uint64_t TickCount() {
     // see https://stackoverflow.com/a/35962360 ?
     // Approximate ms -> tick (1/60th of a second in old mac parlance)
     // return SDL_GetTicks() >> 4;
-    return (uint64_t)((double)SDL_GetTicks() / MSEC_PER_TICK_COUNT);
+    return MSEC_TO_TICK_COUNT(SDL_GetTicks());
 }
 
 static std::map<QHdrPtr, std::deque<QElemPtr>> gQueues;

--- a/src/compat/System.h
+++ b/src/compat/System.h
@@ -3,7 +3,8 @@
 #include "Types.h"
 
 // (60 ticks/sec = 16.66667 msec) the old mac method TickCount() ticked at this rate
-#define MSEC_PER_TICK_COUNT (1000.0/60)
+#define MSEC_TO_TICK_COUNT(msec) ((msec)*60/1000)
+#define TICK_COUNT_TO_MSEC(tick) ((tick)*1000/60)
 uint64_t TickCount();
 
 void Enqueue(QElemPtr qElement, QHdrPtr qHeader);

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -405,7 +405,7 @@ void CAvaraAppImpl::ParamLine(short index, MsgAlignment align, StringPtr param1,
             buffa << "Game paused by " << a << ".";
             break;
         case kmWaitingForPlayer:
-            buffa << "Waiting for " << a << ".";
+            buffa << "Waiting for " << a << "... (abort to exit)";
             category = MsgCategory::Error;
             break;
         case kmAKilledBPlayer:

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -139,10 +139,7 @@ void CAvaraAppImpl::idle() {
     CheckSockets();
     TrackerUpdate();
     if(itsGame->GameTick()) {
-        glClearColor(mBackground[0], mBackground[1], mBackground[2], mBackground[3]);
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-        drawContents();
-        SDL_GL_SwapWindow(mSDLWindow);
+        RenderContents();
     }
 }
 
@@ -157,6 +154,14 @@ void CAvaraAppImpl::drawContents() {
         previewAngle += FIX3(1);
     }
     itsGame->Render(mNVGContext);
+}
+
+// display only the game screen, not the widgets
+void CAvaraAppImpl::RenderContents() {
+    glClearColor(mBackground[0], mBackground[1], mBackground[2], mBackground[3]);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+    drawContents();
+    SDL_GL_SwapWindow(mSDLWindow);
 }
 
 void CAvaraAppImpl::WindowResized(int width, int height) {

--- a/src/game/CAvaraApp.h
+++ b/src/game/CAvaraApp.h
@@ -40,6 +40,7 @@ public:
     virtual void GameStarted(std::string set, std::string level) = 0;
     virtual void MessageLine(short index, MsgAlignment align) = 0;
     virtual void AddMessageLine(std::string lines, MsgAlignment align = MsgAlignment::Left, MsgCategory category = MsgCategory::System) = 0;
+    virtual void RenderContents() = 0;
     virtual std::deque<MsgLine>& MessageLines() = 0;
     virtual void DrawUserInfoPart(short i, short partList) = 0;
     virtual void ParamLine(short index, MsgAlignment align, StringPtr param1, StringPtr param2) = 0;
@@ -96,6 +97,7 @@ public:
     virtual std::deque<MsgLine>& MessageLines() override;
     virtual void idle() override;
     virtual void drawContents() override;
+    virtual void RenderContents() override;
 
     virtual bool DoCommand(int theCommand) override;
     virtual void WindowResized(int width, int height) override;

--- a/src/game/CAvaraApp.h
+++ b/src/game/CAvaraApp.h
@@ -43,7 +43,7 @@ public:
     virtual void RenderContents() = 0;
     virtual std::deque<MsgLine>& MessageLines() = 0;
     virtual void DrawUserInfoPart(short i, short partList) = 0;
-    virtual void ParamLine(short index, MsgAlignment align, StringPtr param1, StringPtr param2) = 0;
+    virtual void ParamLine(short index, MsgAlignment align, StringPtr param1, StringPtr param2 = NULL) = 0;
     virtual void StartFrame(long frameNum) = 0;
     virtual void BrightBox(long frameNum, short position) = 0;
     virtual void LevelReset() = 0;

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -574,7 +574,7 @@ Boolean CNetManager::GatherPlayers(Boolean isFreshMission) {
     do {
         if (TickCount() > debugTime) {
             SDL_Log("CNetManager::GatherPlayers loop\n");
-            debugTime = TickCount() + 1000 / MSEC_PER_TICK_COUNT;
+            debugTime = TickCount() + MSEC_TO_TICK_COUNT(1000);
         }
         ProcessQueue();
         goAhead = (TickCount() - lastTime < 1800);

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -534,13 +534,6 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
             quickTick = TickCount();
 
             if (quickTick - askAgainTime >= 0) {
-                if (quickTick - firstTime > 120) {
-                    if (TestKeyPressed(kfuAbortGame)) {
-                        itsGame->statusRequest = kAbortStatus;
-                        break;
-                    }
-                }
-
                 if (theNetManager->IAmAlive() || askCount > 0) {
                     askAgainTime = quickTick + MSEC_TO_TICK_COUNT(2000); //	2 seconds = 120 ticks
                 } else {
@@ -570,6 +563,12 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
                         MsgAlignment::Center, MsgCategory::Error);
                     break;
                 }
+            }
+
+            // allow immediate abort after the kmWaitingForPlayer message displays
+            if (askCount >= 2 && TestKeyPressed(kfuAbortGame)) {
+                itsGame->statusRequest = kAbortStatus;
+                break;
             }
 
         } while (frameFuncs[i].validFrame != itsGame->frameNumber);

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -146,41 +146,9 @@ uint32_t CPlayerManagerImpl::DoMouseControl(Point *deltaMouse, Boolean doCenter)
     return state;
 }
 
-Boolean CPlayerManagerImpl::TestHeldKey(short funcCode) {
-    /*
-    long			m0, m1;
-    KeyMap			keyMap;
-    char			*keyMapP;
-    long			*mapPtr, *keyFun;
-    short			i,j;
-    Handle			mapRes;
-
-    m0 = 0x80000000L >> funcCode;
-    m1 = 0x80000000L >> (funcCode - 32);
-
-    mapRes = itsGame->mapRes;
-    mapPtr = (long *)*mapRes;
-    keyMapP = (Ptr)keyMap;
-    GetKeys(keyMap);
-
-    for(i=0;i<128;i+=8)
-    {	char	bits;
-
-        bits = *keyMapP++;
-        if(bits)
-        {	j = 8;
-            while(j-- && bits)
-            {	if(bits < 0)
-                {	keyFun = &mapPtr[2*(i+j)];
-                    if((keyFun[0] & m0) || (keyFun[1] & m1))
-                        return true;
-                }
-                bits += bits;
-            }
-        }
-    }
-    */
-    return false;
+Boolean CPlayerManagerImpl::TestKeyPressed(short funcCode) {
+    CPlayerManagerImpl* localManager = ((CPlayerManagerImpl*)itsGame->GetLocalPlayer()->itsManager);
+    return TESTFUNC(funcCode, localManager->keysDown);
 }
 
 void FrameFunctionToPacket(FrameFunction *ff, PacketInfo *outPacket, short slot);
@@ -566,17 +534,19 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
             quickTick = TickCount();
 
             if (quickTick - askAgainTime >= 0) {
-                if (quickTick - firstTime > 120 && TestHeldKey(kfuAbortGame)) {
-                    itsGame->statusRequest = kAbortStatus;
-                    break;
+                if (quickTick - firstTime > 120) {
+                    if (TestKeyPressed(kfuAbortGame)) {
+                        itsGame->statusRequest = kAbortStatus;
+                        break;
+                    }
                 }
 
-                if (theNetManager->IAmAlive()) {
-                    askAgainTime = quickTick + 62; //	~1 second
+                if (theNetManager->IAmAlive() || askCount > 0) {
+                    askAgainTime = quickTick + MSEC_TO_TICK_COUNT(2000); //	2 seconds = 120 ticks
                 } else {
-                    // spectators can't afford to wait as long because players might still be going and
-                    // the FUNCTIONBUFFERS might overflow, so ask for resend every 3.0LT ≈ (12 ticks = 200ms)
-                    askAgainTime = quickTick + (3.0 * (CLASSICFRAMETIME / MSEC_PER_TICK_COUNT) + 0.5);
+                    // spectators may not be able to wait as long because players could still be going and
+                    // the FUNCTIONBUFFERS might overflow, so ask for first resend within 2.0LT ≈ (8 ticks = 133ms)
+                    askAgainTime = quickTick + MSEC_TO_TICK_COUNT(2.0*CLASSICFRAMETIME) + 0.5;
                 }
 
                 SendResendRequest(askCount++);
@@ -589,22 +559,14 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
                     // gApplication->SetCommandParams(STATUSSTRINGSLISTID, kmWaitingPlayers, true, 0);
                     // gApplication->BroadcastCommand(kBusyStartCmd);
                 }
-                else if (askCount > 3) {
-                    if (theNetManager->IAmAlive()) {
-                        // pause the game so the server can boot the unresponsive player
-                        itsGame->statusRequest = kPauseStatus;
-                        itsGame->pausePlayer = theNetManager->itsCommManager->myId;
-                        std::string msg = "Pausing game because of unresponsive player: " + GetPlayerName();
-                        if (theNetManager->itsCommManager->myId == 0) {
-                            msg += "\nRecommend running command: /kick " + std::to_string(slot + 1);
-                        }
-                        itsGame->itsApp->AddMessageLine(msg, MsgAlignment::Center, MsgCategory::Error);
-                    } else {
-                        itsGame->statusRequest = kAbortStatus;
-                        itsGame->itsApp->AddMessageLine(
-                            "Exiting game because of unrereceived data from: " + GetPlayerName(),
-                            MsgAlignment::Center, MsgCategory::Error);
-                    }
+
+                // spectator gives up after newer frames appear in the frameFuncs buffer
+                // which indicates the buffer has wrapped around and this frame won't be arriving
+                if (!theNetManager->IAmAlive() && frameFuncs[i].validFrame > itsGame->frameNumber) {
+                    itsGame->statusRequest = kAbortStatus;
+                    itsGame->itsApp->AddMessageLine(
+                        "Exiting game - missing data from: " + GetPlayerName(),
+                        MsgAlignment::Center, MsgCategory::Error);
                     break;
                 }
             }

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -554,6 +554,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
                 if (askCount == 2) {
                     SDL_Log("Waiting for '%s' to resend frame #%ld\n", GetPlayerName().c_str(), itsGame->frameNumber);
                     itsGame->itsApp->ParamLine(kmWaitingForPlayer, MsgAlignment::Center, playerName, NULL);
+                    itsGame->itsApp->RenderContents();  // force render now so message shows up
                     // TODO: waiting for player dialog
                     // InitCursor();
                     // gApplication->SetCommandParams(STATUSSTRINGSLISTID, kmWaitingPlayers, true, 0);

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -504,6 +504,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
     // SDL_Log("CPlayerManagerImpl::GetFunctions, %ld, %hd\n", itsGame->frameNumber, slot);
     uint32_t ffi = (itsGame->frameNumber);
     short i = (FUNCTIONBUFFERS - 1) & ffi;
+    static int WAITING_MESSAGE_COUNT = 2;
 
     // if player is finished don't wait for their frames to sync up
     if (frameFuncs[i].validFrame != itsGame->frameNumber && itsPlayer->lives > 0) {
@@ -544,9 +545,9 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
 
                 SendResendRequest(askCount++);
 
-                if (askCount == 2) {
+                if (askCount == WAITING_MESSAGE_COUNT) {
                     SDL_Log("Waiting for '%s' to resend frame #%ld\n", GetPlayerName().c_str(), itsGame->frameNumber);
-                    itsGame->itsApp->ParamLine(kmWaitingForPlayer, MsgAlignment::Center, playerName, NULL);
+                    itsGame->itsApp->ParamLine(kmWaitingForPlayer, MsgAlignment::Center, playerName);
                     itsGame->itsApp->RenderContents();  // force render now so message shows up
                     // TODO: waiting for player dialog
                     // InitCursor();
@@ -573,8 +574,9 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
 
         } while (frameFuncs[i].validFrame != itsGame->frameNumber);
 
-        if (askCount > 1) {
+        if (askCount >= WAITING_MESSAGE_COUNT) {
             gApplication->BroadcastCommand(kBusyEndCmd);
+            itsGame->itsApp->AddMessageLine("...resuming game", MsgAlignment::Center);
             // HideCursor();
         }
 

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -211,7 +211,7 @@ public:
 
     virtual void Dispose();
 
-    virtual Boolean TestHeldKey(short funcCode);
+    virtual Boolean TestKeyPressed(short funcCode);
 
     // virtual	void			FlushMessageText(Boolean forceAll);
     virtual void RosterMessageText(short len, const char *c);

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -128,6 +128,7 @@ public:
     virtual bool DoCommand(int theCommand) {return false;}
     virtual void MessageLine(short index, MsgAlignment align) {}
     virtual void AddMessageLine(std::string lines, MsgAlignment align = MsgAlignment::Left, MsgCategory category = MsgCategory::System) {}
+    virtual void RenderContents() {};
     virtual void DrawUserInfoPart(short i, short partList) {}
     virtual void ParamLine(short index, MsgAlignment align, StringPtr param1, StringPtr param2) {}
     virtual void StartFrame(long frameNum) {}


### PR DESCRIPTION
Instead of pausing automatically, which is a big change, I fixed the ability to abort from a hung game by pressing the kfuAbortGame key.  So it's up to the user to abort out of a hung game.

Spectators will automatically abort out of a game in which they receive so many frames that it wraps around the functions buffer.