### PR TITLE
Packet stats

### DIFF
--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -121,7 +121,7 @@ CAvaraAppImpl::CAvaraAppImpl() : CApplication("Avara") {
     );
 
     // load up a random decent starting level
-    itsTui->ExecuteMatchingCommand("/rand -normal -tre avaraline emo", CPlayerManagerImpl::LocalPlayer());
+    itsTui->ExecuteMatchingCommand("/rand -normal -tre avaraline emo not-aa ex", CPlayerManagerImpl::LocalPlayer());
 }
 
 CAvaraAppImpl::~CAvaraAppImpl() {

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -869,9 +869,12 @@ bool CAvaraGame::GameTick() {
 
     if (startTime > nextPingTime) {
         // send pings periodically to maintain connection & improve estimate for LT
-        itsNet->SendPingCommand(statusRequest != kPlayingStatus ? 8 : 2);
-        static long PING_INTERVAL_MSEC = 2000;
-        nextPingTime = startTime + PING_INTERVAL_MSEC;
+        itsNet->SendPingCommand(2);
+        long pingInterval = 500; //msec
+        if (statusRequest == kPlayingStatus) {
+            pingInterval = 2000;
+        }
+        nextPingTime = startTime + pingInterval;
     }
 
     // Not playing? Nothing to do!

--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -72,3 +72,18 @@ long CApplication::Number(const std::string name, const long defaultValue) {
     }
     return defaultValue;
 }
+
+// for now it's just a list of keys that you can turn on/off
+bool CApplication::ToggleDebug(const std::string& key) {
+    bool hasKey = Debug(key);
+    if (hasKey) {
+        debugKeys.erase(key);
+    } else {
+        debugKeys.insert(key);
+    }
+    return !hasKey;
+}
+
+bool CApplication::Debug(const std::string& key) {
+    return (debugKeys.find(key) != debugKeys.end());
+}

--- a/src/gui/CApplication.h
+++ b/src/gui/CApplication.h
@@ -7,6 +7,7 @@
 #include <nanogui/nanogui.h>
 #include <string>
 #include <vector>
+#include <set>
 
 using json = nlohmann::json;
 
@@ -55,9 +56,14 @@ public:
         PrefChanged(name);
     }
 
+    // debug flags that can be toggled on/off by user
+    bool ToggleDebug(const std::string& key);
+    bool Debug(const std::string& key);
+
 protected:
     static json _prefs;
     std::vector<CWindow *> windowList;
+    std::set<std::string> debugKeys;
 };
 
 #ifdef APPLICATIONMAIN

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -199,7 +199,10 @@ void CRosterWindow::UpdateRoster() {
             std::string theName((char *)thisPlayer->PlayerName() + 1, thisPlayer->PlayerName()[0]);
             if (i != theNet->itsCommManager->myId && theName.length() > 0) {
                 long rtt = theNet->itsCommManager->GetMaxRoundTrip(1 << i);
-                theName += std::string(" (") + std::to_string(rtt) + " ms)";
+                float loss = 100*theNet->itsCommManager->GetMaxMeanReceiveCount(1 << i);
+                std::ostringstream os;
+                os << theName << " (" << rtt << "/" << std::setprecision(loss < 2 ? 1 : 0) << std::fixed << loss << "%)";
+                theName = os.str();
                 maxRtt = std::max(maxRtt, rtt);
             }
             std::string theStatus = GetStringStatus(thisPlayer);

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -201,7 +201,11 @@ void CRosterWindow::UpdateRoster() {
                 long rtt = theNet->itsCommManager->GetMaxRoundTrip(1 << i);
                 float loss = 100*theNet->itsCommManager->GetMaxMeanReceiveCount(1 << i);
                 std::ostringstream os;
-                os << theName << " (" << rtt << "/" << std::setprecision(loss < 2 ? 1 : 0) << std::fixed << loss << "%)";
+                os << theName << " (" << rtt << "ms";
+                if (gApplication->Debug("loss")) {
+                    os << "/" << std::setprecision(loss < 2 ? 1 : 0) << std::fixed << loss << "%";
+                }
+                os << ")";
                 theName = os.str();
                 maxRtt = std::max(maxRtt, rtt);
             }

--- a/src/net/CCommManager.cpp
+++ b/src/net/CCommManager.cpp
@@ -402,3 +402,9 @@ void CCommManager::Reconfigure() {}
 long CCommManager::GetMaxRoundTrip(short distribution, short *slowPlayerId) {
     return 0; //	Local net.
 }
+float CCommManager::GetMaxMeanSendCount(short distribution) {
+    return 0; //	Local net.
+}
+float CCommManager::GetMaxMeanReceiveCount(short distribution) {
+    return 0; //	Local net.
+}

--- a/src/net/CCommManager.h
+++ b/src/net/CCommManager.h
@@ -95,4 +95,6 @@ public:
     virtual void Reconfigure();
 
     virtual long GetMaxRoundTrip(short distribution, short *slowPlayerId = nullptr);
+    virtual float GetMaxMeanSendCount(short distribution);
+    virtual float GetMaxMeanReceiveCount(short distribution);
 };

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -148,6 +148,8 @@ public:
     virtual Boolean ReconfigureAvailable();
     virtual void Reconfigure();
     virtual long GetMaxRoundTrip(short distribution, short *slowPlayerId = nullptr);
+    virtual float GetMaxMeanSendCount(short distribution);
+    virtual float GetMaxMeanReceiveCount(short distribution);
 
     virtual void BuildServerTags();
 };

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -12,6 +12,7 @@
 #include "CUDPComm.h"
 #include "System.h"
 #include "CAvaraGame.h"  // gCurrentGame->fpsScale
+#include "CApplication.h"  // gApplication
 
 #include <SDL2/SDL.h>
 
@@ -452,10 +453,12 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, long when) {
                         myId, thePacket->packet.command, roundTrip, meanRoundTripTime, stdevRoundTripTime, retransmitTime, urgentRetransmitTime);
             #endif
 
-            latencyHistogram->push(roundTrip / (2.0*CLASSICFRAMETIME));
-            if (thePacket->serialNumber % (latencyHistogram->size()*2/3) == 0) {  // 1/3 overlap each output
-                latencyHistogram->setTitle("LT histogram for connection #" + std::to_string(myId));
-                std::cerr << *latencyHistogram;
+            if (gApplication->Debug("hist")) {
+                latencyHistogram->push(roundTrip / (2.0*CLASSICFRAMETIME));
+                if (thePacket->serialNumber % (latencyHistogram->size()*2/3) == 0) {  // 1/3 overlap each output
+                    SDL_Log("\n       LT histogram for connection #%d", myId);
+                    std::cerr << *latencyHistogram;
+                }
             }
         }
 

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -12,6 +12,7 @@
 #include "CDirectObject.h"
 #include "CommDefs.h"
 #include "RolloverCounter.h"
+#include "SlidingHistogram.h"
 
 #define kSerialNumberStepSize 2
 #define kNumReceivedOffsets 128
@@ -84,6 +85,8 @@ public:
     float varRoundTripTime;
     float meanSendCount;
     float meanReceiveCount;
+    SlidingHistogram<float>* latencyHistogram;
+
     long retransmitTime;
     long urgentRetransmitTime;
 

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -28,7 +28,8 @@ typedef struct {
     // int32_t lastSendTime;
     int32_t nextSendTime;
     SerialNumber serialNumber;
-    int16_t sendCount;
+    uint8_t sendCount;
+    uint8_t _spare; // not sure if needed, just to be safe
 
 } UDPPacketInfo;
 #pragma pack()
@@ -81,6 +82,8 @@ public:
 
     float meanRoundTripTime;
     float varRoundTripTime;
+    float meanSendCount;
+    float meanReceiveCount;
     long retransmitTime;
     long urgentRetransmitTime;
 
@@ -117,7 +120,8 @@ public:
     virtual void RunValidate();
 
     virtual void ValidatePacket(UDPPacketInfo *thePacket, long when);
-    virtual char *ValidateReceivedPackets(char *validateInfo, long curTime);
+    virtual void ValidateReceivedPacket(UDPPacketInfo *thePacket);
+    virtual char *ValidatePackets(char *validateInfo, long curTime);
     virtual void ReceivedPacket(UDPPacketInfo *thePacket);
 
     virtual void FlushQueues();

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -71,6 +71,10 @@ CommandManager::CommandManager(CAvaraAppImpl *theApp) : itsApp(theApp) {
         return true;
     });
     TextCommand::Register(cmd);
+
+    cmd = new TextCommand("/dbg flag     <- toggles named debugging flag",
+                          METHOD_TO_LAMBDA(CommandManager::SetDebugFlag));
+    TextCommand::Register(cmd);
 }
 
 
@@ -351,5 +355,18 @@ bool CommandManager::GetSetPreference(VectorOfArgs vargs) {
         itsApp->AddMessageLine(pref + " changed from " + currentValue + " to " + value);
         itsApp->CApplication::PrefChanged(pref);
     }
+    return true;
+}
+
+bool CommandManager::SetDebugFlag(VectorOfArgs vargs) {
+    if (vargs.size() == 0) {
+        itsApp->AddMessageLine("Need to specify a key");
+        return false;
+    }
+    auto key = vargs[0];
+    bool dbg = itsApp->ToggleDebug(key);
+    std::ostringstream os;
+    os << "Debugging is now " << (dbg ? "ON" : "OFF") << " for " << key;
+    itsApp->AddMessageLine(os.str());
     return true;
 }

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -15,7 +15,7 @@ CommandManager::CommandManager(CAvaraAppImpl *theApp) : itsApp(theApp) {
     TextCommand* cmd;
     cmd = new TextCommand("/help            <- show list of all commands\n"
                           "/help /xyz       <- show help for command /xyz",
-                          METHOD_TO_LAMBDA(CommandManager::CommandHelp));
+                          METHOD_TO_LAMBDA_VARGS(CommandHelp));
     TextCommand::Register(cmd);
 
     cmd = new TextCommand("/beep            <- ring the bell",
@@ -35,30 +35,30 @@ CommandManager::CommandManager(CAvaraAppImpl *theApp) : itsApp(theApp) {
 
     cmd = new TextCommand("/pref name       <- display value of named preference\n"
                           "/pref name value <- set value of named preference",
-                          METHOD_TO_LAMBDA(CommandManager::GetSetPreference));
+                          METHOD_TO_LAMBDA_VARGS(GetSetPreference));
     TextCommand::Register(cmd);
 
     cmd = new TextCommand("/gg              <- good game!\n"
                           "/gg new phrase   <- change the /gg phrase",
-                          METHOD_TO_LAMBDA(CommandManager::GoodGame));
+                          METHOD_TO_LAMBDA_VARGS(GoodGame));
     TextCommand::Register(cmd);
 
     cmd = new TextCommand("/kick slot       <- kick player in given slot. slots start at 1",
-                          METHOD_TO_LAMBDA(CommandManager::KickPlayer));
+                          METHOD_TO_LAMBDA_VARGS(KickPlayer));
     TextCommand::Register(cmd);
 
     cmd = new TextCommand("/away            <- toggle my presence\n"
                           "/away slot       <- toggle presence of given slot, starting from 1",
-                          METHOD_TO_LAMBDA(CommandManager::ToggleAwayState));
+                          METHOD_TO_LAMBDA_VARGS(ToggleAwayState));
     TextCommand::Register(cmd);
 
     cmd = new TextCommand("/load chok       <- load level with name containing the letters 'chok'",
-                          METHOD_TO_LAMBDA(CommandManager::LoadNamedLevel));
+                          METHOD_TO_LAMBDA_VARGS(LoadNamedLevel));
     TextCommand::Register(cmd);
 
     cmd = new TextCommand("/random       <- load random level from all available levels\n"
                           "/random aa ex <- load random level from any set name containing either 'aa' or 'ex'",
-                          METHOD_TO_LAMBDA(CommandManager::LoadRandomLevel));
+                          METHOD_TO_LAMBDA_VARGS(LoadRandomLevel));
     TextCommand::Register(cmd);
 
     cmd = new TextCommand("/vvvvv        <- clear line then output ready checkmarks \xE2\x88\x9A",
@@ -73,7 +73,7 @@ CommandManager::CommandManager(CAvaraAppImpl *theApp) : itsApp(theApp) {
     TextCommand::Register(cmd);
 
     cmd = new TextCommand("/dbg flag     <- toggles named debugging flag",
-                          METHOD_TO_LAMBDA(CommandManager::SetDebugFlag));
+                          METHOD_TO_LAMBDA_VARGS(SetDebugFlag));
     TextCommand::Register(cmd);
 }
 

--- a/src/tui/CommandManager.h
+++ b/src/tui/CommandManager.h
@@ -41,4 +41,7 @@ public:
     // LevelCommands
     bool LoadNamedLevel(VectorOfArgs);
     bool LoadRandomLevel(VectorOfArgs);
+
+    // Coding helpers
+    bool SetDebugFlag(VectorOfArgs);
 };

--- a/src/tui/TextCommand.h
+++ b/src/tui/TextCommand.h
@@ -8,7 +8,7 @@
 
 typedef std::vector<std::string> VectorOfArgs;
 typedef std::function<bool(VectorOfArgs)> TextCommandCallbackArgs;
-typedef std::function<bool(std::string)>  TextCommandCallbackCmd;
+typedef std::function<bool(const std::string)>  TextCommandCallbackCmd;
 
 // why doesn't C++ have stuff like this?
 #define join_with(vargs, sep) \
@@ -17,7 +17,8 @@ typedef std::function<bool(std::string)>  TextCommandCallbackCmd;
 
 // This crazy macro allows you to use an instance method as a lambda/callback
 // For example: METHOD_TO_LAMBDA(MyClass::SomeMethod) allows SomeMethod to be used as a callback
-#define METHOD_TO_LAMBDA(method) std::bind(&method, this, std::placeholders::_1)
+#define METHOD_TO_LAMBDA_VARGS(method) [&](VectorOfArgs args) { return method(args); }
+#define METHOD_TO_LAMBDA_CMD(method)   [&](const std::string) { return method(cmd); }
 
 class TextCommand {
 private:

--- a/src/util/SlidingHistogram.h
+++ b/src/util/SlidingHistogram.h
@@ -78,7 +78,10 @@ public:
         float markers[] = {0.5, 0.99, 0.993, 0.995};  // smallest to biggest
         int nextMarker = 0;
         int prec = -log2(sh.stepSize);  // approx how many digits to show
-        os << std::setfill(' ') << std::setw(prec+5) << " " << sh.displayTitle << std::endl;
+
+        if (sh.displayTitle.size() > 0) {
+            os << std::setfill(' ') << std::setw(prec+5) << " " << sh.displayTitle << std::endl;
+        }
 
         for (int i = 0; i < sh.cellCounts.size(); i++) {
             sum += sh.cellCounts[i];

--- a/src/util/SlidingHistogram.h
+++ b/src/util/SlidingHistogram.h
@@ -1,0 +1,110 @@
+/*
+    Copyright ©2023, Tom Anderson (@tra on github)
+    All rights reserved.
+
+    File: SlidingHistogram.h
+*/
+
+#include <deque>
+#include <vector>
+#include <iostream>
+#include <iomanip>
+#include <math.h>
+
+template<class T>
+class SlidingHistogram {
+private:
+    // histogram cells
+    T minValue;                         // minimum value of the histogram
+    T maxValue;                         // max value allowed
+    T stepSize;                         // incremental value between histogram cells
+    std::vector<std::size_t> cellCounts;// number of data points in each histogram cell
+    // histogram data
+    std::deque<T> dataFifo;             // where data values are stored
+    std::size_t windowSize;             // the size the dataFifo will grow to when full
+
+    int displayWidth = 100;
+    std::string displayTitle = "";
+
+    std::size_t cellIndex(T value) {
+        std::size_t idx;
+        if (value < minValue) {
+            idx = 0;
+        } else if (value > maxValue) {
+            idx = cellCounts.size() - 1;
+        } else {
+            idx = (value - minValue) / stepSize;
+        }
+        return idx;
+    }
+
+public:
+    // Example: SlidingHistogram<double>(500, 0.0, 3.0, 0.5) keeps 500 data points with cellCounts from 0.0-3.0 in 0.5 increments
+    SlidingHistogram(std::size_t dataSize, T minRange, T maxRange, T rangeStep) {
+        windowSize = dataSize;
+        minValue = minRange;
+        maxValue = maxRange;
+        stepSize = rangeStep;
+        std::size_t numCells = (maxRange - minRange) / rangeStep;
+        cellCounts.resize(numCells, 0);
+    }
+
+    void push(T value) {
+        if (dataFifo.size() == windowSize) {
+            // pop value off the front of data queue
+            T front = dataFifo.front();
+            dataFifo.pop_front();
+            // decrement count of the matching cell
+            cellCounts[cellIndex(front)]--;
+        }
+        // push data to the end of data queue
+        dataFifo.push_back(value);
+        // increment value of matching cell
+        cellCounts[cellIndex(value)]++;
+    }
+
+    void setTitle(const std::string& title) {
+        displayTitle = title;
+    }
+
+    std::size_t size() {
+        return windowSize;
+    }
+
+    // output a ascii graph using: std::cout << mySlidingHistogram;
+    friend std::ostream& operator<<(std::ostream& os, const SlidingHistogram<T>& sh)
+    {
+        int sum = 0;
+        float markers[] = {0.5, 0.99, 0.993, 0.995};  // smallest to biggest
+        int nextMarker = 0;
+        int prec = -log2(sh.stepSize);  // approx how many digits to show
+        os << std::setfill(' ') << std::setw(prec+5) << " " << sh.displayTitle << std::endl;
+
+        for (int i = 0; i < sh.cellCounts.size(); i++) {
+            sum += sh.cellCounts[i];
+            // label
+            os << std::setprecision(prec) << std::fixed << std::setw(prec+3) << sh.minValue + (i+1)*sh.stepSize << ": ";
+            // histogram bar
+            int ticks = sh.displayWidth * sh.cellCounts[i] / sh.dataFifo.size();
+            for (int j = 0; j < ticks; j++) {
+                os << '+';
+            }
+            if (sh.displayWidth * sh.cellCounts[i] % sh.dataFifo.size()) {
+                // indicate a non-zero amount leftover
+                os << "-  ";
+            }
+            // show where marker percentages are
+            while (nextMarker < std::size(markers) && sum >= sh.dataFifo.size() * markers[nextMarker]) {
+                os.unsetf(std::ios::fixed);
+                os << " (" << std::setprecision(3) << (markers[nextMarker] * 100) << "%)";
+                nextMarker++;
+            }
+            os << std::endl;
+            if (sum == sh.dataFifo.size() && sh.cellCounts[i] == 0) {
+                // if all remaining lines will be empty, don't draw them
+                break;
+            }
+        }
+        return os;
+    }
+};


### PR DESCRIPTION
There are 2 main features of this branch, both turned on/off by a new "/dbg" command.

* `/dbg loss` turns on/off display of packet loss percentage in the roster window.  This was made possible by adding a single byte, `sendCount` to each packet which indicates how many times this packet has been re-sent. Normally the receiving client would expect to receive the packet with `sendCount == 0` but if it is greater than zero, that would indicate that either the first packet was lost or the packets were received out-of-order.  So technically the "packet loss" percent is either due to a lost packet or packets received out-of-order.
* `/dbg hist` turns on/off LT sliding histograms in your console output.  The histogram about 16 seconds in duration at the 16ms frame rate, or 1000 samples of data.  There will be a histogram for each connection so it could be quite a bit of output for 6-8 players.

Also, the `/dbg` command is something that I think can be useful for toggling feature and/or experiments on and off easily so I hope others will find it useful too.  All you have to do is add `if (gApplication->Debug("foo")) { /* experimental code */ }` to your code then typing `/dbg foo` will toggle that code on/off.