### PR TITLE
Identify fragging player on fragmentation

### DIFF
--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -949,7 +949,7 @@ void CAbstractPlayer::FrameAction() {
         }
 
         // if a frag frame is specified with /dbg, force a frag on that frame by messing with FRandSeed
-        int fragFrame = gApplication->DebugValue("frag");
+        int fragFrame = gApplication != nullptr ? gApplication->DebugValue("frag") : -1;
         if (fragFrame > 0 && itsGame->frameNumber == fragFrame) {
             extern Fixed FRandSeed; // to intentionally cause frags below
             FRandSeed += 1;

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -947,6 +947,13 @@ void CAbstractPlayer::FrameAction() {
         if (doIncarnateSound) {
             IncarnateSound();
         }
+
+        // if a frag frame is specified with /dbg, force a frag on that frame by messing with FRandSeed
+        int fragFrame = gApplication->DebugValue("frag");
+        if (fragFrame > 0 && itsGame->frameNumber == fragFrame) {
+            extern Fixed FRandSeed; // to intentionally cause frags below
+            FRandSeed += 1;
+        }
     }
 }
 

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -37,6 +37,8 @@
 #include "Parser.h"
 #include "Preferences.h"
 
+#include "Debug.h"
+
 #define MOUSESHOOTDELAY 8
 // replaced by kFOV preference
 //#define MAXFOV FIX(60)
@@ -949,7 +951,7 @@ void CAbstractPlayer::FrameAction() {
         }
 
         // if a frag frame is specified with /dbg, force a frag on that frame by messing with FRandSeed
-        int fragFrame = gApplication != nullptr ? gApplication->DebugValue("frag") : -1;
+        int fragFrame = Debug::GetValue("frag");
         if (fragFrame > 0 && itsGame->frameNumber == fragFrame) {
             extern Fixed FRandSeed; // to intentionally cause frags below
             FRandSeed += 1;

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -751,7 +751,6 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
             if (fragmentDetected) {
                 itsGame->itsApp->MessageLine(kmFragmentAlert, MsgAlignment::Center);
                 itsGame->itsApp->AddMessageLine(FragmentMapToString(), MsgAlignment::Left, MsgCategory::Error);
-                SDL_Log("FRAGMENTATION, fragmentMap ...\n%s\n", FragmentMapToString().c_str());
             }
 
             if (IsAutoLatencyEnabled() && autoLatencyVoteCount) {

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -750,7 +750,8 @@ void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
 
             if (fragmentDetected) {
                 itsGame->itsApp->MessageLine(kmFragmentAlert, MsgAlignment::Center);
-                fragmentDetected = false;
+                itsGame->itsApp->AddMessageLine(FragmentMapToString(), MsgAlignment::Left, MsgCategory::Error);
+                SDL_Log("FRAGMENTATION, fragmentMap ...\n%s\n", FragmentMapToString().c_str());
             }
 
             if (IsAutoLatencyEnabled() && autoLatencyVoteCount) {
@@ -798,6 +799,63 @@ void CNetManager::ResetLatencyVote() {
     maxRoundTripLatency = 0;
     maxPlayer = nullptr;
     latencyVoteOpen = false;
+    fragmentMap.clear();
+}
+
+void CNetManager::ReceiveLatencyVote(int16_t sender,
+                                     int8_t p1,         // localLatencyVote
+                                     int16_t p2,        // maxRoundLatency
+                                     int32_t p3) {      // FRandSeed
+
+    SDL_Log("CNetManager::ReceiveLatencyVote(%d, %d, %hd, %d)\n", sender, p1, p2, p3);
+    autoLatencyVoteCount++;
+    autoLatencyVote += p1;
+
+    maxRoundTripLatency = std::max(maxRoundTripLatency, p2);
+
+    playerTable[sender]->RandomKey(p3);
+
+    // to be considered for fragmentation, packet must be received in the voting time window
+    if (IsFragmentCheckWindowOpen()) {
+        // keep track of who is which FRandSeed. Normally everyone on the same value, but with frags this identifies who is different
+        if (fragmentMap.find(p3) == fragmentMap.end()) {
+            fragmentMap[p3] = std::vector<int16_t>();
+        }
+        fragmentMap[p3].push_back(sender);
+
+        if (fragmentCheck == 0) {
+            // the first vote received dictates what the fragmentCheck value is, not necessarily the current player
+            fragmentDetected = false;
+            fragmentCheck = p3;
+            // SDL_Log("autoLatencyVoteCount = 1, setting fragmentCheck = %d, in frameNumber %ld", fragmentCheck, itsGame->frameNumber);
+        } else {
+            // any votes after the first must have a matching p3 value
+            if (fragmentCheck != p3) {
+                SDL_Log("FRAGMENTATION %d != %d in frameNumber %ld", fragmentCheck, p3, itsGame->frameNumber);
+                fragmentDetected = true;
+            // } else {
+            //     SDL_Log("No frags detected so far %d == %d in frameNumber %ld", fragmentCheck, p3, itsGame->frameNumber);
+            }
+        }
+    } else {
+        SDL_Log("LatencyVote with checksum=%d received outside of the normal voting window not used for fragment check. fn=%ld",
+                p3, itsGame->frameNumber);
+    }
+}
+
+std::string CNetManager::FragmentMapToString() {
+    std::ostringstream os;
+    bool firstFrag = true;
+    for (auto const& pair : fragmentMap) {
+        if (!firstFrag) { os << std::endl; }
+        os << std::hex << std::setfill('0') << std::setw(sizeof(int32_t)*2) << pair.first << ": [";
+        for (auto const& slot : pair.second) {
+            os << " " << playerTable[slot]->GetPlayerName();
+        }
+        os << " ]";
+        firstFrag = false;
+    }
+    return os.str();
 }
 
 void CNetManager::ViewControl() {

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -17,6 +17,7 @@
 
 #include <SDL2/SDL.h>
 #include <string>
+#include <map>
 #include <vector>
 
 #define NULLNETPACKETS (32 + MINIMUMBUFFERRESERVE)
@@ -107,6 +108,7 @@ public:
     short addOneLatency;
     CPlayerManager *maxPlayer;
     Boolean latencyVoteOpen;
+    std::map<int32_t, std::vector<int16_t>> fragmentMap;  // maps FRandSeed to list of players having that seed
 
     long lastLoginRefusal;
 
@@ -179,6 +181,9 @@ public:
     virtual bool IsAutoLatencyEnabled();
     virtual bool IsFragmentCheckWindowOpen();
     virtual void ResetLatencyVote();
+    virtual void ReceiveLatencyVote(int16_t sender, int8_t p1, int16_t p2, int32_t p3);
+    virtual std::string FragmentMapToString();
+
     virtual void ViewControl();
     virtual void AttachPlayers(CAbstractPlayer *thePlayer);
 

--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -72,29 +72,3 @@ long CApplication::Number(const std::string name, const long defaultValue) {
     }
     return defaultValue;
 }
-
-// for now it's just a list of keys that you can turn on/off
-bool CApplication::ToggleDebug(const std::string& key) {
-    bool hasKey = Debug(key);
-    if (hasKey) {
-        debugMap.erase(key);
-    } else {
-        debugMap[key] = -1;  // value doesn't matter for on/off debug
-    }
-    return !hasKey;
-}
-
-bool CApplication::Debug(const std::string& key) {
-    return (debugMap.find(key) != debugMap.end());
-}
-
-int CApplication::SetDebugValue(const std::string& key, int value) {
-    return debugMap[key] = value;
-}
-
-int CApplication::DebugValue(const std::string& key) {
-    if (debugMap.find(key) != debugMap.end()) {
-        return debugMap[key];
-    }
-    return -1;
-}

--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -77,13 +77,24 @@ long CApplication::Number(const std::string name, const long defaultValue) {
 bool CApplication::ToggleDebug(const std::string& key) {
     bool hasKey = Debug(key);
     if (hasKey) {
-        debugKeys.erase(key);
+        debugMap.erase(key);
     } else {
-        debugKeys.insert(key);
+        debugMap[key] = -1;  // value doesn't matter for on/off debug
     }
     return !hasKey;
 }
 
 bool CApplication::Debug(const std::string& key) {
-    return (debugKeys.find(key) != debugKeys.end());
+    return (debugMap.find(key) != debugMap.end());
+}
+
+int CApplication::SetDebugValue(const std::string& key, int value) {
+    return debugMap[key] = value;
+}
+
+int CApplication::DebugValue(const std::string& key) {
+    if (debugMap.find(key) != debugMap.end()) {
+        return debugMap[key];
+    }
+    return -1;
 }

--- a/src/gui/CApplication.h
+++ b/src/gui/CApplication.h
@@ -7,7 +7,6 @@
 #include <nanogui/nanogui.h>
 #include <string>
 #include <vector>
-#include <map>
 
 using json = nlohmann::json;
 
@@ -56,16 +55,9 @@ public:
         PrefChanged(name);
     }
 
-    // debug flags that can be toggled on/off by user
-    bool ToggleDebug(const std::string& key);
-    bool Debug(const std::string& key);
-    int SetDebugValue(const std::string& key, int value);
-    int DebugValue(const std::string& key);
-
 protected:
     static json _prefs;
     std::vector<CWindow *> windowList;
-    std::map<std::string, int> debugMap;
 };
 
 #ifdef APPLICATIONMAIN

--- a/src/gui/CApplication.h
+++ b/src/gui/CApplication.h
@@ -7,7 +7,7 @@
 #include <nanogui/nanogui.h>
 #include <string>
 #include <vector>
-#include <set>
+#include <map>
 
 using json = nlohmann::json;
 
@@ -59,11 +59,13 @@ public:
     // debug flags that can be toggled on/off by user
     bool ToggleDebug(const std::string& key);
     bool Debug(const std::string& key);
+    int SetDebugValue(const std::string& key, int value);
+    int DebugValue(const std::string& key);
 
 protected:
     static json _prefs;
     std::vector<CWindow *> windowList;
-    std::set<std::string> debugKeys;
+    std::map<std::string, int> debugMap;
 };
 
 #ifdef APPLICATIONMAIN

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -9,6 +9,7 @@
 #include "CScoreKeeper.h"
 #include "Preferences.h"
 #include "RGBAColor.h"
+#include "Debug.h"
 
 #include <nanogui/colorcombobox.h>
 #include <nanogui/layout.h>
@@ -202,7 +203,7 @@ void CRosterWindow::UpdateRoster() {
                 float loss = 100*theNet->itsCommManager->GetMaxMeanReceiveCount(1 << i);
                 std::ostringstream os;
                 os << theName << " (" << rtt << "ms";
-                if (gApplication->Debug("loss")) {
+                if (Debug::IsEnabled("loss")) {
                     os << "/" << std::setprecision(loss < 2 ? 1 : 0) << std::fixed << loss << "%";
                 }
                 os << ")";

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -159,38 +159,9 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             theNet->HandleDisconnect(itsManager->myId, kpKickClient);
             break;
 
-        case kpLatencyVote: {
-            int32_t p3 = thePacket->p3;
-
-            theNet->autoLatencyVoteCount++;
-            theNet->autoLatencyVote += thePacket->p1;
-
-            if (thePacket->p2 > theNet->maxRoundTripLatency)
-                theNet->maxRoundTripLatency = thePacket->p2;
-
-            theNet->playerTable[thePacket->sender]->RandomKey(p3);
-
-            // to be considered for fragmentation, packet must be received in the voting time window
-            if (theNet->IsFragmentCheckWindowOpen()) {
-                if (theNet->fragmentCheck == 0) {
-                    // the first vote received dictates what the fragmentCheck value is, not necessarily the current player
-                    theNet->fragmentDetected = false;
-                    theNet->fragmentCheck = p3;
-                    // SDL_Log("autoLatencyVoteCount = 1, setting fragmentCheck = %d, in frameNumber %ld", theNet->fragmentCheck, theGame->frameNumber);
-                } else {
-                    // any votes after the first must have a matching p3 value
-                    if (theNet->fragmentCheck != p3) {
-                        SDL_Log("FRAGMENTATION %d != %d in frameNumber %ld", theNet->fragmentCheck, p3, theGame->frameNumber);
-                        theNet->fragmentDetected = true;
-                    // } else {
-                    //     SDL_Log("No frags detected so far %d == %d in frameNumber %ld", theNet->fragmentCheck, p3, theGame->frameNumber);
-                    }
-                }
-            } else {
-                SDL_Log("LatencyVote with checksum=%d received outside of the normal voting window not used for fragment check. fn=%ld",
-                        p3, theGame->frameNumber);
-            }
-        } break;
+        case kpLatencyVote:
+            theNet->ReceiveLatencyVote(thePacket->sender, thePacket->p1, thePacket->p2, thePacket->p3);
+            break;
 
         case kpResultsReport:
             theNet->ResultsReport(thePacket->dataBuffer);

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -13,6 +13,7 @@
 #include "System.h"
 #include "CAvaraGame.h"  // gCurrentGame->fpsScale
 #include "CApplication.h"  // gApplication
+#include "Debug.h"
 
 #include <SDL2/SDL.h>
 
@@ -453,7 +454,7 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, long when) {
                         myId, thePacket->packet.command, roundTrip, meanRoundTripTime, stdevRoundTripTime, retransmitTime, urgentRetransmitTime);
             #endif
 
-            if (gApplication->Debug("hist")) {
+            if (Debug::IsEnabled("hist")) {
                 latencyHistogram->push(roundTrip / (2.0*CLASSICFRAMETIME));
                 if (thePacket->serialNumber % (latencyHistogram->size()*2/3) == 0) {  // 1/3 overlap each output
                     SDL_Log("\n       LT histogram for connection #%d", myId);

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -72,7 +72,8 @@ CommandManager::CommandManager(CAvaraAppImpl *theApp) : itsApp(theApp) {
     });
     TextCommand::Register(cmd);
 
-    cmd = new TextCommand("/dbg flag     <- toggles named debugging flag",
+    cmd = new TextCommand("/dbg flag     <- toggles named debugging flag on/off\n"
+                          "/dbg flag val <- sets debug flag to integer value",
                           METHOD_TO_LAMBDA_VARGS(SetDebugFlag));
     TextCommand::Register(cmd);
 }
@@ -364,9 +365,14 @@ bool CommandManager::SetDebugFlag(VectorOfArgs vargs) {
         return false;
     }
     auto key = vargs[0];
-    bool dbg = itsApp->ToggleDebug(key);
     std::ostringstream os;
-    os << "Debugging is now " << (dbg ? "ON" : "OFF") << " for " << key;
+    if (vargs.size() == 1) {
+        bool dbg = itsApp->ToggleDebug(key);
+        os << "Debugging flag " << key << " is " << (dbg ? "ON" : "OFF");
+    } else {
+        int val = itsApp->SetDebugValue(key, std::stoi(vargs[1]));
+        os << "Debugging flag " << key << " = " << val;
+    }
     itsApp->AddMessageLine(os.str());
     return true;
 }

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -7,6 +7,7 @@
 
 #include "CommDefs.h"       // kdEveryone
 #include "Resource.h"       // LevelDirNameListing
+#include "Debug.h"          // Debug::methods
 #include <random>           // std::random_device
 
 CommandManager::CommandManager(CAvaraAppImpl *theApp) : itsApp(theApp) {
@@ -367,10 +368,10 @@ bool CommandManager::SetDebugFlag(VectorOfArgs vargs) {
     auto key = vargs[0];
     std::ostringstream os;
     if (vargs.size() == 1) {
-        bool dbg = itsApp->ToggleDebug(key);
+        bool dbg = Debug::Toggle(key);
         os << "Debugging flag " << key << " is " << (dbg ? "ON" : "OFF");
     } else {
-        int val = itsApp->SetDebugValue(key, std::stoi(vargs[1]));
+        int val = Debug::SetValue(key, std::stoi(vargs[1]));
         os << "Debugging flag " << key << " = " << val;
     }
     itsApp->AddMessageLine(os.str());

--- a/src/util/Debug.cpp
+++ b/src/util/Debug.cpp
@@ -1,0 +1,29 @@
+#include "Debug.h"
+
+std::map<std::string, int> Debug::debugMap;
+
+// toggle a flag on/off
+bool Debug::Toggle(const std::string& key) {
+    bool hasKey = IsEnabled(key);
+    if (hasKey) {
+        debugMap.erase(key);
+    } else {
+        debugMap[key] = -1;  // value doesn't matter for on/off debug
+    }
+    return !hasKey;
+}
+
+bool Debug::IsEnabled(const std::string& key) {
+    return (debugMap.find(key) != debugMap.end());
+}
+
+int Debug::SetValue(const std::string& key, int value) {
+    return debugMap[key] = value;
+}
+
+int Debug::GetValue(const std::string& key) {
+    if (debugMap.find(key) != debugMap.end()) {
+        return debugMap[key];
+    }
+    return -1;
+}

--- a/src/util/Debug.h
+++ b/src/util/Debug.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <map>
+
+class Debug {
+private:
+    static std::map<std::string, int> debugMap;
+
+public:
+    // debug flags that can be toggled on/off by user
+    static bool Toggle(const std::string& key);
+    static bool IsEnabled(const std::string& key);
+    // set/get a debug flag value
+    static int SetValue(const std::string& key, int value);
+    static int GetValue(const std::string& key);
+};


### PR DESCRIPTION
Display the FRandSeed values for each player grouped by the seed value.  Hopefully this will help to narrow down which platforms and/or players are causing problems.

Also added `/dbg flag value` option to set a debugging flag to a particular value.  For this commit, it was used to set `/dbg frag 1000` if you want to force a frag on frame #1000 for testing purposes.