### PR TITLE
FrameNumber with a sprinkling of FrameTime

### DIFF
--- a/src/compat/Types.h
+++ b/src/compat/Types.h
@@ -27,6 +27,9 @@ typedef uint8_t Str255[256];
 typedef uint8_t Byte;
 typedef int8_t SignedByte;
 
+typedef int32_t FrameNumber;
+typedef int32_t FrameTime;   // 64,32,16(default),8
+
 typedef uint32_t ip_addr;
 typedef uint16_t port_num;
 

--- a/src/game/AvaraScoreInterface.h
+++ b/src/game/AvaraScoreInterface.h
@@ -80,8 +80,8 @@ typedef struct {
     long maxPlayers; //	ksiInit sets this. (current default is 6)
     long maxTeams; //	ksiInit sets this. (current default is 6) Doesn't include neutral team!!
 
-    long frameTime; //	Time for each frame in milliseconds.
-    long frameNumber; //	Number of current frame (starts at 0)
+    FrameTime frameTime; //	Time for each frame in milliseconds.
+    FrameNumber frameNumber; //	Number of current frame (starts at 0)
 
     /*
     **	The results are stored in a text handle called resultsHandle.
@@ -131,7 +131,7 @@ typedef struct {
     long playerTeam; //	From -1 to 5 (0 to 5 are players. Unless Avara is changed!)
     long playerLives; //	Not valid when playerID == -1 (computer)
     StringPtr playerName; //	Player name, when appropriate
-    long winFrame; //	Frame at which player exited (won) or -1.
+    FrameNumber winFrame; //	Frame at which player exited (won) or -1.
 
     /*
     **	The following are only valid for ksiScore calls:

--- a/src/game/CAbstractActor.cpp
+++ b/src/game/CAbstractActor.cpp
@@ -1258,10 +1258,10 @@ double CAbstractActor::FpsCoefficient1(double fpsCoeff1, double fpsScale) {
     return pow(fpsCoeff1, fpsScale);
 }
 
-long CAbstractActor::FpsFramesPerClassic(long classicFrames)
+FrameNumber CAbstractActor::FpsFramesPerClassic(FrameNumber classicFrames)
 {
     if (HandlesFastFPS()) {
-        return long(classicFrames / itsGame->fpsScale);
+        return (classicFrames / itsGame->fpsScale);
     } else {
         return 1;
     }

--- a/src/game/CAbstractActor.h
+++ b/src/game/CAbstractActor.h
@@ -101,7 +101,7 @@ public:
     CAbstractActor *nextActor;
     CAbstractActor *identLink;
     long ident;
-    long sleepTimer;
+    FrameNumber sleepTimer;
 
     CAbstractActor *postMortemLink;
     Fixed blastPower;
@@ -229,7 +229,7 @@ public:
     Fixed FpsCoefficient1(Fixed classicMultiplier1);
     Fixed FpsCoefficient2(Fixed classicMultiplier2);
     Fixed FpsOffset(Fixed classicCoeff2);
-    long FpsFramesPerClassic(long classicFrames = 1);
+    FrameNumber FpsFramesPerClassic(FrameNumber classicFrames = 1);
     Fixed ClassicCoefficient2(Fixed fpsValue);
 private:
     virtual double FpsCoefficient1(double classicCoeef1, double fpsScale);

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -1399,7 +1399,7 @@ void CAbstractPlayer::ResumeLevel() {
 
 extern Fixed sliverGravity;
 
-#define INTERPTIME FpsFramesPerClassic(20)
+#define INTERPTIME Fixed(FpsFramesPerClassic(20))
 
 void CAbstractPlayer::Win(long winScore, CAbstractActor *teleport) {
     short count = 16;
@@ -1468,7 +1468,7 @@ void CAbstractPlayer::Win(long winScore, CAbstractActor *teleport) {
 }
 
 void CAbstractPlayer::WinAction() {
-    long interFrame;
+    Fixed interFrame;
     Fixed inter2;
 
     interFrame = itsGame->frameNumber - winFrame;

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -50,7 +50,7 @@ public:
     Fixed energy = 0;
     Fixed maxEnergy = 0; //	Maximum stored energy level
     Fixed classicGeneratorPower, generatorPower = 0; //	Energy gain/frame
-    long boostEndFrame = 0;
+    FrameNumber boostEndFrame = 0;
     long boostsRemaining = 0;
 
     Fixed maxShields = 0; //	Maximum shield energy
@@ -58,8 +58,8 @@ public:
 
     short missileCount = 0;
     short grenadeCount = 0;
-    long nextGrenadeLoad = 0;
-    long nextMissileLoad = 0;
+    FrameNumber nextGrenadeLoad = 0;
+    FrameNumber nextMissileLoad = 0;
 
     short missileLimit = 0;
     short grenadeLimit = 0;
@@ -130,7 +130,7 @@ public:
     Boolean didSelfDestruct = 0;
 
     //	Winning/loosing:
-    long winFrame = 0;
+    FrameNumber winFrame = 0;
     Quaternion winStart = {0};
     Quaternion winEnd = {0};
     Boolean isOut = 0;

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -67,7 +67,7 @@ void TrackerPinger(CAvaraAppImpl *app) {
 }
 
 CAvaraAppImpl::CAvaraAppImpl() : CApplication("Avara") {
-    itsGame = new CAvaraGame(gApplication->Get<FrameTime>(kFrameTimeTag));
+    itsGame = new CAvaraGame(Get<FrameTime>(kFrameTimeTag));
     gCurrentGame = itsGame;
     itsGame->IAvaraGame(this);
     itsGame->UpdateViewRect(mSize.x, mSize.y, mPixelRatio);

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -67,7 +67,7 @@ void TrackerPinger(CAvaraAppImpl *app) {
 }
 
 CAvaraAppImpl::CAvaraAppImpl() : CApplication("Avara") {
-    itsGame = new CAvaraGame(gApplication->Number(kFrameTimeTag));
+    itsGame = new CAvaraGame(gApplication->Get<FrameTime>(kFrameTimeTag));
     gCurrentGame = itsGame;
     itsGame->IAvaraGame(this);
     itsGame->UpdateViewRect(mSize.x, mSize.y, mPixelRatio);
@@ -424,7 +424,7 @@ void CAvaraAppImpl::ParamLine(short index, MsgAlignment align, StringPtr param1,
 
     AddMessageLine(buffa.str(), align, category);
 }
-void CAvaraAppImpl::StartFrame(long frameNum) {}
+void CAvaraAppImpl::StartFrame(FrameNumber frameNum) {}
 
 void CAvaraAppImpl::StringLine(std::string theString, MsgAlignment align) {
     AddMessageLine(theString.c_str(), align, MsgCategory::Level);
@@ -473,4 +473,4 @@ std::string CAvaraAppImpl::TrackerPayload() {
 void CAvaraAppImpl::SetIndicatorDisplay(short i, short v) {}
 void CAvaraAppImpl::NumberLine(long theNum, short align) {}
 void CAvaraAppImpl::DrawUserInfoPart(short i, short partList) {}
-void CAvaraAppImpl::BrightBox(long frameNum, short position) {}
+void CAvaraAppImpl::BrightBox(FrameNumber frameNum, short position) {}

--- a/src/game/CAvaraApp.h
+++ b/src/game/CAvaraApp.h
@@ -44,8 +44,8 @@ public:
     virtual std::deque<MsgLine>& MessageLines() = 0;
     virtual void DrawUserInfoPart(short i, short partList) = 0;
     virtual void ParamLine(short index, MsgAlignment align, StringPtr param1, StringPtr param2 = NULL) = 0;
-    virtual void StartFrame(long frameNum) = 0;
-    virtual void BrightBox(long frameNum, short position) = 0;
+    virtual void StartFrame(FrameNumber frameNum) = 0;
+    virtual void BrightBox(FrameNumber frameNum, short position) = 0;
     virtual void LevelReset() = 0;
     virtual long Number(const std::string name) = 0;
     virtual bool Boolean(const std::string name) = 0;
@@ -116,11 +116,11 @@ public:
     virtual void SetIndicatorDisplay(short i, short v);
     virtual void NumberLine(long theNum, short align);
     virtual void DrawUserInfoPart(short i, short partList) override;
-    virtual void BrightBox(long frameNum, short position) override;
+    virtual void BrightBox(FrameNumber frameNum, short position) override;
     virtual void MessageLine(short index, MsgAlignment align) override;
     virtual void LevelReset() override;
     virtual void ParamLine(short index, MsgAlignment align, StringPtr param1, StringPtr param2) override;
-    virtual void StartFrame(long frameNum) override;
+    virtual void StartFrame(FrameNumber frameNum) override;
     virtual void StringLine(std::string theString, MsgAlignment align) override;
     virtual void ComposeParamLine(StringPtr destStr, short index, StringPtr param1, StringPtr param2) override;
     virtual void SetNet(CNetManager*) override;

--- a/src/game/CAvaraApp.h
+++ b/src/game/CAvaraApp.h
@@ -136,6 +136,7 @@ public:
     virtual SDL_Window* sdlWindow() override { return CApplication::sdlWindow(); }
     virtual long Number(const std::string name) override { return CApplication::Number(name); }
     virtual bool Boolean(const std::string name) override { return CApplication::Boolean(name); }
+    template <class T> T Get(const std::string name) { return CApplication::Get<T>(name); }
 
     void TrackerUpdate();
     std::string TrackerPayload();

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -87,7 +87,7 @@ CNetManager* CAvaraGame::CreateNetManager() {
     return new CNetManager;
 }
 
-CAvaraGame::CAvaraGame(int32_t frameTime) {
+CAvaraGame::CAvaraGame(FrameTime frameTime) {
     SetFrameTime(frameTime);
 }
 void CAvaraGame::IAvaraGame(CAvaraApp *theApp) {
@@ -1107,17 +1107,17 @@ void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayer
     }
 }
 
-long CAvaraGame::TimeToFrameCount(long timeInMsec) {
+FrameNumber CAvaraGame::TimeToFrameCount(long timeInMsec) {
     // how many frames occur in timeInMsec?
-    return timeInMsec / frameTime;
+    return FrameNumber(timeInMsec / frameTime);
 }
 
-long CAvaraGame::NextFrameForPeriod(long period, long referenceFrame) {
+FrameNumber CAvaraGame::NextFrameForPeriod(long period, long referenceFrame) {
     // Jump forward to the next full period.
     // For example, if we are changing latencies such that we start with 48 frames/period
     // and we're moving to 60 frames/period, and we're on frame 48, we want to
     // move forward to frame 120 and NOT frame 60.
-    long periodFrames = TimeToFrameCount(period);
+    FrameNumber periodFrames = TimeToFrameCount(period);
     return periodFrames * ceil(double(referenceFrame + periodFrames) / periodFrames);
 }
 
@@ -1143,6 +1143,6 @@ void CAvaraGame::IncrementFrame(bool firstFrame) {
     isClassicFrame = (frameNumber % (CLASSICFRAMETIME / frameTime) == 0);
 }
 
-long CAvaraGame::FramesFromNow(long classicFrameCount) {
+FrameNumber CAvaraGame::FramesFromNow(FrameNumber classicFrameCount) {
     return frameNumber + classicFrameCount / fpsScale;
 }

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -75,13 +75,13 @@ public:
     std::string loadedInfo = "";
     long loadedTimeLimit;
     int32_t timeInSeconds;
-    int32_t frameNumber;
+    FrameNumber frameNumber;
     bool isClassicFrame;
     int32_t frameAdjust;
 
-    long topSentFrame;
+    FrameNumber topSentFrame;
 
-    int32_t frameTime; //	In milliseconds.
+    FrameTime frameTime; //	In milliseconds.
     double fpsScale;  // 0.25 => CLASSICFRAMETIME / 4
 
     short gameStatus;
@@ -183,7 +183,7 @@ public:
     long oldPlayersStanding;
     short oldTeamsStanding;
 
-    CAvaraGame(int32_t frameTime = 64);
+    CAvaraGame(FrameTime frameTime = 64);
     //	Methods:
     virtual void IAvaraGame(CAvaraApp *theApp);
     virtual CBSPWorld* CreateCBSPWorld(short initialObjectSpace);
@@ -249,11 +249,11 @@ public:
 
     virtual long RoundTripToFrameLatency(long rtt);
     virtual void SetFrameLatency(short newFrameLatency, short maxChange = 2, CPlayerManager *slowPlayer = nullptr);
-    virtual long TimeToFrameCount(long timeInMsec);
-    virtual long NextFrameForPeriod(long period, long referenceFrame = 0);
+    virtual FrameNumber TimeToFrameCount(long timeInMsec);
+    virtual FrameNumber NextFrameForPeriod(long period, long referenceFrame = 0);
     virtual void SetFrameTime(int32_t ft);
     virtual void IncrementFrame(bool firstFrame = false);
-    virtual long FramesFromNow(long classicFrames);
+    virtual FrameNumber FramesFromNow(FrameNumber classicFrames);
 };
 
 #ifndef MAINAVARAGAME

--- a/src/game/CBall.cpp
+++ b/src/game/CBall.cpp
@@ -284,7 +284,7 @@ void CBall::BuzzControl(Boolean doBuzz) {
 
 void CBall::MagnetAction() {
     CAbstractActor *theActor;
-    long thisFrame = itsGame->frameNumber;
+    FrameNumber thisFrame = itsGame->frameNumber;
     Boolean didAttract = false;
 
     BuildActorProximityList(location, partList[0]->bigRadius, kBallSnapBit);

--- a/src/game/CLogicDelay.cpp
+++ b/src/game/CLogicDelay.cpp
@@ -22,7 +22,7 @@ CAbstractActor *CLogicDelay::EndScript() {
     }
 
     if (CLogic::EndScript()) {
-        theDelay = ReadLongVar(iTimer);
+        theDelay = FrameNumber(ReadLongVar(iTimer));
         if (theDelay < 0) {
             theDelay = -theDelay;
             sleepTimer = theDelay + 1;
@@ -39,7 +39,7 @@ CAbstractActor *CLogicDelay::EndScript() {
 void CLogicDelay::FrameAction() {
     short i;
     short theCount;
-    long thisFrame = itsGame->frameNumber;
+    FrameNumber thisFrame = itsGame->frameNumber;
     long closestAlarm;
     Boolean foundAlarm;
 

--- a/src/game/CLogicDelay.h
+++ b/src/game/CLogicDelay.h
@@ -14,8 +14,8 @@
 
 class CLogicDelay : public CLogic {
 public:
-    long theDelay;
-    long scheduledFrame[DELAY_PIPELINE];
+    FrameNumber theDelay;
+    FrameNumber scheduledFrame[DELAY_PIPELINE];
 
     virtual void FrameAction();
     virtual void BeginScript();

--- a/src/game/CLogicTimer.cpp
+++ b/src/game/CLogicTimer.cpp
@@ -16,7 +16,7 @@ void CLogicTimer::BeginScript() {
 
 CAbstractActor *CLogicTimer::EndScript() {
     if (CLogic::EndScript()) {
-        theDelay = ReadLongVar(iTimer);
+        theDelay = FrameNumber(ReadLongVar(iTimer));
 
         if (theDelay)
             return this;

--- a/src/game/CLogicTimer.h
+++ b/src/game/CLogicTimer.h
@@ -12,8 +12,8 @@
 
 class CLogicTimer : public CLogic {
 public:
-    long theDelay;
-    long whenFrame;
+    FrameNumber theDelay;
+    FrameNumber whenFrame;
 
     virtual void FrameAction();
     virtual void BeginScript();

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -718,7 +718,7 @@ void CNetManager::FrameAction() {
     }
 }
 
-void CNetManager::AutoLatencyControl(long frameNumber, Boolean didWait) {
+void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
     if (didWait) {
         localLatencyVote++;
     }

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -103,7 +103,7 @@ public:
     long localLatencyVote;
     long autoLatencyVote;
     long autoLatencyVoteCount;
-    long latencyVoteFrame;
+    FrameNumber latencyVoteFrame;
     short maxRoundTripLatency;
     short addOneLatency;
     long subtractOneCheck;
@@ -178,7 +178,7 @@ public:
     virtual void ResumeGame();
     virtual void FrameAction();
     virtual void HandleEvent(SDL_Event &event);
-    virtual void AutoLatencyControl(long frameNumber, Boolean didWait);
+    virtual void AutoLatencyControl(FrameNumber frameNumber, Boolean didWait);
     virtual bool IsAutoLatencyEnabled();
     virtual bool IsFragmentCheckWindowOpen();
     virtual void ResetLatencyVote();

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -170,7 +170,7 @@ private:
     unsigned char message[kMaxMessageChars + 1];
     std::deque<char> lineBuffer;
 
-    long winFrame;
+    FrameNumber winFrame;
     short loadingStatus;
     short slot;
     short playerColor;

--- a/src/game/CRealShooters.cpp
+++ b/src/game/CRealShooters.cpp
@@ -47,8 +47,8 @@ CAbstractActor *CRealShooters::EndScript() {
         visionRange = ReadFixedVar(iRange);
         shotPower = ReadFixedVar(iShotPower);
         burstLength = ReadLongVar(iBurstLength);
-        burstSpeed = ReadLongVar(iBurstSpeed);
-        burstCharge = ReadLongVar(iBurstCharge);
+        burstSpeed = FrameNumber(ReadLongVar(iBurstSpeed));
+        burstCharge = FrameNumber(ReadLongVar(iBurstCharge));
 
         watchTeams = ReadLongVar(iMask);
         watchMask = ReadLongVar(iWatchMask);

--- a/src/game/CRealShooters.h
+++ b/src/game/CRealShooters.h
@@ -16,13 +16,13 @@ public:
     Fixed visionRange;
     Fixed shotPower;
 
-    long burstStartFrame;
-    long nextShotFrame;
+    FrameNumber burstStartFrame;
+    FrameNumber nextShotFrame;
     short burstCount;
 
     long burstLength;
-    long burstSpeed;
-    long burstCharge;
+    FrameNumber burstSpeed;
+    FrameNumber burstCharge;
 
     //	Who to fire at.
     MaskType watchMask;

--- a/src/game/CSmart.h
+++ b/src/game/CSmart.h
@@ -24,7 +24,7 @@ public:
     Fixed thrust;
     Fixed angleStep;
     short inSight;
-    long fireFrame;
+    FrameNumber fireFrame;
 
     virtual void IWeapon(CDepot *theDepot);
     virtual void ResetWeapon();

--- a/src/game/CTextActor.cpp
+++ b/src/game/CTextActor.cpp
@@ -51,9 +51,9 @@ CAbstractActor *CTextActor::EndScript() {
 
         nextShowTime = 0;
         restartDelay = ReadLongVar(iRestartFlag);
-        frequency = ReadLongVar(iFrequency);
+        frequency = FrameNumber(ReadLongVar(iFrequency));
 
-        textTimer = ReadLongVar(iTimer);
+        textTimer = FrameNumber(ReadLongVar(iTimer));
         showTime = -1;
 
         soundId = ReadLongVar(iSound);

--- a/src/game/CTextActor.h
+++ b/src/game/CTextActor.h
@@ -19,15 +19,15 @@ public:
     Boolean enabled;
     Boolean showEveryone;
 
-    long nextShowTime;
+    FrameNumber nextShowTime;
     long restartDelay;
     Vector location;
     Fixed radius;
-    long frequency;
+    FrameNumber frequency;
     Boolean areaFlag;
     short alignment;
 
-    long textTimer;
+    FrameNumber textTimer;
     long showTime;
 
     short soundId;

--- a/src/game/CWeapon.h
+++ b/src/game/CWeapon.h
@@ -31,7 +31,7 @@ public:
     short ownerSlot;
     short weaponKind;
 
-    long flyCount;
+    FrameNumber flyCount;
     Boolean doExplode;
 
     virtual void IWeapon(CDepot *theDepot);

--- a/src/game/KeyFuncs.h
+++ b/src/game/KeyFuncs.h
@@ -27,7 +27,7 @@ typedef struct {
 
 typedef struct {
     FunctionTable ft;
-    uint32_t validFrame;
+    FrameNumber validFrame;
 } FrameFunction;
 
 //	Flags for "p1" of packet.
@@ -70,10 +70,10 @@ enum {
 
     kfuScoutView,
     kfuScoutControl,
-    
+
     kfuSpectateNext,
     kfuSpectatePrevious,
-    
+
     kfuScoreboard,
 
     kfuPauseGame,

--- a/src/gui/CApplication.h
+++ b/src/gui/CApplication.h
@@ -41,7 +41,7 @@ public:
     // templated version works for new types too (float, double, short, etc.)
     template <class T> T Get(const std::string name) {
         // throws json::out_of_range exception if 'name' not a known key
-        return _prefs.at(name);
+        return static_cast<T>(_prefs.at(name));
     }
     // these getters are here for backwards compatibility and/or readability
     std::string String(const std::string name)       { return Get<std::string>(name); };

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -131,8 +131,8 @@ public:
     virtual void RenderContents() {};
     virtual void DrawUserInfoPart(short i, short partList) {}
     virtual void ParamLine(short index, MsgAlignment align, StringPtr param1, StringPtr param2) {}
-    virtual void StartFrame(long frameNum) {}
-    virtual void BrightBox(long frameNum, short position) {}
+    virtual void StartFrame(FrameNumber frameNum) {}
+    virtual void BrightBox(FrameNumber frameNum, short position) {}
     virtual void LevelReset() {}
     virtual long Number(const std::string name) { return 0; }
     virtual bool Boolean(const std::string name) { return false; }


### PR DESCRIPTION
I tried to find any variable that was used in frameNumber calculations and converted them all to type FrameNumber which is `typedef int32_t`.  Now everything dealing with frame numbers should have the same type and 1 place to change that type.

Also did frameTime but there are not very many of those variables.

Killed a few warnings along the way.