### PR TITLE
output error message and restrict size of dataBuffer

### DIFF
--- a/src/net/CCommManager.cpp
+++ b/src/net/CCommManager.cpp
@@ -258,6 +258,11 @@ PacketInfo *CCommManager::DuplicatePacket(PacketInfo *original) {
         duplicate->p3 = original->p3;
         duplicate->dataLen = original->dataLen;
         if (duplicate->dataLen) {
+            if (duplicate->dataLen > PACKETDATABUFFERSIZE) {
+                SDL_Log("CCommManager::DuplicatePacket BUFFER TOO BIG ERROR!! cmd=%d, sndr=%d dataLen = %d\n",
+                        duplicate->command, duplicate->sender, duplicate->dataLen);
+                duplicate->dataLen = PACKETDATABUFFERSIZE;
+            }
             BlockMoveData(original->dataBuffer, duplicate->dataBuffer, duplicate->dataLen);
         }
     }

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -733,6 +733,11 @@ void CUDPComm::ReadComplete(UDPpacket *packet) {
                         #endif
 
                         if (p->dataLen) {
+                            if (p->dataLen > PACKETDATABUFFERSIZE) {
+                                SDL_Log("CUDPComm::ReadComplete BUFFER TOO BIG ERROR!! cmd=%d, sndr=%d dataLen = %d\n",
+                                        p->command, p->sender, p->dataLen);
+                                p->dataLen = PACKETDATABUFFERSIZE;
+                            }
                             BlockMoveData(inData.c, p->dataBuffer, p->dataLen);
                             inData.c += p->dataLen;
                         }
@@ -1004,6 +1009,11 @@ Boolean CUDPComm::AsyncWrite() {
             p->flags = flags;  // stick flags in the packet structure
 
             if (p->dataLen) {
+                if (p->dataLen > PACKETDATABUFFERSIZE) {
+                    SDL_Log("CUDPComm::AsyncWrite BUFFER TOO BIG ERROR!! cmd=%d, sndr=%d dataLen = %d\n",
+                            p->command, p->sender, p->dataLen);
+                    p->dataLen = PACKETDATABUFFERSIZE;
+                }
                 BlockMoveData(p->dataBuffer, outData.c, p->dataLen);
                 outData.c += p->dataLen;
             }


### PR DESCRIPTION
prevents BlockMoveData errors and tells us the command type that caused the problem