### PR TITLE
use std::containers for packet buffers

### DIFF
--- a/src/Avara.cpp
+++ b/src/Avara.cpp
@@ -74,8 +74,10 @@ int main(int argc, char *argv[]) {
         } else if (arg == "-c" || arg == "--connect") {
             connectAddress = std::string(argv[++i]);
             app->Set(kLastAddress, connectAddress);
-        } else if (arg == "-s" || arg == "--serve") {
+        } else if (arg == "-s" || arg == "--serve" ||
+                   arg == "-S" || arg == "--Serve") {
             host = true;
+            app->Set(kTrackerRegister, arg[1] == 'S' || arg[2] == 'S');
         } else if (arg == "-f" || arg == "--frametime") {
             uint16_t frameTime = atol(argv[++i]);  // pre-inc to next arg
             app->GetGame()->SetFrameTime(frameTime);

--- a/src/compat/Types.h
+++ b/src/compat/Types.h
@@ -71,7 +71,6 @@ struct QElem {
 typedef struct QElem QElem;
 typedef QElem *QElemPtr;
 struct QHdr {
-    volatile int16_t qFlags;
     volatile QElemPtr qHead;
     volatile QElemPtr qTail;
 };

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -955,6 +955,14 @@ void CAbstractPlayer::FrameAction() {
 }
 
 void CAbstractPlayer::PlayerAction() {
+    if (itsGame->frameNumber == 0 && itsManager->LoadingStatus() == kLSpectating) {
+        lives = 0;
+#define EXPLODING_SPECTATORS
+#ifdef EXPLODING_SPECTATORS
+        WasDestroyed();
+#endif
+        GoLimbo(0);  // hides the hector
+    }
     if (lives) {
         itsGame->playersStanding++;
         // Send score updates to other players every 17 seconds worth of frames

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -955,7 +955,7 @@ void CAbstractPlayer::FrameAction() {
 }
 
 void CAbstractPlayer::PlayerAction() {
-    if (itsGame->frameNumber == 0 && itsManager->LoadingStatus() == kLSpectating) {
+    if (itsGame->frameNumber == 0 && itsManager->Presence() == kzSpectating) {
         lives = 0;
 #define EXPLODING_SPECTATORS
 #ifdef EXPLODING_SPECTATORS

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -682,7 +682,7 @@ void CAvaraGame::StartIfReady() {
         bool allReady = true;
         for (int i = 0; i < kMaxAvaraPlayers; i++) {
             CPlayerManager *mgr = itsNet->playerTable[i];
-            if (mgr && mgr->LoadingStatus() == kLLoaded) {
+            if (mgr && mgr->LoadingStatus() == kLLoaded && mgr->Presence() == kzAvailable) {
                 allReady = false;
                 break;
             }

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -14,6 +14,7 @@
 #include "KeyFuncs.h"
 //#include "LevelScoreRecord.h"
 #include "PlayerConfig.h"
+#include "CPlayerManager.h"
 
 #include <SDL2/SDL.h>
 #include <string>
@@ -50,7 +51,6 @@ void ServerOptionsDialog();
 #define kAllowTeamControlBitMask ((1 << kFreeColorBit) + (1 << kAllowOwnColorBit))
 class CAvaraGame;
 class CCommManager;
-class CPlayerManager;
 class CProtoControl;
 // class	CRosterWindow;
 class CAbstractPlayer;
@@ -133,7 +133,7 @@ public:
     virtual void SendRealName(short toSlot);
     virtual void RealNameReport(short slot, short regStatus, StringPtr realName);
     virtual void NameChange(StringPtr newName);
-    virtual void RecordNameAndLocation(short slotId, StringPtr theName, short status, Point location);
+    virtual void RecordNameAndLocation(short slotId, StringPtr theName, LoadingState status, Point location);
     virtual void ValueChange(short slot, std::string attributeName, bool value);
 
     virtual void SwapPositions(short ind1, short ind2);
@@ -163,7 +163,7 @@ public:
     virtual void ReceiveResumeCommand(short activeDistribution, short fromSlot, Fixed randomKey, int16_t originalSender);
     virtual void ReceivedUnavailable(short slot, short fromSlot);
 
-    virtual void ReceivePlayerStatus(short slotId, short newStatus, Fixed randomKey, FrameNumber winFrame);
+    virtual void ReceivePlayerStatus(short slotId, LoadingState newStatus, Fixed randomKey, FrameNumber winFrame);
     virtual void ReceiveJSON(short slotId, Fixed randomKey, FrameNumber winFrame, std::string json);
 
     virtual short PlayerCount();

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -133,7 +133,7 @@ public:
     virtual void SendRealName(short toSlot);
     virtual void RealNameReport(short slot, short regStatus, StringPtr realName);
     virtual void NameChange(StringPtr newName);
-    virtual void RecordNameAndLocation(short slotId, StringPtr theName, LoadingState status, Point location);
+    virtual void RecordNameAndState(short slotId, StringPtr theName, LoadingState status, PresenceType presence);
     virtual void ValueChange(short slot, std::string attributeName, bool value);
 
     virtual void SwapPositions(short ind1, short ind2);
@@ -163,7 +163,7 @@ public:
     virtual void ReceiveResumeCommand(short activeDistribution, short fromSlot, Fixed randomKey, int16_t originalSender);
     virtual void ReceivedUnavailable(short slot, short fromSlot);
 
-    virtual void ReceivePlayerStatus(short slotId, LoadingState newStatus, Fixed randomKey, FrameNumber winFrame);
+    virtual void ReceivePlayerStatus(short slotId, LoadingState newStatus, PresenceType newPresence, Fixed randomKey, FrameNumber winFrame);
     virtual void ReceiveJSON(short slotId, Fixed randomKey, FrameNumber winFrame, std::string json);
 
     virtual short PlayerCount();

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <memory>
 
-#define NULLNETPACKETS (32 + MINIMUMBUFFERRESERVE)
+#define NULLNETPACKETS (MINIMUMBUFFERRESERVE)
 #define SERVERNETPACKETS (16 * 2 * kMaxAvaraPlayers)
 #define CLIENTNETPACKETS (16 * kMaxAvaraPlayers)
 #define TCPNETPACKETS (32 * kMaxAvaraPlayers)

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -17,7 +17,7 @@
 #include <deque>
 #include <string>
 
-enum LoadingStatus {
+enum LoadingState {
     kLNotConnected,
     kLConnected,
     kLActive,
@@ -81,8 +81,9 @@ public:
     virtual void IsRegistered(short) = 0;
     virtual Str255& PlayerRegName() = 0;
     virtual short LoadingStatus() = 0;
-    virtual void SetPlayerStatus(short newStatus, FrameNumber theWin) = 0;
+    virtual void SetPlayerStatus(LoadingState newStatus, FrameNumber theWin) = 0;
     virtual bool IsAway() = 0;
+    virtual bool IsActive() = 0;
 
     virtual void ChangeNameAndLocation(StringPtr theName, Point location) = 0;
     virtual void SetPosition(short pos) = 0;
@@ -172,7 +173,7 @@ private:
     std::deque<char> lineBuffer;
 
     FrameNumber winFrame;
-    short loadingStatus;
+    LoadingState loadingStatus;
     short slot;
     short playerColor;
 
@@ -225,9 +226,10 @@ public:
     virtual void NetDisconnect();
     virtual void ChangeNameAndLocation(StringPtr theName, Point location);
     virtual void SetPosition(short pos);
-    virtual void SetPlayerStatus(short newStatus, FrameNumber theWin);
+    virtual void SetPlayerStatus(LoadingState newStatus, FrameNumber theWin);
     virtual void SetPlayerReady(bool isReady);
     virtual bool IsAway();
+    virtual bool IsActive();
     virtual void ResendFrame(FrameNumber theFrame, short requesterId, short commandCode);
 
     virtual void LoadStatusChange(short serverCRC, OSErr serverErr, std::string serverTag);

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -17,7 +17,7 @@
 #include <deque>
 #include <string>
 
-enum {
+enum LoadingStatus {
     kLNotConnected,
     kLConnected,
     kLActive,
@@ -29,6 +29,7 @@ enum {
     kLPaused,
     kLNoVehicle,
     kLAway,
+    kLSpectating,
     kLReady,    // implies kLLoaded, i.e. Loaded & Ready to start
 
     kStringNorth,

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -28,14 +28,21 @@ enum LoadingState {
     kLNotFound,
     kLPaused,
     kLNoVehicle,
-    kLAway,
-    kLSpectating,
+//    kLAway,
+//    kLSpectating,
     kLReady,    // implies kLLoaded, i.e. Loaded & Ready to start
 
     kStringNorth,
     kStringSouth,
     kStringEast,
     kStringWest
+};
+
+enum PresenceType {
+    kzUnknown,
+    kzAvailable,
+    kzSpectating,
+    kzAway
 };
 
 #define FUNCTIONBUFFERS 64*8  // 512 frames at 16ms/frame = 8.192s rollover time
@@ -50,7 +57,7 @@ static const char* lThing_utf8    = "\xC2\xAC ";     // ¬
 static const char* checkMark_utf8 = "\xE2\x88\x9A";  // ✓
 static const char* triangle_utf8  = "\xCE\x94";      // Δ
 static const char* clearChat_utf8 = "\x1B";          // Fn-Del on Mac
-
+static const char* eyeballs_utf8  = "\xF0\x9F\x91\x80";
 
 class CPlayerManager {
 protected:
@@ -80,12 +87,12 @@ public:
     virtual short IsRegistered() = 0;
     virtual void IsRegistered(short) = 0;
     virtual Str255& PlayerRegName() = 0;
-    virtual short LoadingStatus() = 0;
-    virtual void SetPlayerStatus(LoadingState newStatus, FrameNumber theWin) = 0;
+    virtual LoadingState LoadingStatus() = 0;
+    virtual PresenceType Presence() = 0;
+    virtual void SetPlayerStatus(LoadingState newStatus, PresenceType newPresence, FrameNumber theWin) = 0;
     virtual bool IsAway() = 0;
-    virtual bool IsActive() = 0;
 
-    virtual void ChangeNameAndLocation(StringPtr theName, Point location) = 0;
+    virtual void ChangeName(StringPtr theName) = 0;
     virtual void SetPosition(short pos) = 0;
     virtual void RosterKeyPress(unsigned char c) = 0;
     virtual void RosterMessageText(short len, const char *c) = 0;
@@ -174,6 +181,7 @@ private:
 
     FrameNumber winFrame;
     LoadingState loadingStatus;
+    PresenceType presence;
     short slot;
     short playerColor;
 
@@ -224,12 +232,12 @@ public:
     virtual void GameKeyPress(char c);
 
     virtual void NetDisconnect();
-    virtual void ChangeNameAndLocation(StringPtr theName, Point location);
+    virtual void ChangeName(StringPtr theName);
     virtual void SetPosition(short pos);
-    virtual void SetPlayerStatus(LoadingState newStatus, FrameNumber theWin);
+    virtual void SetPlayerStatus(LoadingState newStatus, PresenceType newPresence, FrameNumber theWin);
     virtual void SetPlayerReady(bool isReady);
     virtual bool IsAway();
-    virtual bool IsActive();
+
     virtual void ResendFrame(FrameNumber theFrame, short requesterId, short commandCode);
 
     virtual void LoadStatusChange(short serverCRC, OSErr serverErr, std::string serverTag);
@@ -263,7 +271,8 @@ public:
     virtual short IsRegistered();
     virtual void IsRegistered(short);
     virtual Str255& PlayerRegName();
-    virtual short LoadingStatus();
+    virtual LoadingState LoadingStatus();
+    virtual PresenceType Presence();
     virtual short LevelCRC();
     virtual OSErr LevelErr();
     virtual std::string LevelTag();

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -300,7 +300,7 @@ std::string CRosterWindow::GetStringStatus(CPlayerManager *player) {
     if(status == kLAway) {
         strStatus = "not playing";
     } else if(status == kLSpectating) {
-        strStatus = "spectating";
+        strStatus = "spectator";
     } else if (status == kLConnected) {
         strStatus = "connected";
     } else if (status == kLLoaded) {

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -277,7 +277,6 @@ bool CRosterWindow::DoCommand(int theCommand) {
 }
 
 std::string CRosterWindow::GetStringStatus(CPlayerManager *player) {
-    short status = player->LoadingStatus();
     std::string strStatus;
     if (player->WinFrame() >= 0) {
         long timeTemp = FMulDiv(player->WinFrame(), ((CAvaraAppImpl *)gApplication)->GetGame()->frameTime, 10);
@@ -297,32 +296,40 @@ std::string CRosterWindow::GetStringStatus(CPlayerManager *player) {
         return strStatus;
     }
 
-    if(status == kLAway) {
-        strStatus = "not playing";
-    } else if(status == kLSpectating) {
-        strStatus = "spectator";
-    } else if (status == kLConnected) {
-        strStatus = "connected";
-    } else if (status == kLLoaded) {
-        strStatus = "loaded";
-    } else if (status == kLReady) {
-        strStatus = "ready";
-    } else if (status == kLWaiting) {
-        strStatus = "waiting";
-    } else if (status == kLTrying) {
-        strStatus = "loading";
-    } else if (status == kLMismatch) {
-        strStatus = "version mismatch";
-    } else if (status == kLNotFound) {
-        strStatus = "level not found";
-    } else if (status == kLPaused) {
-        strStatus = "paused";
-    } else if (status == kLActive) {
-        strStatus = "active";
-    } else if (status == kLNoVehicle) {
-        strStatus = "HECTOR not available";
+    LoadingState status = player->LoadingStatus();
+    PresenceType presence = player->Presence();
+    if (presence != kzAway) {
+        if (status == kLConnected) {
+            strStatus = "connected";
+        } else if (status == kLLoaded) {
+            strStatus = "loaded";
+        } else if (status == kLReady) {
+            strStatus = "ready";
+        } else if (status == kLWaiting) {
+            strStatus = "waiting";
+        } else if (status == kLTrying) {
+            strStatus = "loading";
+        } else if (status == kLMismatch) {
+            strStatus = "version mismatch";
+        } else if (status == kLNotFound) {
+            strStatus = "level not found";
+        } else if (status == kLPaused) {
+            strStatus = "paused";
+        } else if (status == kLActive) {
+            strStatus = "active";
+        } else if (status == kLNoVehicle) {
+            strStatus = "HECTOR not available";
+        } else {
+            strStatus = "";
+        }
     } else {
-        strStatus = "";
+        strStatus = "away";
+    }
+    if (presence == kzSpectating) {
+        if (status == kLConnected || status == kLActive || status == kLLoaded) {
+            strStatus = "spectator";
+        }
+//        strStatus += eyeballs_utf8;
     }
     return strStatus;
 }

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -299,6 +299,8 @@ std::string CRosterWindow::GetStringStatus(CPlayerManager *player) {
 
     if(status == kLAway) {
         strStatus = "not playing";
+    } else if(status == kLSpectating) {
+        strStatus = "spectating";
     } else if (status == kLConnected) {
         strStatus = "connected";
     } else if (status == kLLoaded) {

--- a/src/gui/CServerWindow.cpp
+++ b/src/gui/CServerWindow.cpp
@@ -38,7 +38,7 @@ CServerWindow::CServerWindow(CApplication *app) : CWindow(app, "Server") {
             avara->GetNet()->ChangeNet(kServerNet, "");
     });
 
-    nanogui::CheckBox *registerBox = new nanogui::CheckBox(this, "Register With Tracker:", [this, app](bool checked) {
+    registerBox = new nanogui::CheckBox(this, "Register With Tracker:", [this, app](bool checked) {
         this->trackerBox->setEditable(checked);
         this->trackerBox->setEnabled(checked);
         app->Set(kTrackerRegister, (int)checked);
@@ -129,6 +129,7 @@ bool CServerWindow::DoCommand(int theCommand) {
 void CServerWindow::PrefChanged(std::string name) {
     frameTimeBox->setSelectedIndex(6-log2(gCurrentGame->frameTime));
     latencyBox->setValue(std::to_string(mApplication->Get<float>(kLatencyToleranceTag)).substr(0, 5));
+    registerBox->setChecked(mApplication->Get<int>(kTrackerRegister) != 0);
 }
 
 void CServerWindow::EnableLatencyOptions(bool enable) {

--- a/src/gui/CServerWindow.h
+++ b/src/gui/CServerWindow.h
@@ -18,6 +18,7 @@ public:
 
 protected:
 
+    nanogui::CheckBox *registerBox;
     nanogui::TextBox *trackerBox;
     nanogui::TextBox *descriptionBox;
     nanogui::TextBox *passwordBox;

--- a/src/net/CCommManager.h
+++ b/src/net/CCommManager.h
@@ -10,6 +10,7 @@
 #pragma once
 #include "CDirectObject.h"
 #include "Memory.h"
+#include <list>
 
 #define TALKERSTRINGS 1000
 #define PACKETDATABUFFERSIZE (1024-40)          // -40 to get UDPPacketInfo to 1024 bytes
@@ -54,10 +55,10 @@ class CCommManager : public CDirectObject {
 public:
     short myId; //	Required/accessed publicly
 
-    Ptr packetBuffers;
+    std::size_t packetSize;
+    std::list<std::vector<std::byte>> packetBuffers;
     QHdr freeQ;
     QHdr inQ;
-    long freeCount;
 
     ReceiverRecord *firstReceivers[2]; //	Receiver queues
 
@@ -67,7 +68,9 @@ public:
     ~CCommManager() { Dispose(); }
 
     virtual void ICommManager(short packetSpace);
-    virtual OSErr AllocatePacketBuffers(short numPackets);
+
+    void InitializePacketQueues(int numPackets, size_t packetSize);
+    void AllocatePacketBuffers(int numPackets);
     virtual void AddReceiver(ReceiverRecord *aReceiver, Boolean delayed);
     virtual void RemoveReceiver(ReceiverRecord *aReceiver, Boolean delayed);
 

--- a/src/net/CCommManager.h
+++ b/src/net/CCommManager.h
@@ -11,6 +11,7 @@
 #include "CDirectObject.h"
 #include "Memory.h"
 #include <list>
+#include <vector>
 
 #define TALKERSTRINGS 1000
 #define PACKETDATABUFFERSIZE (1024-40)          // -40 to get UDPPacketInfo to 1024 bytes

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -82,8 +82,8 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             theNet->SendRealName(thePacket->p1);
             break;
         case kpNameChange:
-            theNet->RecordNameAndLocation(
-                thePacket->sender, (StringPtr)thePacket->dataBuffer, (LoadingState)thePacket->p2, *(Point *)&thePacket->p3);
+            theNet->RecordNameAndState(
+                thePacket->sender, (StringPtr)thePacket->dataBuffer, (LoadingState)thePacket->p2, (PresenceType)thePacket->p3);
             break;
         case kpOrderChange:
             theNet->PositionsChanged(thePacket->dataBuffer);
@@ -125,11 +125,11 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             break;
         case kpStartSynch:
             theNet->ConfigPlayer(thePacket->sender, thePacket->dataBuffer);
-            theNet->ReceivePlayerStatus(thePacket->sender, (LoadingState)thePacket->p2, thePacket->p3, -1);
+            theNet->ReceivePlayerStatus(thePacket->sender, (LoadingState)thePacket->p2, kzUnknown, (PresenceType)thePacket->p3, -1);
             break;
         case kpPlayerStatusChange:
             theNet->ReceivePlayerStatus(
-                thePacket->p1, (LoadingState)thePacket->p2, thePacket->p3, *(FrameNumber *)thePacket->dataBuffer);
+                                        thePacket->p1, (LoadingState)thePacket->p2, (PresenceType)thePacket->p3, 0, *(FrameNumber *)thePacket->dataBuffer);
             break;
         case kpJSON:
             theNet->ReceiveJSON(

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -83,7 +83,7 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             break;
         case kpNameChange:
             theNet->RecordNameAndLocation(
-                thePacket->sender, (StringPtr)thePacket->dataBuffer, thePacket->p2, *(Point *)&thePacket->p3);
+                thePacket->sender, (StringPtr)thePacket->dataBuffer, (LoadingState)thePacket->p2, *(Point *)&thePacket->p3);
             break;
         case kpOrderChange:
             theNet->PositionsChanged(thePacket->dataBuffer);
@@ -125,11 +125,11 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             break;
         case kpStartSynch:
             theNet->ConfigPlayer(thePacket->sender, thePacket->dataBuffer);
-            theNet->ReceivePlayerStatus(thePacket->sender, thePacket->p2, thePacket->p3, -1);
+            theNet->ReceivePlayerStatus(thePacket->sender, (LoadingState)thePacket->p2, thePacket->p3, -1);
             break;
         case kpPlayerStatusChange:
             theNet->ReceivePlayerStatus(
-                thePacket->p1, thePacket->p2, thePacket->p3, *(FrameNumber *)thePacket->dataBuffer);
+                thePacket->p1, (LoadingState)thePacket->p2, thePacket->p3, *(FrameNumber *)thePacket->dataBuffer);
             break;
         case kpJSON:
             theNet->ReceiveJSON(

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -97,7 +97,7 @@ public:
     Str255 inviteString;
 
     virtual void IUDPComm(short clientCount, short bufferCount, short version, ClockTick urgentTimePeriod);
-    virtual OSErr AllocatePacketBuffers(short numPackets);
+
     virtual void Disconnect();
     virtual void WritePrefs();
     virtual void Dispose();

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -61,7 +61,6 @@ void CUDPConnection::IUDPConnection(CUDPComm *theOwner) {
     port = 0;
 
     for (i = 0; i < kQueueCount; i++) {
-        queues[i].qFlags = 0;
         queues[i].qHead = 0;
         queues[i].qTail = 0;
     }

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -61,8 +61,9 @@ public:
     virtual Str255& PlayerRegName() { return str; }
     virtual short LoadingStatus() { return 0; }
     virtual void LoadStatusChange(short serverCRC, OSErr serverErr, std::string serverTag) {}
-    virtual void SetPlayerStatus(short newStatus, FrameNumber theWin) {}
+    virtual void SetPlayerStatus(LoadingState newStatus, FrameNumber theWin) {}
     virtual bool IsAway() { return false; };
+    virtual bool IsActive() { return true; };
     virtual void ChangeNameAndLocation(StringPtr theName, Point location) {}
     virtual void SetPosition(short pos) {}
 

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -59,12 +59,12 @@ public:
     virtual short IsRegistered() { return 0; }
     virtual void IsRegistered(short) {}
     virtual Str255& PlayerRegName() { return str; }
-    virtual short LoadingStatus() { return 0; }
+    virtual LoadingState LoadingStatus() { return kLNotConnected; }
+    virtual PresenceType Presence() { return kzAvailable; }
     virtual void LoadStatusChange(short serverCRC, OSErr serverErr, std::string serverTag) {}
-    virtual void SetPlayerStatus(LoadingState newStatus, FrameNumber theWin) {}
+    virtual void SetPlayerStatus(LoadingState newStatus, PresenceType newPresence, FrameNumber theWin) {}
     virtual bool IsAway() { return false; };
-    virtual bool IsActive() { return true; };
-    virtual void ChangeNameAndLocation(StringPtr theName, Point location) {}
+    virtual void ChangeName(StringPtr theName) {}
     virtual void SetPosition(short pos) {}
 
     virtual void RosterKeyPress(unsigned char c) {}

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -53,6 +53,11 @@ CommandManager::CommandManager(CAvaraAppImpl *theApp) : itsApp(theApp) {
                           METHOD_TO_LAMBDA_VARGS(ToggleAwayState));
     TextCommand::Register(cmd);
 
+    cmd = new TextCommand("/spectate        <- toggle spectator mode\n"
+                          "/spectate slot   <- toggle spectator mode of slot, starting from 1",
+                          METHOD_TO_LAMBDA_VARGS(ToggleSpectatorState));
+    TextCommand::Register(cmd);
+
     cmd = new TextCommand("/load chok       <- load level with name containing the letters 'chok'",
                           METHOD_TO_LAMBDA_VARGS(LoadNamedLevel));
     TextCommand::Register(cmd);
@@ -198,6 +203,14 @@ bool CommandManager::KickPlayer(VectorOfArgs vargs) {
 }
 
 bool CommandManager::ToggleAwayState(VectorOfArgs vargs) {
+    return CommandManager::ToggleState(vargs, kLAway, "away");
+}
+
+bool CommandManager::ToggleSpectatorState(VectorOfArgs vargs) {
+    return CommandManager::ToggleState(vargs, kLSpectating, "spectating");
+}
+
+bool CommandManager::ToggleState(VectorOfArgs vargs, LoadingStatus toggleState, std::string stateName) {
     short slot = itsApp->GetNet()->itsCommManager->myId;
 
     if (vargs.size() > 0) {
@@ -232,12 +245,12 @@ bool CommandManager::ToggleAwayState(VectorOfArgs vargs) {
         return false;
     }
 
-    short newStatus = (playerToChange->LoadingStatus() == kLAway) ? kLConnected : kLAway;
+    short newStatus = (playerToChange->LoadingStatus() == toggleState) ? kLConnected : toggleState;
     FrameNumber noWinFrame = -1;
     itsApp->GetNet()->itsCommManager->SendPacket(kdEveryone, kpPlayerStatusChange,
                                         playerToChange->Slot(), newStatus, 0, sizeof(noWinFrame), (Ptr)&noWinFrame);
     itsApp->AddMessageLine("Status of " + playerToChange->GetPlayerName() +
-                   " changed to " + std::string(newStatus == kLConnected ? "available" : "away"));
+                   " changed to " + std::string(newStatus == kLConnected ? "available" : stateName));
     return true;
 }
 

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -210,7 +210,7 @@ bool CommandManager::ToggleSpectatorState(VectorOfArgs vargs) {
     return CommandManager::ToggleState(vargs, kLSpectating, "spectating");
 }
 
-bool CommandManager::ToggleState(VectorOfArgs vargs, LoadingStatus toggleState, std::string stateName) {
+bool CommandManager::ToggleState(VectorOfArgs vargs, LoadingState toggleState, std::string stateName) {
     short slot = itsApp->GetNet()->itsCommManager->myId;
 
     if (vargs.size() > 0) {

--- a/src/tui/CommandManager.h
+++ b/src/tui/CommandManager.h
@@ -38,7 +38,7 @@ public:
     bool KickPlayer(VectorOfArgs);
     bool ToggleAwayState(VectorOfArgs);
     bool ToggleSpectatorState(VectorOfArgs);
-    bool ToggleState(VectorOfArgs, LoadingStatus, std::string);
+    bool ToggleState(VectorOfArgs, LoadingState, std::string);
 
     // LevelCommands
     bool LoadNamedLevel(VectorOfArgs);

--- a/src/tui/CommandManager.h
+++ b/src/tui/CommandManager.h
@@ -2,9 +2,9 @@
 #pragma once
 
 class CAvaraAppImpl;
-class CPlayerManager;
 
 #include "TextCommand.h"
+#include "CPlayerManager.h"
 
 #include <deque>
 
@@ -37,6 +37,8 @@ public:
     // ServerCommands
     bool KickPlayer(VectorOfArgs);
     bool ToggleAwayState(VectorOfArgs);
+    bool ToggleSpectatorState(VectorOfArgs);
+    bool ToggleState(VectorOfArgs, LoadingStatus, std::string);
 
     // LevelCommands
     bool LoadNamedLevel(VectorOfArgs);

--- a/src/tui/CommandManager.h
+++ b/src/tui/CommandManager.h
@@ -36,9 +36,9 @@ public:
 
     // ServerCommands
     bool KickPlayer(VectorOfArgs);
-    bool ToggleAwayState(VectorOfArgs);
-    bool ToggleSpectatorState(VectorOfArgs);
-    bool ToggleState(VectorOfArgs, LoadingState, std::string);
+    bool ToggleAway(VectorOfArgs);
+    bool ToggleSpectator(VectorOfArgs);
+    bool TogglePresence(VectorOfArgs, PresenceType, std::string);
 
     // LevelCommands
     bool LoadNamedLevel(VectorOfArgs);


### PR DESCRIPTION
Instead of the homegrown linked list of buffers, using a list of vector<byte> objects.  Also, no longer need to keep track of freeCount but rather just allocate more space when GetPacket() runs out of queue objects to pull from.