### PR TITLE
handle spectator aborts better

### DIFF
--- a/src/compat/System.cpp
+++ b/src/compat/System.cpp
@@ -72,6 +72,10 @@ void DisposeQueue(QHdrPtr qHeader) {
     DBG_Log("q", "DisposeQueues: gQueues now has %ld elements\n", gQueues.size());
 }
 
-size_t QueueSize() {
+size_t QueueCount() {
     return gQueues.size();
+}
+
+size_t QueueSize(QHdrPtr qHeader) {
+    return gQueues.count(qHeader) ? gQueues.at(qHeader).size() : 0;
 }

--- a/src/compat/System.h
+++ b/src/compat/System.h
@@ -11,4 +11,5 @@ void Enqueue(QElemPtr qElement, QHdrPtr qHeader);
 OSErr Dequeue(QElemPtr qElement, QHdrPtr qHeader);
 
 void DisposeQueue(QHdrPtr qHeader);
-size_t QueueSize();
+size_t QueueCount();
+size_t QueueSize(QHdrPtr);

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -155,7 +155,7 @@ void CAvaraGame::IAvaraGame(CAvaraApp *theApp) {
     keysFromStdin = false;
     keysToStdout = false;
 
-    statusRequest = -1; // who decided to make "playing" 0??
+    statusRequest = kNoVehicleStatus;
 
     nextPingTime = 0;
 

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -45,7 +45,7 @@
 
 #define INACTIVE_LOOP_REFRESH 16
 
-enum { kPlayingStatus, kAbortStatus, kReadyStatus, kPauseStatus, kNoVehicleStatus, kWinStatus, kLoseStatus };
+enum GameStatus { kPlayingStatus, kAbortStatus, kReadyStatus, kPauseStatus, kNoVehicleStatus, kWinStatus, kLoseStatus };
 
 class CAbstractActor;
 class CAbstractPlayer;
@@ -87,8 +87,8 @@ public:
     FrameTime frameTime; //	In milliseconds.
     double fpsScale;  // 0.25 => CLASSICFRAMETIME / 4
 
-    short gameStatus;
-    short statusRequest;
+    GameStatus gameStatus;
+    GameStatus statusRequest;
     short pausePlayer;
 
     CAbstractActor *actorList;

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -1029,6 +1029,9 @@ void CNetManager::StopGame(short newStatus) {
     FrameNumber winFrame = 0;
 
     thePlayerManager = playerTable[slot];
+    if (newStatus == kAbortStatus) {
+        thePlayerManager->RemoveFromGame();
+    }
 
     SDL_Log("CNetManager::StopGame(%d)\n", newStatus);
     isPlaying = false;

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -72,6 +72,7 @@ public:
     virtual short Slot() = 0;
     virtual void SetLocal() = 0;
     virtual void AbortRequest() = 0;
+    virtual void RemoveFromGame() = 0;
     virtual Boolean IsLocalPlayer() = 0;
     virtual bool CalculateIsLocalPlayer() = 0;
 
@@ -251,6 +252,7 @@ public:
     virtual Boolean IncarnateInAnyColor();
 
     virtual void AbortRequest();
+    virtual void RemoveFromGame();
 
     virtual void DeadOrDone();
 

--- a/src/net/CCommManager.cpp
+++ b/src/net/CCommManager.cpp
@@ -12,6 +12,7 @@
 #include "Memory.h"
 #include "Resource.h"
 #include "System.h"
+#include "Debug.h"
 
 #include <SDL2/SDL.h>
 
@@ -210,6 +211,7 @@ PacketInfo* CCommManager::GetPacket() {
             Dequeue((QElemPtr)thePacket, &freeQ);
             break;
         } else {
+            DBG_Log("q", "CCommManager::GetPacket myId=%d, allocating %d more packets, inQ size = %zu\n", myId, FRESHALLOCSIZE, QueueSize(&inQ));
             // no packets left? dynamically increase the freeQ then try again
             AllocatePacketBuffers(FRESHALLOCSIZE);
         }

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -237,6 +237,7 @@ Boolean CProtoControl::PacketHandler(PacketInfo *thePacket) {
             */
 
         case kpRemoveMeFromGame:
+            SDL_Log("kpRemoveFromGame: removing player %d\n", thePacket->sender);
             theNet->activePlayersDistribution &= ~(1 << thePacket->sender);
             break;
 

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -14,6 +14,7 @@
 #include "CAvaraGame.h"  // gCurrentGame->fpsScale
 #include "CApplication.h"  // gApplication
 #include "Debug.h"
+#include "System.h"
 
 #include <SDL2/SDL.h>
 
@@ -285,7 +286,10 @@ UDPPacketInfo *CUDPConnection::FindBestPacket(int32_t curTime, int32_t cramTime,
     }
 
     if (transmitQueueLength > kMaxTransmitQueueLength) {
-        SDL_Log("Transmit Queue Overflow\n");
+        DBG_Log("q", "Transmit Queue Overflow - myId = %d\n", myId);
+        for (int i = 0; i < kQueueCount; i++) {
+            DBG_Log("q", "   Queue[%d] size = %zu\n", i, QueueSize(&queues[i]));
+        }
         ErrorKill();
     }
 

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -45,6 +45,7 @@ public:
     virtual short Slot() { return 0; }
     virtual void SetLocal() {};
     virtual void AbortRequest() {}
+    virtual void RemoveFromGame() {}
     virtual Boolean IsLocalPlayer() { return true; }
     virtual Boolean CalculateIsLocalPlayer() { return true; }
     virtual void GameKeyPress(char c) {}
@@ -1156,7 +1157,7 @@ TEST(SERIAL_NUMBER, Rollover) {
 
 TEST(QUEUES, Clean) {
     // after all of the tests have run, the queues should be all cleaned up suggesting all destructors did their job
-    ASSERT_EQ(QueueSize(), 0)  << "queues not empty";
+    ASSERT_EQ(QueueCount(), 0)  << "queues not empty";
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
If a spectator aborts either manually or automatically, they will send the kpRemoveMeFromGame packet.  This removes the aborted player from the activeDistribution list which means that the active players will stop trying to send them game packets.