### PR TITLE
ask for some re-send packets a little faster

### DIFF
--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -556,21 +556,20 @@ void CNetManager::LevelLoadStatus(short senderSlot, short crc, OSErr err, std::s
 Boolean CNetManager::GatherPlayers(Boolean isFreshMission) {
     short i;
     Boolean goAhead;
-    long lastTime, debugTime;
+    long lastTime, resendTime;
 
     totalDistribution = 0;
     for (i = 0; i < kMaxAvaraPlayers; i++) {
         playerTable[i]->ResumeGame();
     }
 
-    // itsCommManager->SendUrgentPacket(kdEveryone, kpFastTrack, 0, 0, fastTrack.addr.value, 0,0);
-    SDL_Log("CNetManager::GatherPlayers activePlayersDistribution = 0x%02x\n", activePlayersDistribution);
-    itsCommManager->SendUrgentPacket(activePlayersDistribution, kpReadySynch, 0, 0, 0, 0, 0);
-    lastTime = debugTime = TickCount();
+    lastTime = resendTime = TickCount();
     do {
-        if (TickCount() > debugTime) {
+        if (TickCount() > resendTime) {
             SDL_Log("CNetManager::GatherPlayers loop\n");
-            debugTime = TickCount() + MSEC_TO_TICK_COUNT(1000);
+            resendTime = TickCount() + MSEC_TO_TICK_COUNT(1000);
+            SDL_Log("CNetManager::GatherPlayers sending kpReadySynch to 0x%02x\n", activePlayersDistribution);
+            itsCommManager->SendUrgentPacket(activePlayersDistribution, kpReadySynch, 0, 0, 0, 0, 0);
         }
         ProcessQueue();
         goAhead = (TickCount() - lastTime < 1800);

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -544,7 +544,8 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
         itsGame->didWait = true;
 
         if (frameFuncs[(FUNCTIONBUFFERS - 1) & (i + 1)].validFrame < itsGame->frameNumber) {
-            askAgainTime += 5 + (rand() & 3);  // 5-8 ticks = 83-133ms = 5.2-8.3 frames
+            // if next frame hasn't arrived yet, don't ask for resend on this one RIGHT away
+            askAgainTime += 2 + (rand() & 3);  // 2-5 ticks = 33-83ms = 2.1-5.2 frames (16ms)
         }
 
         do {


### PR DESCRIPTION
When the next frame isn't here yet, you wait a little bit but the previous wait seems a bit too much for a 16ms frame.  I reduced it a bit and this seems a little better.  It might make the game feel a little smoother when the spikes hit?  Hard to know for sure.