### PR TITLE
Gather players rewrite

### DIFF
--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -7,6 +7,7 @@
     Modified: Tuesday, September 17, 1996, 03:21
 */
 #include <algorithm> // std::max
+#include <bitset>
 
 #include "CNetManager.h"
 

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -161,7 +161,7 @@ public:
 
     virtual void SendResumeCommand(int16_t originalSender = 0);
     virtual void ReceiveResumeCommand(short activeDistribution, short fromSlot, Fixed randomKey, int16_t originalSender);
-    virtual void ReceiveReady(short slot, uint32_t readyPlayers);
+    virtual void ReceiveReady(short slot, uint32_t readyPlayers, bool resendOurs);
 
     virtual void ReceivePlayerStatus(short slotId, LoadingState newStatus, PresenceType newPresence, Fixed randomKey, FrameNumber winFrame);
     virtual void ReceiveJSON(short slotId, Fixed randomKey, FrameNumber winFrame, std::string json);

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -78,11 +78,11 @@ public:
     int8_t slotToPosition[kMaxAvaraPlayers];
     int8_t positionToSlot[kMaxAvaraPlayers];
 
-    short activePlayersDistribution;
-    short readyPlayers;
-    short unavailablePlayers;
-    short startPlayersDistribution;
-    short totalDistribution;
+    uint16_t activePlayersDistribution;
+    uint16_t readyPlayers;
+    uint16_t readyPlayersConsensus;
+    uint16_t startPlayersDistribution;
+    uint16_t totalDistribution;
     short netStatus;
     CDirectObject *netOwner;
     short deadOrDonePlayers;
@@ -161,7 +161,7 @@ public:
 
     virtual void SendResumeCommand(int16_t originalSender = 0);
     virtual void ReceiveResumeCommand(short activeDistribution, short fromSlot, Fixed randomKey, int16_t originalSender);
-    virtual void ReceivedUnavailable(short slot, short fromSlot);
+    virtual void ReceiveReady(short slot, uint32_t readyPlayers);
 
     virtual void ReceivePlayerStatus(short slotId, LoadingState newStatus, PresenceType newPresence, Fixed randomKey, FrameNumber winFrame);
     virtual void ReceiveJSON(short slotId, Fixed randomKey, FrameNumber winFrame, std::string json);

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -114,7 +114,7 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             theNet->ReceiveResumeCommand(thePacket->p2, thePacket->sender, thePacket->p3, thePacket->p1);
             break;
         case kpReadySynch:
-            theNet->ReceiveReady(thePacket->sender, theNet->readyPlayers);
+            theNet->ReceiveReady(thePacket->sender, theNet->readyPlayers, thePacket->p1);
             break;
         case kpStartSynch:
             theNet->ConfigPlayer(thePacket->sender, thePacket->dataBuffer);

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -114,14 +114,7 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             theNet->ReceiveResumeCommand(thePacket->p2, thePacket->sender, thePacket->p3, thePacket->p1);
             break;
         case kpReadySynch:
-            theNet->readyPlayers |= 1 << thePacket->sender;
-            SDL_Log("--- readyPlayers = 0x%02x\n", theNet->readyPlayers);
-            break;
-        case kpUnavailableSynch:
-            theNet->ReceivedUnavailable(thePacket->sender, thePacket->p1);
-            break;
-        case kpUnavailableZero:
-            theNet->unavailablePlayers = 0;
+            theNet->ReceiveReady(thePacket->sender, theNet->readyPlayers);
             break;
         case kpStartSynch:
             theNet->ConfigPlayer(thePacket->sender, thePacket->dataBuffer);

--- a/src/net/CommDefs.h
+++ b/src/net/CommDefs.h
@@ -43,8 +43,8 @@ enum {
     kpResumeLevel, // 12
 
     kpReadySynch, // 13
-    kpUnavailableSynch, // 14
-    kpUnavailableZero, // 15
+    kpUnavailableSynch, // 14 (unused)
+    kpUnavailableZero, // 15 (unused)
     kpStartSynch, // 16
 
     kpKeyAndMouse, // 17


### PR DESCRIPTION
Trying to make GatherPlayers more robust and able to start a game with a subset of players
if not all players respond with "ready".

This eliminates the 30-second GatherPlayers loop of death and will instead, worst case, end after 5 seconds and start a game if there is a majority of players who agree on what players are actually "ready" to play.
