### PR TITLE
Don't call 'SDL_HINT_MOUSE_RELATIVE_MODE_WARP' in Windows to fix mouse control issues.

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -801,9 +801,12 @@ void CAvaraGame::GameStart() {
 
     // SDL_ShowCursor(SDL_DISABLE);
     // SDL_CaptureMouse(SDL_TRUE);
-    SDL_SetRelativeMouseMode(SDL_TRUE);
-    SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "1");
 
+    SDL_SetRelativeMouseMode(SDL_TRUE);
+#ifdef _WIN32
+#else
+    SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "1");
+#endif
     // HideCursor();
     // FlushEvents(everyEvent, 0);
 

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -803,7 +803,7 @@ void CAvaraGame::GameStart() {
     // SDL_CaptureMouse(SDL_TRUE);
 
     SDL_SetRelativeMouseMode(SDL_TRUE);
-#ifdef _WIN32
+#ifdef WIN32
 #else
     SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "1");
 #endif


### PR DESCRIPTION
SDL_HINT_MOUSE_RELATIVE_MODE_WARP was causing raw mouse motion inputs to be larger after a game pause. Not calling this line in Windows means mouse movements before and after a game pause are the same.

This will attempt to resolve https://github.com/avaraline/Avara/issues/276