### PR TITLE
Add indicators for player ready/waiting status as well as ping display in bottom right HUD.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ The following people have contributed to this port:
 * Eric Blenkush <@blenkush> - user interface, spectator mode, scoreboard, bug fixes
 * Tom Anderson <@tra> - critical networking fixes and updates
 * Jack Carlson <@JackCarlson> - user interface, bug fixes, playtesting
+* Ben Darling <@Ymihere03> - user interface, bug fixes, playtesting

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -383,7 +383,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
           case kLActive:
             // Ping Indicator
             NVGcolor pingColor;
-            if (rtt != 0) { // Don't draw ping for yourself
+            if (rtt != 0 && thisPlayer->Presence() != kzSpectating) { // Don't draw ping for yourself or spectators
               if (rtt < 100) {
                 pingColor = ColorManager::getPingColor(0).IntoNVG();
                 colorBoxHeight = 2;

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -379,25 +379,27 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
             nvgStroke(ctx);
             nvgClosePath(ctx);
             break;
-        }
 
-        // Ping Indicator
-        NVGcolor pingColor;
-        if (rtt != 0 && !thisPlayer->IsAway()) { // Don't draw indicator if player is you or they are away
-          if (rtt < 100) {
-            pingColor = ColorManager::getPingColor(0).IntoNVG();
-            colorBoxHeight = 2;
-          } else if (rtt <= 200) {
-            pingColor = ColorManager::getPingColor(1).IntoNVG();
-            colorBoxHeight = 6;
-          } else if (rtt > 200) {
-            pingColor = ColorManager::getPingColor(2).IntoNVG();
-            colorBoxHeight = 10;
-          }
-          nvgBeginPath(ctx);
-          nvgRect(ctx, bufferWidth - 147, pY + (10 - colorBoxHeight), 3, colorBoxHeight);
-          nvgFillColor(ctx, pingColor);
-          nvgFill(ctx);
+          case kLActive:
+            // Ping Indicator
+            NVGcolor pingColor;
+            if (rtt != 0) { // Don't draw ping for yourself
+              if (rtt < 100) {
+                pingColor = ColorManager::getPingColor(0).IntoNVG();
+                colorBoxHeight = 2;
+              } else if (rtt <= 200) {
+                pingColor = ColorManager::getPingColor(1).IntoNVG();
+                colorBoxHeight = 6;
+              } else if (rtt > 200) {
+                pingColor = ColorManager::getPingColor(2).IntoNVG();
+                colorBoxHeight = 10;
+              }
+              nvgBeginPath(ctx);
+              nvgRect(ctx, bufferWidth - 147, pY + (10 - colorBoxHeight), 3, colorBoxHeight);
+              nvgFillColor(ctx, pingColor);
+              nvgFill(ctx);
+            }
+            break;
         }
 
         //player name

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -383,14 +383,14 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
 
         // Ping Indicator
         NVGcolor pingColor;
-        if (rtt != 0) { // Don't draw indicator if player is you
+        if (rtt != 0 || thisPlayer->IsAway()) { // Don't draw indicator if player is you or they are away
           if (rtt < 100) {
             pingColor = ColorManager::getPingColor(0).IntoNVG();
             colorBoxHeight = 2;
-          } else if (rtt < 200) {
+          } else if (rtt <= 200) {
             pingColor = ColorManager::getPingColor(1).IntoNVG();
             colorBoxHeight = 6;
-          } else if (rtt < 300) {
+          } else if (rtt > 200) {
             pingColor = ColorManager::getPingColor(2).IntoNVG();
             colorBoxHeight = 10;
           }

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -383,7 +383,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
 
         // Ping Indicator
         NVGcolor pingColor;
-        if (rtt != 0 || thisPlayer->IsAway()) { // Don't draw indicator if player is you or they are away
+        if (rtt != 0 && !thisPlayer->IsAway()) { // Don't draw indicator if player is you or they are away
           if (rtt < 100) {
             pingColor = ColorManager::getPingColor(0).IntoNVG();
             colorBoxHeight = 2;

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -266,7 +266,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
         }
     }
     int playerSlots = std::max(6, lastPlayerSlot + 1);
-
+    
     int bufferWidth = view->viewPixelDimensions.h, bufferHeight = view->viewPixelDimensions.v;
     int chudHeight = 13 * playerSlots;
 

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -266,7 +266,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
         }
     }
     int playerSlots = std::max(6, lastPlayerSlot + 1);
-    
+
     int bufferWidth = view->viewPixelDimensions.h, bufferHeight = view->viewPixelDimensions.v;
     int chudHeight = 13 * playerSlots;
 
@@ -316,6 +316,13 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
         CPlayerManager *thisPlayer = net->playerTable[i];
         std::string playerName((char *)thisPlayer->PlayerName() + 1, thisPlayer->PlayerName()[0]);
         if (playerName.length() < 1) continue;
+
+        // Get player RTT
+        long rtt = 0;
+        if (i != net->itsCommManager->myId && playerName.length() > 0) {
+            rtt = net->itsCommManager->GetMaxRoundTrip(1 << i);
+        }
+
         pY = (bufferHeight - chudHeight + 8) + (11 * i);
         longTeamColor = *ColorManager::getTeamColor(net->teamColors[i] + 1);
         longTeamColor.ExportGLFloats(teamColorRGB, 3);
@@ -334,6 +341,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
 
         //player color box
         float colorBoxWidth = 10.0;
+        float colorBoxHeight = 10.0;
         nvgBeginPath(ctx);
 
         //highlight player if spectating
@@ -342,15 +350,61 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
             colorBoxWidth = 150.0;
         }
 
-        nvgRect(ctx, bufferWidth - 160, pY, colorBoxWidth, 10.0);
+        nvgRect(ctx, bufferWidth - 160, pY, colorBoxWidth, colorBoxHeight);
         nvgFillColor(ctx, nvgRGBAf(teamColorRGB[0], teamColorRGB[1], teamColorRGB[2], colorBoxAlpha));
         nvgFill(ctx);
+
+        // draw something based on the player status
+        switch (thisPlayer->LoadingStatus()) {
+          // Draw a dot
+          case kLReady:
+            nvgBeginPath(ctx);
+            nvgCircle(ctx, bufferWidth - 155, pY + (colorBoxHeight / 2), 3.0);
+            nvgFillColor(ctx, nvgRGBAf(0, 0, 0, 255));
+            nvgFill(ctx);
+
+            nvgBeginPath(ctx);
+            nvgCircle(ctx, bufferWidth - 155, pY + (colorBoxHeight / 2), 2.0);
+            nvgFillColor(ctx, nvgRGBAf(255, 255, 255, 255));
+            nvgFill(ctx);
+            break;
+
+          // Draw a slash
+          case kLWaiting:
+            nvgBeginPath(ctx);
+            nvgMoveTo(ctx, bufferWidth - 150, pY);
+            nvgLineTo(ctx, bufferWidth - 160, pY + colorBoxHeight);
+            nvgStrokeColor(ctx, nvgRGBAf(0, 0, 0, 255));
+            nvgStrokeWidth(ctx, 1);
+            nvgStroke(ctx);
+            nvgClosePath(ctx);
+            break;
+        }
+
+        // Ping Indicator
+        NVGcolor pingColor;
+        if (rtt != 0) { // Don't draw indicator if player is you
+          if (rtt < 100) {
+            pingColor = ColorManager::getPingColor(0).IntoNVG();
+            colorBoxHeight = 2;
+          } else if (rtt < 200) {
+            pingColor = ColorManager::getPingColor(1).IntoNVG();
+            colorBoxHeight = 6;
+          } else if (rtt < 300) {
+            pingColor = ColorManager::getPingColor(2).IntoNVG();
+            colorBoxHeight = 10;
+          }
+          nvgBeginPath(ctx);
+          nvgRect(ctx, bufferWidth - 147, pY + (10 - colorBoxHeight), 3, colorBoxHeight);
+          nvgFillColor(ctx, pingColor);
+          nvgFill(ctx);
+        }
 
         //player name
         nvgFillColor(ctx, textColor);
         nvgTextAlign(ctx, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
         nvgFontSize(ctx, fontsz_m);
-        nvgText(ctx, bufferWidth - 148, pY - 3, playerName.c_str(), NULL);
+        nvgText(ctx, bufferWidth - 141, pY - 2, playerName.c_str(), NULL);
 
         short status = thisPlayer->GetStatusChar();
         if (status >= 0) {
@@ -370,7 +424,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
         nvgTextAlign(ctx, NVG_ALIGN_RIGHT | NVG_ALIGN_TOP);
         nvgFontSize(ctx, fontsz_m);
         nvgFillColor(ctx, nvgRGBA(255, 255, 255, 255));
-        nvgText(ctx, bufferWidth - 168, pY - 3, playerChat.c_str(), NULL);
+        nvgText(ctx, bufferWidth - 168, pY - 2, playerChat.c_str(), NULL);
 
         //spectating onscreen name
         if(spectatePlayer != NULL && thisPlayer->GetPlayer() == spectatePlayer) {

--- a/src/gui/ColorManager.cpp
+++ b/src/gui/ColorManager.cpp
@@ -69,6 +69,12 @@ ARGBColor ColorManager::messageColors[3] = {
     0xffff8185
 };
 
+ARGBColor ColorManager::pingColors[3] = {
+    0xff2eff2e,
+    0xffffee2e,
+    0xffff382e
+};
+
 void ColorManager::setColorBlind(ColorBlindMode mode) {
     switch (mode) {
         case Off:
@@ -113,6 +119,9 @@ void ColorManager::setColorBlind(ColorBlindMode mode) {
             ColorManager::messageColors[0] = 0xffffffff;
             ColorManager::messageColors[1] = 0xff92ebe9;
             ColorManager::messageColors[2] = 0xffff8185;
+            ColorManager::pingColors[0] = 0xff2eff2e;
+            ColorManager::pingColors[1] = 0xffffee2e;
+            ColorManager::pingColors[2] = 0xffff382e;
             break;
         case Deuteranopia:
             ColorManager::energyGaugeColor = 0xff009ea0;

--- a/src/gui/ColorManager.h
+++ b/src/gui/ColorManager.h
@@ -150,6 +150,10 @@ public:
         return color;
     }
 
+    static inline ARGBColor getPingColor(uint8_t num) {
+      return pingColors[num];
+    }
+
     static inline float getHudAlpha() {
         return hudAlpha;
     }
@@ -190,4 +194,5 @@ private:
     static ARGBColor teamTextColors[kMaxTeamColors + 1];
     static std::string teamColorNames[kMaxTeamColors + 1];
     static ARGBColor messageColors[3];
+    static ARGBColor pingColors[3];
 };


### PR DESCRIPTION
Changes based on recommendations in https://github.com/avaraline/Avara/issues/222
I would suggest decoupling the waiting on network loop be a separate task due to complexity.

Screenshots of the added UI elements:
Draw a slash for each user with the waiting status (waiting on network)
![image](https://user-images.githubusercontent.com/1258387/222825242-cd85a6e1-10c5-463f-bb00-a0c79dbdb07c.png)

Draw a dot for each user with the ready status
![image](https://user-images.githubusercontent.com/1258387/222825304-b3062ece-4fc9-4b1e-9620-d6e504fb5c74.png)

Added a ping indicator next to active players
* <100ms: small/green
* 100-200ms: medium/yellow
* \>200ms: large/red
* No indicator shown for yourself
![image](https://user-images.githubusercontent.com/1258387/222824326-a63a340a-d418-4734-9273-3582e40f323e.png)

Also moved UI elements in the name list by a few pixels for better alignment.

