### PR TITLE
fix GatherPlayers loop

### DIFF
--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -578,8 +578,8 @@ Boolean CNetManager::GatherPlayers(Boolean isFreshMission) {
            currentTime < timeLimit) {
         if (currentTime >= resendTime) {
             uint16_t distrib = activePlayersDistribution & ~readyPlayersConsensus;
-            bool resendYours = readyPlayersConsensus == 0 && readyPlayers != 0;
 //#define DONT_SEND_FIRST_READY  // debug what happens when slot 0 doesn't get packet from slot 1
+            bool resendYours = readyPlayersConsensus != readyPlayers;
 #ifdef DONT_SEND_FIRST_READY
             if (itsCommManager->myId == 1 && loopCount == 0) {
                 distrib &= ~1; // don't send kpReadySynch from player 2 to player 1
@@ -644,8 +644,8 @@ void CNetManager::ReceiveReady(short senderSlot, uint32_t senderReadyPlayers, bo
         // reset consensus so we send our updated readyPlayers mask to everyone on next loop iteration
         readyPlayersConsensus = 0;
     } else {
-        if (senderReadyPlayers == readyPlayers) {
-            // which players have the same value for readyPlayers as me
+        if (senderReadyPlayers == activePlayersDistribution) {
+            // which players have heard from all other active players
             readyPlayersConsensus |= senderBit;
         }
     }

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -161,7 +161,7 @@ public:
 
     virtual void SendResumeCommand(int16_t originalSender = 0);
     virtual void ReceiveResumeCommand(short activeDistribution, short fromSlot, Fixed randomKey, int16_t originalSender);
-    virtual void ReceiveReady(short slot, uint32_t readyPlayers, bool resendOurs);
+    virtual void ReceiveReady(short slot, uint32_t readyPlayers);
 
     virtual void ReceivePlayerStatus(short slotId, LoadingState newStatus, PresenceType newPresence, Fixed randomKey, FrameNumber winFrame);
     virtual void ReceiveJSON(short slotId, Fixed randomKey, FrameNumber winFrame, std::string json);

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -173,7 +173,7 @@ public:
     virtual bool IAmAlive();
 
     //	Game loop methods:
-
+    size_t SkipLostPackets(int16_t dist);
     virtual Boolean GatherPlayers(Boolean isFreshMission);
     virtual void UngatherPlayers();
 

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -512,20 +512,10 @@ void CPlayerManagerImpl::Dispose() {
 }
 
 void CPlayerManagerImpl::SendResendRequest(short askCount) {
-#if DONT_SEND_FRAME > 0
-#else
     if (/* theNetManager->fastTrack.addr.value || */ askCount >= 0) {
         theNetManager->playerTable[theNetManager->itsCommManager->myId]->ResendFrame(
             itsGame->frameNumber, slot, kpKeyAndMouseRequest);
     }
-#endif
-}
-
-size_t CPlayerManagerImpl::SkipLostPackets() {
-    CUDPComm* theComm = dynamic_cast<CUDPComm*>(theNetManager->itsCommManager.get());
-    size_t remaining = theComm->SkipLostPackets(slot);
-    DBG_Log("q", "SkipLostPackets: remaining on queue[%d] = %zu", slot, remaining);
-    return remaining;
 }
 
 FunctionTable *CPlayerManagerImpl::GetFunctions() {
@@ -569,7 +559,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
 //                Debug::Toggle("nq");
                 // if we get the packet from the Resend above, it might be stuck on the end of the readQ waiting for
                 // a packet that is lost, so skip 1 lost packet at a time until it frees up the queue again
-                SkipLostPackets();
+                theNetManager->SkipLostPackets(1 << slot);
 
                 askAgainTime = quickTick + ASK_INTERVAL;
 

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -223,7 +223,6 @@ public:
 
     virtual FunctionTable *GetFunctions();
     virtual void SendResendRequest(short askCount);
-    virtual size_t SkipLostPackets();
 
     virtual void Dispose();
 

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -114,7 +114,7 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             theNet->ReceiveResumeCommand(thePacket->p2, thePacket->sender, thePacket->p3, thePacket->p1);
             break;
         case kpReadySynch:
-            theNet->ReceiveReady(thePacket->sender, theNet->readyPlayers, thePacket->p1);
+            theNet->ReceiveReady(thePacket->sender, thePacket->p2, thePacket->p1);
             break;
         case kpStartSynch:
             theNet->ConfigPlayer(thePacket->sender, thePacket->dataBuffer);

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -114,7 +114,7 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             theNet->ReceiveResumeCommand(thePacket->p2, thePacket->sender, thePacket->p3, thePacket->p1);
             break;
         case kpReadySynch:
-            theNet->ReceiveReady(thePacket->sender, thePacket->p2, thePacket->p1);
+            theNet->ReceiveReady(thePacket->sender, thePacket->p2);
             break;
         case kpStartSynch:
             theNet->ConfigPlayer(thePacket->sender, thePacket->dataBuffer);

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -811,13 +811,14 @@ void CUDPComm::ReceivedGoodPacket(PacketInfo *thePacket) {
         DispatchAndReleasePacket(thePacket);
 }
 
-size_t CUDPComm::SkipLostPackets(int slot) {
+size_t CUDPComm::SkipLostPackets(int16_t dist) {
+    size_t sumRecvQs = 0;
     for (CUDPConnection *conn = connections; conn; conn = conn->next) {
-        if (conn->myId == slot) {
-            return conn->ReceivedPacket(nullptr);
+        if ((1 << conn->myId) & dist) {
+            sumRecvQs += conn->ReceivedPacket(nullptr);
         }
     }
-    return 0;
+    return sumRecvQs;
 }
 
 void CUDPComm::WriteComplete(int result) {

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -129,7 +129,7 @@ public:
     virtual Boolean AsyncWrite();
 
     virtual void ReceivedGoodPacket(PacketInfo *thePacket);
-    virtual size_t SkipLostPackets(int slot);
+    virtual size_t SkipLostPackets(int16_t dist);
 
     virtual OSErr CreateStream(port_num streamPort);
 


### PR DESCRIPTION
Like the wait-for-frame loop, sometimes you need to skip lost packets in the readQueue and GatherPlayers wasn't doing that and could hang if it didn't get all the packets.

Also, build the consensus up based on who agrees with me instead of ANDing them together to avoid possible race condition where it breaks out of the loop based on consensus being equal to all active players.