### PR TITLE
Add new Presence Type for players we are waiting on. Use the new type for the waiting indicator.

### DIFF
--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -389,18 +389,18 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
               nvgFillColor(ctx, pingColor);
               nvgFill(ctx);
             }
+          break;
 
-            // Draw a slash
-            if (thisPlayer->Presence() == kzNetDelayed) {
-              nvgBeginPath(ctx);
-              nvgMoveTo(ctx, bufferWidth - 150, pY);
-              nvgLineTo(ctx, bufferWidth - 160, pY + colorBoxHeight);
-              nvgStrokeColor(ctx, nvgRGBAf(0, 0, 0, 255));
-              nvgStrokeWidth(ctx, 1);
-              nvgStroke(ctx);
-              nvgClosePath(ctx);
-            }
-            break;
+          // Draw a slash
+          case kLNetDelayed:
+            nvgBeginPath(ctx);
+            nvgMoveTo(ctx, bufferWidth - 150, pY);
+            nvgLineTo(ctx, bufferWidth - 160, pY + colorBoxHeight);
+            nvgStrokeColor(ctx, nvgRGBAf(0, 0, 0, 255));
+            nvgStrokeWidth(ctx, 1);
+            nvgStroke(ctx);
+            nvgClosePath(ctx);
+          break;
 
           default:
             break;

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -266,7 +266,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
         }
     }
     int playerSlots = std::max(6, lastPlayerSlot + 1);
-    
+
     int bufferWidth = view->viewPixelDimensions.h, bufferHeight = view->viewPixelDimensions.v;
     int chudHeight = 13 * playerSlots;
 
@@ -342,6 +342,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
         //player color box
         float colorBoxWidth = 10.0;
         float colorBoxHeight = 10.0;
+        float pingBarHeight = 0.0;
         nvgBeginPath(ctx);
 
         //highlight player if spectating
@@ -354,7 +355,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
         nvgFillColor(ctx, nvgRGBAf(teamColorRGB[0], teamColorRGB[1], teamColorRGB[2], colorBoxAlpha));
         nvgFill(ctx);
 
-        // draw something based on the player status
+        // draw something based on the loading status
         switch (thisPlayer->LoadingStatus()) {
           // Draw a dot
           case kLReady:
@@ -369,35 +370,35 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
             nvgFill(ctx);
             break;
 
-          // Draw a slash
-          case kLWaiting:
-            nvgBeginPath(ctx);
-            nvgMoveTo(ctx, bufferWidth - 150, pY);
-            nvgLineTo(ctx, bufferWidth - 160, pY + colorBoxHeight);
-            nvgStrokeColor(ctx, nvgRGBAf(0, 0, 0, 255));
-            nvgStrokeWidth(ctx, 1);
-            nvgStroke(ctx);
-            nvgClosePath(ctx);
-            break;
-
           case kLActive:
             // Ping Indicator
             NVGcolor pingColor;
             if (rtt != 0 && thisPlayer->Presence() != kzSpectating) { // Don't draw ping for yourself or spectators
-              if (rtt < 100) {
+              if (rtt < 100) {  // Green + Small
                 pingColor = ColorManager::getPingColor(0).IntoNVG();
-                colorBoxHeight = 2;
-              } else if (rtt <= 200) {
+                pingBarHeight = 2;
+              } else if (rtt <= 200) { // Yellow + Medium
                 pingColor = ColorManager::getPingColor(1).IntoNVG();
-                colorBoxHeight = 6;
-              } else if (rtt > 200) {
+                pingBarHeight = 6;
+              } else if (rtt > 200) { // Red + Large
                 pingColor = ColorManager::getPingColor(2).IntoNVG();
-                colorBoxHeight = 10;
+                pingBarHeight = 10;
               }
               nvgBeginPath(ctx);
-              nvgRect(ctx, bufferWidth - 147, pY + (10 - colorBoxHeight), 3, colorBoxHeight);
+              nvgRect(ctx, bufferWidth - 147, pY + (10 - pingBarHeight), 3, pingBarHeight);
               nvgFillColor(ctx, pingColor);
               nvgFill(ctx);
+            }
+
+            // Draw a slash
+            if (thisPlayer->Presence() == kzNetDelayed) {
+              nvgBeginPath(ctx);
+              nvgMoveTo(ctx, bufferWidth - 150, pY);
+              nvgLineTo(ctx, bufferWidth - 160, pY + colorBoxHeight);
+              nvgStrokeColor(ctx, nvgRGBAf(0, 0, 0, 255));
+              nvgStrokeWidth(ctx, 1);
+              nvgStroke(ctx);
+              nvgClosePath(ctx);
             }
             break;
 

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -529,7 +529,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
         long firstTime = askAgainTime = TickCount();
         long quickTick = firstTime;
         short askCount = 0;
-        PresenceType oldPresc;
+        LoadingState oldStatus;
 
         itsGame->didWait = true;
 
@@ -564,9 +564,9 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
                 askAgainTime = quickTick + ASK_INTERVAL;
 
                 if (askCount == WAITING_MESSAGE_COUNT) {
-                    oldPresc = presence;
                     SDL_Log("Waiting for '%s' to resend frame #%u\n", GetPlayerName().c_str(), itsGame->frameNumber);
-                    presence = kzNetDelayed;
+                    oldStatus = loadingStatus;
+                    loadingStatus = kLNetDelayed;
                     itsGame->itsApp->ParamLine(kmWaitingForPlayer, MsgAlignment::Center, playerName);
                     itsGame->itsApp->RenderContents();  // force render now so message shows up
                     // TODO: waiting for player dialog
@@ -599,7 +599,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
         if (askCount >= WAITING_MESSAGE_COUNT && frameFuncs[i].validFrame == itsGame->frameNumber) {
             gApplication->BroadcastCommand(kBusyEndCmd);
             itsGame->itsApp->AddMessageLine("...resuming game", MsgAlignment::Center);
-            presence = oldPresc;
+            loadingStatus = oldStatus;
             // HideCursor();
         }
 

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -529,6 +529,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
         long firstTime = askAgainTime = TickCount();
         long quickTick = firstTime;
         short askCount = 0;
+        PresenceType oldPresc;
 
         itsGame->didWait = true;
 
@@ -563,7 +564,9 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
                 askAgainTime = quickTick + ASK_INTERVAL;
 
                 if (askCount == WAITING_MESSAGE_COUNT) {
+                    oldPresc = presence;
                     SDL_Log("Waiting for '%s' to resend frame #%u\n", GetPlayerName().c_str(), itsGame->frameNumber);
+                    presence = kzNetDelayed;
                     itsGame->itsApp->ParamLine(kmWaitingForPlayer, MsgAlignment::Center, playerName);
                     itsGame->itsApp->RenderContents();  // force render now so message shows up
                     // TODO: waiting for player dialog
@@ -596,6 +599,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
         if (askCount >= WAITING_MESSAGE_COUNT && frameFuncs[i].validFrame == itsGame->frameNumber) {
             gApplication->BroadcastCommand(kBusyEndCmd);
             itsGame->itsApp->AddMessageLine("...resuming game", MsgAlignment::Center);
+            presence = oldPresc;
             // HideCursor();
         }
 

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -29,6 +29,7 @@ enum LoadingState {
     kLNotFound,
     kLPaused,
     kLNoVehicle,
+    kLNetDelayed,
 //    kLAway,
 //    kLSpectating,
     kLReady,    // implies kLLoaded, i.e. Loaded & Ready to start
@@ -43,8 +44,7 @@ enum PresenceType {
     kzUnknown,
     kzAvailable,
     kzSpectating,
-    kzAway,
-    kzNetDelayed
+    kzAway
 };
 
 #define FUNCTIONBUFFERS 64*8  // 512 frames at 16ms/frame = 8.192s rollover time

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -43,7 +43,8 @@ enum PresenceType {
     kzUnknown,
     kzAvailable,
     kzSpectating,
-    kzAway
+    kzAway,
+    kzNetDelayed
 };
 
 #define FUNCTIONBUFFERS 64*8  // 512 frames at 16ms/frame = 8.192s rollover time


### PR DESCRIPTION
Slash indicator wasn't showing when waiting on players during a game because the indicator referenced a LoadingStatus value that is used for a completely different purpose.

I created a new presence type for this scenario to use for the waiting indicator. Presence is set back to the old value after the player regains connection. This will make the waiting indicator display properly.