### PR TITLE
GatherPlayers fixes, this time with more feeling

### DIFF
--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -567,6 +567,9 @@ Boolean CNetManager::GatherPlayers(Boolean isFreshMission) {
         playerTable[i]->ResumeGame();
     }
 
+    readyPlayers = 0;
+    readyPlayersConsensus = 0;
+
     Boolean goAhead = false;
     uint64_t currentTime = TickCount();
     int loopCount = 0;


### PR DESCRIPTION
initializing readyPlayers variables before the loop fixes problems with receiving message responses after the loop on the previous game.

also, don't skip lost packets too frequently because that can cause weird sh*t to happen by killing packets on or before frame zero.