### PR TITLE
Force team colors

### DIFF
--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -1303,6 +1303,10 @@ bool CAbstractPlayer::ReincarnateComplete(CIncarnator* newSpot) {
         return false;
     }
 
+    if (newSpot->colorMask != -1) {
+        didIncarnateMasked = true;
+    }
+
     return true;
 }
 

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -45,7 +45,7 @@ public:
     CAbstractPlayer *nextPlayer = 0;
     PlayerConfigRecord defaultConfig {};
 
-    ARGBColor longTeamColor = 0; // Hull color in 0x00RRGGBB format.
+    ARGBColor longTeamColor = 0;
 
     //	Shields & energy:
     Fixed energy = 0;
@@ -129,6 +129,7 @@ public:
     Boolean doIncarnateSound = 0;
     Boolean reEnergize = 0;
     Boolean didSelfDestruct = 0;
+    bool didIncarnateMasked = false;
 
     //	Winning/loosing:
     FrameNumber winFrame = 0;

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -46,6 +46,7 @@ public:
     PlayerConfigRecord defaultConfig {};
 
     ARGBColor longTeamColor = 0;
+    bool hasTeammates = false;
 
     //	Shields & energy:
     Fixed energy = 0;

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -1222,12 +1222,13 @@ void CNetManager::AttachPlayers(CAbstractPlayer *playerActorList) {
         short slot = positionToSlot[i];
         short teammateCount = 0;
         CPlayerManager *thePlayerMan = playerTable[slot];
-        if (thePlayerMan->GetPlayer()) {
+        if (thePlayerMan->Presence() == kzAvailable && thePlayerMan->GetPlayer()) {
             for (short j = 0; j < kMaxAvaraPlayers; j++) {
                 if (i != j) {
                     short otherSlot = positionToSlot[j];
                     CPlayerManager *otherPlayerMan = playerTable[otherSlot];
-                    if (otherPlayerMan->GetPlayer() &&
+                    if (otherPlayerMan->Presence() == kzAvailable &&
+                        otherPlayerMan->GetPlayer() &&
                         thePlayerMan->PlayerColor() == otherPlayerMan->PlayerColor()) {
                         teammateCount++;
                     }

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -1219,7 +1219,7 @@ void CNetManager::AttachPlayers(CAbstractPlayer *playerActorList) {
     }
 
     for (i = 0; i < kMaxAvaraPlayers; i++) {
-        if (playerTable[i]->GetPlayer()) {
+        if (playerTable[i]->GetPlayer() && !playerTable[i]->GetPlayer()->didIncarnateMasked) {
             playerTable[i]->SpecialColorControl();
         }
     }

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -1219,7 +1219,30 @@ void CNetManager::AttachPlayers(CAbstractPlayer *playerActorList) {
     }
 
     for (i = 0; i < kMaxAvaraPlayers; i++) {
-        if (playerTable[i]->GetPlayer() && !playerTable[i]->GetPlayer()->didIncarnateMasked) {
+        short slot = positionToSlot[i];
+        short teammateCount = 0;
+        CPlayerManager *thePlayerMan = playerTable[slot];
+        if (thePlayerMan->GetPlayer()) {
+            for (short j = 0; j < kMaxAvaraPlayers; j++) {
+                if (i != j) {
+                    short otherSlot = positionToSlot[j];
+                    CPlayerManager *otherPlayerMan = playerTable[otherSlot];
+                    if (otherPlayerMan->GetPlayer() &&
+                        thePlayerMan->PlayerColor() == otherPlayerMan->PlayerColor()) {
+                        teammateCount++;
+                    }
+                }
+            }
+            if (teammateCount > 0) {
+                thePlayerMan->GetPlayer()->hasTeammates = true;
+            }
+        }
+    }
+
+    for (i = 0; i < kMaxAvaraPlayers; i++) {
+        if (playerTable[i]->GetPlayer() &&
+            !playerTable[i]->GetPlayer()->didIncarnateMasked &&
+            !playerTable[i]->GetPlayer()->hasTeammates) {
             playerTable[i]->SpecialColorControl();
         }
     }

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -1013,6 +1013,7 @@ CAbstractPlayer *CPlayerManagerImpl::ChooseActor(CAbstractPlayer *actorList, sho
 
             itsPlayer = actorList;
             itsPlayer->itsManager = this;
+            itsPlayer->didIncarnateMasked = true;
             itsPlayer->PlayerWasMoved();
             itsPlayer->BuildPartProximityList(itsPlayer->location, itsPlayer->proximityRadius, kSolidBit);
             itsPlayer->AddToGame();


### PR DESCRIPTION
When a player starts a game, before allowing them to be black or white, try to guess if they are playing a team game. If they incarnate into a masked incarnator or walker, or have teammates, do _not_ allow them to be black or white.

If this proves to be an effective strategy, we will be able to retire the black & white HECTOR easter egg in favor of fully customizable hull colors, similar to what was just merged into main for cockpit and gun colors.