### PR TITLE
Reset zoom state when game ends

### DIFF
--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -180,6 +180,13 @@ void CAbstractPlayer::StartSystems() {
     classicMotorFriction = CLASSICMOTORFRICTION;
 }
 
+void CAbstractPlayer::LevelReset() {
+    fieldOfView = maxFOV;
+    AvaraGLSetFOV(ToFloat(fieldOfView));
+    RecalculateViewDistance();
+    CAbstractActor::LevelReset();
+}
+
 void CAbstractPlayer::LoadScout() {
     scoutCommand = kScoutNullCommand;
 
@@ -687,9 +694,6 @@ void CAbstractPlayer::ControlSoundPoint() {
 
 void CAbstractPlayer::ControlViewPoint() {
     CViewParameters *theView;
-    Fixed viewDist;
-    // CInfoPanel       *infoPanel;
-    Fixed frameYon;
 
     theView = itsGame->itsView;
 
@@ -719,6 +723,19 @@ void CAbstractPlayer::ControlViewPoint() {
         theView->inverseDone = false;
     }
 
+    RecalculateViewDistance();
+
+    // SetPort(itsGame->itsWindow);
+    ControlSoundPoint();
+}
+
+void CAbstractPlayer::RecalculateViewDistance() {
+    CViewParameters *theView;
+    Fixed viewDist;
+    Fixed frameYon;
+
+    theView = itsGame->itsView;
+
     viewDist = FMulDivNZ(theView->viewWidth, FDegCos(fieldOfView), 2 * FDegSin(fieldOfView));
 
     if (itsGame->yonList) {
@@ -735,9 +752,6 @@ void CAbstractPlayer::ControlViewPoint() {
         theView->Recalculate();
         theView->CalculateViewPyramidCorners();
     }
-
-    // SetPort(itsGame->itsWindow);
-    ControlSoundPoint();
 }
 
 void CAbstractPlayer::ReturnWeapon(short theKind) {
@@ -1225,7 +1239,11 @@ void CAbstractPlayer::PlayerAction() {
                     if (lives > 0) {
                         viewYaw = 0;
                         viewPitch = 0;
-                        fieldOfView = maxFOV;
+                        if (!scoutView) {
+                            fieldOfView = maxFOV;
+                            AvaraGLSetFOV(ToFloat(fieldOfView));
+                            RecalculateViewDistance();
+                        }
                         Reincarnate();
                     } else {
                         itsManager->DeadOrDone();

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -181,9 +181,7 @@ void CAbstractPlayer::StartSystems() {
 }
 
 void CAbstractPlayer::LevelReset() {
-    fieldOfView = maxFOV;
-    AvaraGLSetFOV(ToFloat(fieldOfView));
-    RecalculateViewDistance();
+    ResetCamera();
     CAbstractActor::LevelReset();
 }
 
@@ -754,6 +752,12 @@ void CAbstractPlayer::RecalculateViewDistance() {
     }
 }
 
+void CAbstractPlayer::ResetCamera() {
+    fieldOfView = maxFOV;
+    AvaraGLSetFOV(ToFloat(fieldOfView));
+    RecalculateViewDistance();
+}
+
 void CAbstractPlayer::ReturnWeapon(short theKind) {
     switch (theKind) {
         case kweSmart:
@@ -1240,9 +1244,7 @@ void CAbstractPlayer::PlayerAction() {
                         viewYaw = 0;
                         viewPitch = 0;
                         if (!scoutView) {
-                            fieldOfView = maxFOV;
-                            AvaraGLSetFOV(ToFloat(fieldOfView));
-                            RecalculateViewDistance();
+                            ResetCamera();
                         }
                         Reincarnate();
                     } else {

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -217,6 +217,7 @@ public:
     virtual void ControlSoundPoint();
     virtual void ControlViewPoint();
     virtual void RecalculateViewDistance();
+    virtual void ResetCamera();
 
     virtual short GetActorScoringId();
     virtual void PostMortemBlast(short scoreTeam, short scoreId, Boolean doDispose);

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -185,6 +185,7 @@ public:
     virtual void LoadParts();
     virtual void LoadScout();
     virtual void StartSystems();
+    virtual void LevelReset();
 
     virtual void Dispose();
     virtual void DisposeDashboard();
@@ -215,6 +216,7 @@ public:
     virtual void ResetDashboard();
     virtual void ControlSoundPoint();
     virtual void ControlViewPoint();
+    virtual void RecalculateViewDistance();
 
     virtual short GetActorScoringId();
     virtual void PostMortemBlast(short scoreTeam, short scoreId, Boolean doDispose);


### PR DESCRIPTION
Camera state is also reset when reincarnating, provided the player is not in scout view at the time.

Resolves #269.