### PR TITLE
reduce in-game ping and ping resends

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -863,8 +863,9 @@ bool CAvaraGame::GameTick() {
     itsNet->ProcessQueue();
 
     if (startTime > nextPingTime) {
-        static uint32_t pingInterval = 2000; // msec
-        itsNet->SendPingCommand(8);
+        // 3 pings every second, 1 ping used by each client for RTT calc (last ping not used)
+        static uint32_t pingInterval = 1000; // msec
+        itsNet->SendPingCommand(3);
         nextPingTime = startTime + pingInterval;
     }
 

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -926,12 +926,13 @@ void CNetManager::ViewControl() {
 void CNetManager::SendPingCommand(int trips) {
     // there & back = 2 trips... send less to/from players in game
     int notMe = totalDistribution & ~(1 << itsCommManager->myId);
+    int playingDist = (itsGame->gameStatus == kPlayingStatus) ? activePlayersDistribution : 0;
     // only send 1-way pings to/from active players just to keep the connection alive
     int activeTrips = 1;
     int inactiveTrips = isPlaying ? activeTrips : trips;
-    itsCommManager->SendPacket(activePlayersDistribution & notMe,
+    itsCommManager->SendPacket(playingDist & notMe,
                                kpPing, 0, 0, activeTrips-1, 0, NULL);
-    itsCommManager->SendPacket(~activePlayersDistribution & notMe,
+    itsCommManager->SendPacket(~playingDist & notMe,
                                kpPing, 0, 0, inactiveTrips-1, 0, NULL);
 }
 

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -561,7 +561,6 @@ size_t CNetManager::SkipLostPackets(int16_t dist) {
 }
 
 Boolean CNetManager::GatherPlayers(Boolean isFreshMission) {
-    totalDistribution = 0;
     for (int i = 0; i < kMaxAvaraPlayers; i++) {
         // reset frame buffers
         playerTable[i]->ResumeGame();
@@ -926,8 +925,9 @@ void CNetManager::ViewControl() {
 
 void CNetManager::SendPingCommand(int trips) {
     // there & back = 2 trips... send less to/from players in game
-    int notMe = ~(1 << itsCommManager->myId);
-    int activeTrips = 2;
+    int notMe = totalDistribution & ~(1 << itsCommManager->myId);
+    // only send 1-way pings to/from active players just to keep the connection alive
+    int activeTrips = 1;
     int inactiveTrips = isPlaying ? activeTrips : trips;
     itsCommManager->SendPacket(activePlayersDistribution & notMe,
                                kpPing, 0, 0, activeTrips-1, 0, NULL);


### PR DESCRIPTION
Simply changing ping trips from 2 to 1 for active players dramatically reduced the number of total kpPing messages sent because of overly aggressive resend logic.  We don't really need that much pinging for players in game because game packets should keep the connection open so this should only help with game play.