### PR TITLE
don't eval scripts twice

### DIFF
--- a/src/level/LevelLoader.cpp
+++ b/src/level/LevelLoader.cpp
@@ -112,9 +112,6 @@ struct ALFWalker: pugi::xml_tree_walker {
         switch (node.type()){
             case pugi::node_element:
                 handle_element(node, tag);
-                val = node.child_value();
-                if (val.length() > 0)
-                RunThis((StringPtr)val.c_str());
                 break;
             default:
                 break;


### PR DESCRIPTION
this was resulting in multiple @recenter Teleporters in many of Apollo's levels