### PR TITLE
new level tags plus /rand improvements

### DIFF
--- a/Avara.xcodeproj/project.pbxproj
+++ b/Avara.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		94F17DDD29920D90001F5950 /* ARGBColor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94F17DDC29920D90001F5950 /* ARGBColor.cpp */; };
+		E20752EF2A003EC600DCC210 /* Tags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E20752EE2A003EC600DCC210 /* Tags.cpp */; };
 		E20A3C562991CC72005741F7 /* KeyFuncs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E20A3C552991CC72005741F7 /* KeyFuncs.cpp */; };
 		E517F053299713DB0036B206 /* tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E2B62D7D2997052B00600401 /* tests.cpp */; };
 		E517F054299713DB0036B206 /* CBasicSound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5890C7529895118007A875D /* CBasicSound.cpp */; };
@@ -353,6 +354,8 @@
 /* Begin PBXFileReference section */
 		94F17DDB2991FACE001F5950 /* ARGBColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARGBColor.h; sourceTree = "<group>"; };
 		94F17DDC29920D90001F5950 /* ARGBColor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ARGBColor.cpp; sourceTree = "<group>"; };
+		E20752ED29FF1EC500DCC210 /* Tags.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Tags.h; sourceTree = "<group>"; };
+		E20752EE2A003EC600DCC210 /* Tags.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Tags.cpp; sourceTree = "<group>"; };
 		E20A3C552991CC72005741F7 /* KeyFuncs.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyFuncs.cpp; sourceTree = "<group>"; };
 		E248724C29A480990079337E /* prefs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = prefs.json; path = "~/Library/Application Support/Avaraline/Avara/prefs.json"; sourceTree = "<group>"; };
 		E2B62D7D2997052B00600401 /* tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tests.cpp; sourceTree = "<group>"; };
@@ -1353,6 +1356,8 @@
 				E5890C7F29895118007A875D /* CWindow.cpp */,
 				E5890C8E29895118007A875D /* CWindow.h */,
 				E5890C8429895118007A875D /* Preferences.h */,
+				E20752ED29FF1EC500DCC210 /* Tags.h */,
+				E20752EE2A003EC600DCC210 /* Tags.cpp */,
 			);
 			path = gui;
 			sourceTree = "<group>";
@@ -2031,6 +2036,7 @@
 				E517F083299713DB0036B206 /* CLogicDelay.cpp in Sources */,
 				E517F084299713DB0036B206 /* CLogicDistributor.cpp in Sources */,
 				E517F085299713DB0036B206 /* CLogicTimer.cpp in Sources */,
+				E20752F02A003EC600DCC210 /* Tags.cpp in Sources */,
 				E517F086299713DB0036B206 /* CMarkerActor.cpp in Sources */,
 				E517F087299713DB0036B206 /* CMineActor.cpp in Sources */,
 				E517F088299713DB0036B206 /* CMissile.cpp in Sources */,
@@ -2190,6 +2196,7 @@
 				E5890CA829895118007A875D /* Beeper.cpp in Sources */,
 				E5890CDE29895118007A875D /* CYonBox.cpp in Sources */,
 				E5890EF429895124007A875D /* tabheader.cpp in Sources */,
+				E20752EF2A003EC600DCC210 /* Tags.cpp in Sources */,
 				E5890D1029895118007A875D /* CApplication.cpp in Sources */,
 				E5890EEB29895124007A875D /* csscolorparser.cpp in Sources */,
 				E5890CF329895118007A875D /* CSoundActor.cpp in Sources */,

--- a/src/Avara.cpp
+++ b/src/Avara.cpp
@@ -98,7 +98,7 @@ int main(int argc, char *argv[]) {
 
     auto p = CPlayerManagerImpl::LocalPlayer();
     auto *tui = ((CAvaraAppImpl *)app)->GetTui();
-    auto defaultCmd = "/rand -normal -tre avaraline emo not-aa ex";
+    auto defaultCmd = "/rand avara aa emo ex #fav -#bad -#koth";
     if (textCommand.size() > 0) {
         tui->ExecuteMatchingCommand(textCommand, p);
     } else {

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -34,6 +34,7 @@
 #include "httplib.h"
 #include <chrono>
 #include <json.hpp>
+#include "Tags.h"
 #include "Debug.h"
 
 // included while we fake things out
@@ -294,11 +295,22 @@ OSErr CAvaraAppImpl::LoadLevel(std::string set, std::string levelTag, CPlayerMan
     if (result == noErr) {
         playerWindow->RepopulateHullOptions();
         itsGame->loadedLevel = ledi["Name"];
-        itsGame->loadedTag  = levelTag;
-        std::string msgPrefix = "Loaded";
-        if (sendingPlayer != NULL)
-            msgPrefix = sendingPlayer->GetPlayerName() + " loaded";
-        AddMessageLine(msgPrefix + " \"" + itsGame->loadedLevel + "\" from \"" + set + "\".");
+        itsGame->loadedFilename  = levelTag;
+        itsGame->loadedTags = Tags::GetTagsForLevel(Tags::LevelURL(itsGame->loadedSet, itsGame->loadedLevel));
+        std::string msgStr = "Loaded";
+        if (sendingPlayer != NULL) {
+            msgStr = sendingPlayer->GetPlayerName() + " loaded";
+        }
+        msgStr += " \"" + itsGame->loadedLevel + "\" from \"" + set + "\".";
+        if (!itsGame->loadedTags.empty()) {
+            msgStr += " (tags:";
+            for (auto tag: itsGame->loadedTags) {
+                msgStr += " " + tag;
+            }
+            msgStr += ")";
+        }
+        AddMessageLine(msgStr);
+
         levelWindow->SelectLevel(set, itsGame->loadedLevel);
 
         itsGame->itsWorld->OverheadPoint(overhead, extent);

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -145,7 +145,7 @@ void CAvaraGame::IAvaraGame(CAvaraApp *theApp) {
 
     allowBackgroundProcessing = false;
 
-    loadedTag = "";
+    loadedFilename = "";
     loadedLevel = "";
     loadedDesigner = "";
     loadedInfo = "";
@@ -798,8 +798,6 @@ void CAvaraGame::GameStart() {
     while (FramesFromNow(latencyTolerance) > topSentFrame) {
         itsNet->FrameAction();
     }
-
-    loadedLevel = "";
 
     // SDL_ShowCursor(SDL_DISABLE);
     // SDL_CaptureMouse(SDL_TRUE);

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -19,6 +19,7 @@
 #include <SDL2/SDL.h>
 #include <string>
 #include <memory>
+#include <set>
 
 #define IDENTTABLESIZE 512
 
@@ -71,11 +72,12 @@ class CHUD;
 
 class CAvaraGame : public CDirectObject {
 public:
-    std::string loadedTag = "";
+    std::string loadedFilename = "";
     std::string loadedLevel = "";
     std::string loadedSet = "";
     std::string loadedDesigner = "";
     std::string loadedInfo = "";
+    std::set<std::string> loadedTags;
     long loadedTimeLimit;
     int32_t timeInSeconds;
     FrameNumber frameNumber;

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -181,7 +181,7 @@ void CNetManager::ChangeNet(short netKind, std::string address, std::string pass
             totalDistribution = 0;
             DBG_Log("login", "sending kpLogin to server with presence=%d\n", keepPresence);
             itsCommManager->SendPacket(kdServerOnly, kpLogin, 0, keepPresence, 0, 0L, NULL);
-            if (itsGame->loadedTag.length() > 0) {
+            if (itsGame->loadedFilename.length() > 0) {
                 itsGame->LevelReset(true);
                 // theRoster->InvalidateArea(kBottomBox, 0);
             }
@@ -1097,7 +1097,7 @@ void CNetManager::StopGame(short newStatus) {
 
         /*
         GetDateTime(&gameResult.r.when);
-        gameResult.levelTag = itsGame->loadedTag;
+        gameResult.levelTag = itsGame->loadedFilename;
         gameResult.directoryTag = itsGame->loadedDirectory;
         thePlayer->FillGameResultRecord(&gameResult);
 
@@ -1467,7 +1467,7 @@ void	CNetManager::BuildTrackerTags(
     CScoreKeeper	*keeper;
     char			gameStat = ktgsNotLoaded;
 
-    if(itsGame->loadedTag)
+    if(itsGame->loadedFilename)
     {	if(theApp->directorySpec.name[0])
                 tracker->WriteStringTag(ktsLevelDirectory, theApp->directorySpec.name);
         else	tracker->WriteStringTag(ktsLevelDirectory, theApp->appSpec.name);

--- a/src/game/CScoreKeeper.cpp
+++ b/src/game/CScoreKeeper.cpp
@@ -70,7 +70,7 @@ void CScoreKeeper::IScoreKeeper(CAvaraGame *theGame) {
     iface.levelName = itsGame->loadedLevel;
     iface.levelName = itsGame->loadedDesigner;
     iface.levelName = itsGame->loadedInfo;
-    iface.directory = itsGame->loadedTag;
+    iface.directory = itsGame->loadedFilename;
     iface.playerID = 0;
     iface.playerTeam = 0;
     iface.playerLives = 0;

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -181,7 +181,7 @@ CRosterWindow::CRosterWindow(CApplication *app) : CWindow(app, "Roster") {
     }
 
     tabWidget->setActiveTab(0);
-    currentLevel = ((CAvaraAppImpl *)gApplication)->GetGame()->loadedTag;
+    currentLevel = ((CAvaraAppImpl *)gApplication)->GetGame()->loadedFilename;
 
     UpdateRoster();
 
@@ -233,7 +233,7 @@ void CRosterWindow::UpdateRoster() {
             theGame->SetFrameLatency(theGame->RoundTripToFrameLatency(maxRtt), -1);
         }
 
-        if (theGame->loadedTag.compare(currentLevel) != 0) {
+        if (theGame->loadedFilename.compare(currentLevel) != 0) {
             std::string theLevel = theGame->loadedLevel;
             std::string theDesigner = theGame->loadedDesigner;
 
@@ -244,7 +244,7 @@ void CRosterWindow::UpdateRoster() {
 
             if (theGame->loadedInfo.length() > 0) levelDescription->setCaption(theGame->loadedInfo);
             else levelDescription->setCaption("No additional information about this mission is available.");
-            currentLevel = theGame->loadedTag;
+            currentLevel = theGame->loadedFilename;
         }
     }
     else if (tabWidget->activeTab() == 2) {

--- a/src/gui/Tags.cpp
+++ b/src/gui/Tags.cpp
@@ -1,0 +1,122 @@
+//
+//  Tags.cpp
+//  Avara
+//
+//  Created by Tom on 5/1/23.
+//
+
+#include "Tags.h"
+
+#include <json.hpp>
+
+#include <SDL2/SDL.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+Tags::TagMap Tags::_tags = {};
+
+std::string Tags::TagsPath() {
+    char *path = SDL_GetPrefPath("Avaraline", "Avara");
+    std::string jsonPath = std::string(path) + "tags.json";
+    SDL_free(path);
+    return jsonPath;
+}
+
+bool Tags::ReadTags() {
+    std::ifstream in(TagsPath());
+
+    if (!in.fail()) {
+        nlohmann::json jtags;
+        in >> jtags;
+        _tags = jtags.get<TagMap>();
+    } else {
+        // a couple tags to get started
+        AddTagToLevel(LevelURL("avaraline-strict-mode", "I/O"), "fav");
+        AddTagToLevel(LevelURL("aa-abnormal", "Arsenic"), "koth");
+    }
+    return true;
+}
+
+void Tags::TrimTags() {
+    // remove levels with no tags, and sets with no levels
+    std::set<std::string> trimSets;
+    for (auto [lset, levels]: _tags) {
+        std::set<std::string> trimLevels;
+//        std::cout << lset << " has " << levels.size() << " levels" << std::endl;
+        for (auto [level, tags]: levels) {
+//            std::cout << "  " << level << " has " << tags.size() << " tags" << std::endl;
+            if (tags.size() == 0) {
+                // remove levels outside of this loop to avoid access errors
+                trimLevels.insert(level);
+            }
+        }
+        for (auto trimLevel: trimLevels) {
+//            std::cout << "  -removing " << trimLevel << std::endl;
+            _tags[lset].erase(trimLevel);
+        }
+        if (_tags[lset].size() == 0) {
+            trimSets.insert(lset);
+        }
+    }
+    for (auto trimSet: trimSets) {
+//        std::cout << "-removing " << trimSet << std::endl;
+        _tags.erase(trimSet);
+    }
+}
+
+bool Tags::WriteTags() {
+    try {
+        std::ostringstream oss;
+        TrimTags();
+        nlohmann::json jtags = _tags;
+        oss << std::setw(4) << jtags << std::endl;
+        std::ofstream out(TagsPath());
+        out << oss.str();
+    } catch (std::exception& e) {
+        SDL_Log("ERROR WRITING TAGS FILE=%s", e.what());
+        return false;
+    }
+    return true;
+}
+
+const std::set<std::string>& Tags::GetTagsForLevel(LevelURL level) {
+    if (Tags::_tags.empty()) {
+        ReadTags();
+    }
+    return _tags[level.first][level.second];
+}
+
+std::string Tags::NormalizeTagName(std::string tag) {
+    if (tag[0] != '#') {
+        tag = '#' + tag;
+    }
+    return tag;
+}
+
+void Tags::AddTagToLevel(LevelURL level, std::string tag) {
+    _tags[level.first][level.second].insert(NormalizeTagName(tag));
+    WriteTags();
+}
+
+void Tags::DeleteTagFromLevel(LevelURL level, std::string tag) {
+    _tags[level.first][level.second].erase(NormalizeTagName(tag));
+    WriteTags();
+}
+
+std::set<Tags::LevelURL> Tags::GetLevelsMatchingTag(std::string matchTag) {
+    if (Tags::_tags.empty()) {
+        ReadTags();
+    }
+    std::set<Tags::LevelURL> matchingLevels;
+    for (auto [lset, levels]: _tags) {
+        for (auto [level, tags]: levels) {
+            for (auto tag: tags) {
+                if (tag == matchTag) {
+                    matchingLevels.insert(LevelURL(lset, level));
+                }
+            }
+        }
+    }
+    return matchingLevels;
+}

--- a/src/gui/Tags.h
+++ b/src/gui/Tags.h
@@ -1,0 +1,32 @@
+//
+//  Tags.h
+//  Avara
+//
+//  Created by Tom Anderson on 4/30/23.
+//
+
+#ifndef Tags_h
+#define Tags_h
+
+#include <map>
+#include <set>
+
+class Tags {
+    typedef std::map<std::string, std::map<std::string, std::set<std::string>>> TagMap;  // set->level->tags
+    static TagMap _tags;
+    static std::string TagsPath();
+    static bool ReadTags();
+    static bool WriteTags();
+    static void TrimTags();
+
+public:
+    typedef std::pair<std::string, std::string> LevelURL;
+    static const std::set<std::string>& GetTagsForLevel(LevelURL level);
+    static std::string NormalizeTagName(std::string);
+    static void AddTagToLevel(LevelURL level, std::string tag);
+    static void DeleteTagFromLevel(LevelURL level, std::string tag);
+    static std::set<LevelURL> GetLevelsMatchingTag(std::string tag);
+};
+
+
+#endif /* Tags_h */

--- a/src/gui/Tags.h
+++ b/src/gui/Tags.h
@@ -10,6 +10,7 @@
 
 #include <map>
 #include <set>
+#include <string>
 
 class Tags {
     typedef std::map<std::string, std::map<std::string, std::set<std::string>>> TagMap;  // set->level->tags

--- a/src/tui/CommandManager.h
+++ b/src/tui/CommandManager.h
@@ -45,6 +45,7 @@ public:
     // LevelCommands
     bool LoadNamedLevel(VectorOfArgs);
     bool LoadRandomLevel(VectorOfArgs);
+    bool HandleTags(VectorOfArgs);
 
     // Coding helpers
     bool SetDebugFlag(VectorOfArgs);


### PR DESCRIPTION
You can tag levels with anything you want and randomly load up levels with those tags.  For example:

    /load arsenic
    /tags #koth #fav
    /load king of the ring
    /tags #koth

Then to load a random KOTH level,

    /rand #koth

If you change your mind and want to change a tag use '-' to remove. This will remove 'fav' and add 'good':

    /t -fav good

You can also use '-' to remove levels from `/rand` loads. To load randomly from all your 'fav' levels while excluding 'koth' levels:

    /rand #fav -#koth