### PR TITLE
display or update preferences from a substring

### DIFF
--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <nanogui/nanogui.h>
 #include <string>
+#include <string.h>    // strcasestr
 #include <vector>
 
 json CApplication::_prefs = ReadPrefs();
@@ -72,4 +73,26 @@ long CApplication::Number(const std::string name, const long defaultValue) {
         return _prefs[name];
     }
     return defaultValue;
+}
+
+std::vector<std::string> CApplication::Matches(const std::string matchStr) {
+    std::vector<std::string> results;
+    for (auto& el : _prefs.items()) {
+        if (!el.value().is_object() && !el.value().is_array() &&
+            strcasestr(el.key().c_str(), matchStr.c_str())) {
+            results.push_back(el.key());
+        }
+    }
+    return results;
+}
+
+void CApplication::Update(const std::string name, std::string &value) {
+    // construct json from the inputs and update the internal JSON object
+    if (_prefs.at(name).is_string()) {
+        // wrap string values in quotes
+        value = '"' + value + '"';
+    }
+    json updatePref = json::parse("{ \"" + name + "\": " + value + "}");
+    _prefs.update(updatePref);
+    WritePrefs(_prefs);
 }

--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -9,7 +9,6 @@
 #include <fstream>
 #include <nanogui/nanogui.h>
 #include <string>
-#include <string.h>    // strcasestr
 #include <vector>
 
 json CApplication::_prefs = ReadPrefs();
@@ -75,11 +74,19 @@ long CApplication::Number(const std::string name, const long defaultValue) {
     return defaultValue;
 }
 
+std::string ToLower(const std::string source) {
+    std::string result = source;
+    std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+    return result;
+}
+
 std::vector<std::string> CApplication::Matches(const std::string matchStr) {
     std::vector<std::string> results;
+    std::string matchLower = ToLower(matchStr);
     for (auto& el : _prefs.items()) {
+        std::string keyLower = ToLower(el.key());
         if (!el.value().is_object() && !el.value().is_array() &&
-            strcasestr(el.key().c_str(), matchStr.c_str())) {
+            keyLower.find(matchLower) != std::string::npos) {
             results.push_back(el.key());
         }
     }

--- a/src/gui/CApplication.h
+++ b/src/gui/CApplication.h
@@ -57,9 +57,30 @@ public:
     bool Boolean(const std::string name)             { return Get<bool>(name); }
     json Get(const std::string name)                 { return Get<json>(name); }
 
+    std::vector<const std::string> Matches(const std::string matchStr) {
+        std::vector<const std::string> results;
+        for (auto& el : _prefs.items()) {
+            if (el.key().find(matchStr) != std::string::npos) {
+//                std::cout << el.key() << " : " << el.value() << "\n";
+                results.push_back(el.key());
+            }
+        }
+        return results;
+    }
+
     template <class T> void Set(const std::string name, const T value) {
         _prefs[name] = value;
         PrefChanged(name);
+    }
+
+    void Update(const std::string name, std::string &value) {
+        // construct json from the inputs and update the internal JSON object
+        if (_prefs.at(name).is_string()) {
+            // wrap string values in quotes
+            value = '"' + value + '"';
+        }
+        json updatePref = json::parse("{ \"" + name + "\": " + value + "}");
+        _prefs.update(updatePref);
     }
 
 protected:

--- a/src/gui/CApplication.h
+++ b/src/gui/CApplication.h
@@ -57,31 +57,14 @@ public:
     bool Boolean(const std::string name)             { return Get<bool>(name); }
     json Get(const std::string name)                 { return Get<json>(name); }
 
-    std::vector<const std::string> Matches(const std::string matchStr) {
-        std::vector<const std::string> results;
-        for (auto& el : _prefs.items()) {
-            if (el.key().find(matchStr) != std::string::npos) {
-//                std::cout << el.key() << " : " << el.value() << "\n";
-                results.push_back(el.key());
-            }
-        }
-        return results;
-    }
+    std::vector<std::string> Matches(const std::string matchStr);
 
     template <class T> void Set(const std::string name, const T value) {
         _prefs[name] = value;
         PrefChanged(name);
     }
 
-    void Update(const std::string name, std::string &value) {
-        // construct json from the inputs and update the internal JSON object
-        if (_prefs.at(name).is_string()) {
-            // wrap string values in quotes
-            value = '"' + value + '"';
-        }
-        json updatePref = json::parse("{ \"" + name + "\": " + value + "}");
-        _prefs.update(updatePref);
-    }
+    void Update(const std::string name, std::string &value);
 
 protected:
     static json _prefs;

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -430,10 +430,10 @@ bool CommandManager::GetSetPreference(VectorOfArgs vargs) {
     }
 
     // find all matching prefs
-    std::vector<const std::string> prefs = itsApp->Matches(vargs[0]);
+    std::vector<std::string> prefs = itsApp->Matches(vargs[0]);
     if (prefs.size() == 0) {
         itsApp->AddMessageLine("no prefs matching '" + vargs[0] + "'");
-        return false;
+        return true;
     }
 
     std::string prefName;
@@ -444,13 +444,16 @@ bool CommandManager::GetSetPreference(VectorOfArgs vargs) {
         prefName = pref;
     }
 
-    if (vargs.size() == 2) {
+    if (vargs.size() >= 2) {
         if (prefs.size() > 1) {
             itsApp->AddMessageLine("only 1 preference can be updated at a time");
-            return false;
+            return true;
         } else {
             std::string oldValue = itsApp->Get(prefName).dump();
             std::string newValue = vargs[1];
+            for (int i = 2; i < vargs.size(); i++) {
+                newValue += " " + vargs[i];
+            }
             // update pref
             itsApp->Update(prefName, newValue);
             //write prefs


### PR DESCRIPTION
Instead of having to type `/pref mouseSensitivity 0.7` you can now type `/pref mouse 0.7`.  If there are multiple matching preferences, it won't let you change them.

But you can, for example, type `/pref Color` to see the settings for all preferences containing the string `Color`.