### PR TITLE
improve auto LT

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1078,6 +1078,7 @@ long CAvaraGame::RoundTripToFrameLatency(long roundTrip) {
 // latencyTolerance is the number of classic (64ms) frames (= frameLatency * fpsScale).
 void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayerManager* slowPlayer) {
     static int reduceLatencyCounter = 0;
+    static const int REDUCE_LATENCY_COUNT = 5;
     double newLatency = newFrameLatency * fpsScale;
     if (latencyTolerance != newLatency) {
         #define MAX_LATENCY (8)   // in classic units
@@ -1088,8 +1089,8 @@ void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayer
 
         double oldLatency = latencyTolerance;
         if (newLatency < latencyTolerance) {
-            // need 4 consecutive requests to reduce latency
-            if (maxChange == MAX_LATENCY || ++reduceLatencyCounter > 3) {
+            // need REDUCE_LATENCY_COUNT consecutive requests to reduce latency
+            if (maxChange == MAX_LATENCY || ++reduceLatencyCounter >= REDUCE_LATENCY_COUNT) {
                 latencyTolerance = std::max(latencyTolerance-maxChange, std::max(newLatency, double(0.0)));
                 reduceLatencyCounter = 0;
             }

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1077,8 +1077,6 @@ long CAvaraGame::RoundTripToFrameLatency(long roundTrip) {
 // "frameLatency" is the integer number of frames to delay;
 // latencyTolerance is the number of classic (64ms) frames (= frameLatency * fpsScale).
 void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayerManager* slowPlayer) {
-    static int reduceLatencyCounter = 0;
-    static const int REDUCE_LATENCY_COUNT = 5;
     double newLatency = newFrameLatency * fpsScale;
     if (latencyTolerance != newLatency) {
         #define MAX_LATENCY (8)   // in classic units
@@ -1088,15 +1086,24 @@ void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayer
         }
 
         double oldLatency = latencyTolerance;
+
+        static int reduceLatencyCounter = 0;
+        static int increaseLatencyCounter = 0;
         if (newLatency < latencyTolerance) {
+            static const int REDUCE_LATENCY_COUNT = 5;
             // need REDUCE_LATENCY_COUNT consecutive requests to reduce latency
             if (maxChange == MAX_LATENCY || ++reduceLatencyCounter >= REDUCE_LATENCY_COUNT) {
                 latencyTolerance = std::max(latencyTolerance-maxChange, std::max(newLatency, double(0.0)));
                 reduceLatencyCounter = 0;
+                increaseLatencyCounter = 0;
             }
         } else {
-            latencyTolerance = std::min(latencyTolerance+maxChange, std::min(newLatency, double(MAX_LATENCY)));
-            reduceLatencyCounter = 0;
+            static const int INCREASE_LATENCY_COUNT = 2;
+            if (maxChange == MAX_LATENCY || ++increaseLatencyCounter >= INCREASE_LATENCY_COUNT) {
+                latencyTolerance = std::min(latencyTolerance+maxChange, std::min(newLatency, double(MAX_LATENCY)));
+                reduceLatencyCounter = 0;
+                increaseLatencyCounter = 0;
+            }
         }
 
         // make prettier version of the LT string (C++ sucks with strings)

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -778,10 +778,8 @@ void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
 
                 itsCommManager->SendUrgentPacket(
                     activePlayersDistribution, kpLatencyVote, llv, maxRoundLatency, FRandSeed, 0, NULL);
-                #if LATENCY_DEBUG
-                    SDL_Log("*** fn=%ld SENDING kpLatencyVote to %hx, localLatencyVote=%ld, maxRoundLatency=%ld FRandSeed=%d\n",
-                            frameNumber, activePlayersDistribution, localLatencyVote, maxRoundLatency, FRandSeed);
-                #endif
+                DBG_Log("lt+", "*** fn=%d Sending kpLatencyVote to 0x%2hx, localLatencyVote=%ld, maxRoundLatency=%ld FRandSeed=%d\n",
+                        frameNumber, activePlayersDistribution, localLatencyVote, maxRoundLatency, FRandSeed);
             } else {
                 // spectator just sends FRandSeed to self for fragmentation check
                 itsCommManager->SendUrgentPacket(
@@ -798,23 +796,23 @@ void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
 
             if (IsAutoLatencyEnabled() && autoLatencyVoteCount) {
                 autoLatencyVote /= autoLatencyVoteCount;
-                DBG_Log("lt", "====autoLatencyVote = %ld\n", autoLatencyVote);
+                DBG_Log("lt+", "====autoLatencyVote = %ld\n", autoLatencyVote);
                 // if, on average, players had to wait more than some percent of frames during this latency vote period,
                 // then add 1 frame to the LT calculation
                 if (autoLatencyVote > HIGHERLATENCYCOUNT) {
                     addOneLatency++;
                     // don't let it go above 1.0 LT
                     addOneLatency = std::min(short(1.0/itsGame->fpsScale), addOneLatency);
-                    DBG_Log("lt", "  ++addOneLatency increased = %hd\n", addOneLatency);
+                    DBG_Log("lt+", "  ++addOneLatency increased = %hd\n", addOneLatency);
                     subtractOneCheck = frameNumber + DECREASELATENCYPERIOD;
                 } else if (autoLatencyVote > LOWERLATENCYCOUNT) {
                     // vote too high to reduce addOneLatency, push subtractOneCheck forward
-                    DBG_Log("lt", "   >addOneLatency keeping = %hd\n", addOneLatency);
+                    DBG_Log("lt+", "   >addOneLatency keeping = %hd\n", addOneLatency);
                     subtractOneCheck = frameNumber + DECREASELATENCYPERIOD;
                 } else if (addOneLatency > 0 && frameNumber >= subtractOneCheck) {
                     // if no significant waiting seen for 8 CONSECUTIVE autoLatency votes, about 30 seconds, let it creep back down 1 fps frame
                     addOneLatency--;
-                    DBG_Log("lt", "  --addOneLatency decreased = %hd\n", addOneLatency);
+                    DBG_Log("lt+", "  --addOneLatency decreased = %hd\n", addOneLatency);
                     subtractOneCheck = frameNumber + DECREASELATENCYPERIOD;
                 }
 
@@ -822,7 +820,7 @@ void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
                 // but addOneLatency helps account for deficiencies in the calculation by measuring how often clients had to wait too long for packets to arrive
                 short maxFrameLatency = addOneLatency + itsGame->RoundTripToFrameLatency(maxRoundTripLatency);
 
-                SDL_Log("*** fn=%d RTT=%d, Classic LT=%.2lf, add=%lf --> FL=%d\n",
+                DBG_Log("lt", "  fn=%d RTT=%d, Classic LT=%.2lf, add=%lf --> FL=%d\n",
                         frameNumber, maxRoundTripLatency,
                         (maxRoundTripLatency) / (2.0*CLASSICFRAMETIME), addOneLatency*itsGame->fpsScale, maxFrameLatency);
 
@@ -864,7 +862,7 @@ void CNetManager::ReceiveLatencyVote(int16_t sender,
                                      int16_t p2,        // maxRoundLatency
                                      int32_t p3) {      // FRandSeed
 
-    DBG_Log("lt", "CNetManager::ReceiveLatencyVote(%d, %d, %hd, %d)\n", sender, p1, p2, p3);
+    DBG_Log("lt+", "CNetManager::ReceiveLatencyVote(%d, %d, %hd, %d)\n", sender, p1, p2, p3);
     autoLatencyVoteCount++;
     autoLatencyVote += p1;
 

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -431,9 +431,9 @@ void CPlayerManagerImpl::ResendFrame(FrameNumber theFrame, short requesterId, sh
         if (outPacket) {
             // this method used by both requester and sender...
             if (commandCode == kpKeyAndMouseRequest) {
-                SDL_Log("CPlayerManagerImpl::ResendFrame: asking for frame %d from slot %hd\n", theFrame, requesterId);
+                DBG_Log("resend", "asking for frame %d from slot %hd\n", theFrame, requesterId);
             } else {
-                SDL_Log("CPlayerManagerImpl::ResendFrame: re-sending frame %d  to  slot %hd\n", theFrame, requesterId);
+                DBG_Log("resend", "re-sending frame %d  to  slot %hd\n", theFrame, requesterId);
             }
             outPacket->command = commandCode;
             outPacket->distribution = 1 << requesterId;
@@ -445,7 +445,7 @@ void CPlayerManagerImpl::ResendFrame(FrameNumber theFrame, short requesterId, sh
         }
     } else //	Ask me later packet
     {
-        SDL_Log("CPlayerManagerImpl::ResendFrame frame %d not in FUNCTIONBUFFERS, value = %d\n", theFrame, ff->validFrame);
+        DBG_Log("resend", "frame %d not in FUNCTIONBUFFERS, value = %d\n", theFrame, ff->validFrame);
         theComm->SendUrgentPacket(1 << requesterId, kpAskLater, 0, 0, theFrame, 0, 0);
     }
 }
@@ -567,7 +567,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
                 askAgainTime = quickTick + ASK_INTERVAL;
 
                 if (askCount == WAITING_MESSAGE_COUNT) {
-                    SDL_Log("Waiting for '%s' to resend frame #%u\n", GetPlayerName().c_str(), itsGame->frameNumber);
+                    DBG_Log("resend", "Waiting for '%s' to resend frame #%u\n", GetPlayerName().c_str(), itsGame->frameNumber);
                     loadingStatus = kLNetDelayed;
                     itsGame->itsApp->ParamLine(kmWaitingForPlayer, MsgAlignment::Center, playerName);
                     itsGame->itsApp->RenderContents();  // force render now so message shows up
@@ -577,7 +577,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
                     // gApplication->BroadcastCommand(kBusyStartCmd);
                 }
 
-                SDL_Log("frameNumber = %d, validFrame = %d, askCount = %d, askAgainTime = %ld ticks\n",
+                DBG_Log("resend", "frameNumber = %d, validFrame = %d, askCount = %d, askAgainTime = %ld ticks\n",
                         itsGame->frameNumber, frameFuncs[i].validFrame, askCount, askAgainTime-quickTick);
             }
 

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -1905,10 +1905,10 @@ long CUDPComm::GetMaxRoundTrip(short distribution, short *slowPlayerId) {
 
     for (conn = connections; conn; conn = conn->next) {
         if (conn->port && (distribution & (1 << conn->myId))) {
-            // add in 1.9*stdev (~97% prob) but max it at CLASSICFRAMETIME (don't add more than 0.5 to LT)
+            // add in 2.58*stdev (~99% prob) but max it at CLASSICFRAMETIME (don't add more than 0.5 to LT)
             // note: is this really a erlang distribution?  if so, what's the proper equation?
             float stdev = sqrt(conn->varRoundTripTime);
-            float rtt = conn->meanRoundTripTime + std::min(1.9*stdev, (1.0*CLASSICFRAMECLOCK));
+            float rtt = conn->meanRoundTripTime + std::min(2.58*stdev, (1.0*CLASSICFRAMECLOCK));
             if (rtt > maxTrip) {
                 maxTrip = rtt;
                 if (slowPlayerId != nullptr) {


### PR DESCRIPTION
I'm trying to make Auto Latency work better by not churning as much.  This fix only allows LT to decrease if 5 "votes" in a row say it should go down (~19 seconds).  Hopefully this will reduce some extraneous LT changes while still allowing it to respond quickly to latency spikes on the upside.

Also increased the standard deviation multiplier so that displayed RTT/2 is a little closer to actual LT amount.

And... changed some logging to use DBG_Log so as to reduce default logging.
