### PR TITLE
handle possible packet size and blockmove issues

### DIFF
--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -215,7 +215,7 @@ bool CAvaraAppImpl::DoCommand(int theCommand) {
     std::string name = String(kPlayerNameTag);
     Str255 userName;
     userName[0] = name.length();
-    BlockMoveData(name.c_str(), userName + 1, name.length());
+    BlockMoveData(name.c_str(), userName + 1, userName[0]);
     // SDL_Log("DoCommand %d\n", theCommand);
     switch (theCommand) {
         case kReportNameCmd:

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -433,8 +433,8 @@ void CNetManager::SendLoadLevel(std::string theSet, std::string levelTag, int16_
 
     std::string setAndLevel = theSet + "/" + levelTag;
 
-    aPacket->dataLen = setAndLevel.length() + 1;
-    BlockMoveData(setAndLevel.c_str(), aPacket->dataBuffer, setAndLevel.length() + 1);
+    aPacket->dataLen = std::max<int16_t>(setAndLevel.length() + 1, PACKETDATABUFFERSIZE);
+    BlockMoveData(setAndLevel.c_str(), aPacket->dataBuffer, aPacket->dataLen);
 
     /* TODO: implement
      itsGame->itsApp->GetDirectoryLocator((DirectoryLocator *)aPacket->dataBuffer);
@@ -497,8 +497,8 @@ void CNetManager::ReceiveLoadLevel(short senderSlot, int16_t originalSender, cha
             //itsCommManager->SendPacket(kdEveryone, kpLevelLoaded, 0, crc, 0, 0, 0);
         }
 
-        aPacket->dataLen = tag.length() + 1;
-        BlockMoveData(tag.c_str(), aPacket->dataBuffer, tag.length() + 1);
+        aPacket->dataLen = std::max<int16_t>(tag.length() + 1, PACKETDATABUFFERSIZE);
+        BlockMoveData(tag.c_str(), aPacket->dataBuffer, aPacket->dataLen);
         itsCommManager->WriteAndSignPacket(aPacket);
     }
 

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -1573,3 +1573,23 @@ void CNetManager::ChangeTeamColors(std::map<int, std::vector<std::string>> color
     SendColorChange();
 }
 
+void CNetManager::SetTeamColor(int slot, int color) {
+    if (color > kNeutralTeam) {
+        teamColors[slot] = color - kGreenTeam;
+    } else {
+        // pick first color not being used by other slots
+        for (int newColor = 0; newColor < kMaxAvaraPlayers; newColor++) {
+            bool colorUsed = false;
+            for (int i = 0; i < kMaxAvaraPlayers && !colorUsed; i++) {
+                if (i != slot && teamColors[i] == newColor) {
+                    colorUsed = true;
+                }
+            }
+            if (!colorUsed) {
+                teamColors[slot] = newColor;
+                break;
+            }
+        }
+    }
+    SendColorChange();
+}

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -181,6 +181,7 @@ public:
 
     virtual int PlayerSlot(std::string playerName);
     virtual void ChangeTeamColors(std::map<int, std::vector<std::string>> colorTeamMap);
+    virtual void SetTeamColor(int slot, int color);
 
     //	Game loop methods:
     size_t SkipLostPackets(int16_t dist);

--- a/src/gui/CPlayerWindow.cpp
+++ b/src/gui/CPlayerWindow.cpp
@@ -24,7 +24,7 @@ CPlayerWindow::CPlayerWindow(CApplication *app) : CWindow(app, "Player") {
 
         Str255 the_name;
         the_name[0] = value.length();
-        BlockMoveData(value.c_str(), the_name + 1, value.length());
+        BlockMoveData(value.c_str(), the_name + 1, the_name[0]);
 
         ((CAvaraAppImpl *)gApplication)->GetNet()->NameChange(the_name);
         return true;

--- a/src/net/CCommManager.h
+++ b/src/net/CCommManager.h
@@ -75,7 +75,7 @@ public:
     virtual void AddReceiver(ReceiverRecord *aReceiver, Boolean delayed);
     virtual void RemoveReceiver(ReceiverRecord *aReceiver, Boolean delayed);
 
-    virtual OSErr SendPacket(short distribution, int8_t command, int8_t p1, int16_t p2, int32_t p3, int16_t dataLen, Ptr dataPtr);
+    virtual OSErr SendPacket(short distribution, int8_t command, int8_t p1, int16_t p2, int32_t p3, int16_t dataLen, Ptr dataPtr, int16_t flags = 0);
     virtual OSErr SendUrgentPacket(short distribution, int8_t command, int8_t p1, int16_t p2, int32_t p3, int16_t dataLen, Ptr dataPtr);
     virtual void Dispose();
 

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -355,6 +355,10 @@ bool CommandManager::TogglePresence(int slot, PresenceType togglePresence, std::
             playerToChange->Slot(), playerToChange->LoadingStatus(), newPresence, sizeof(FrameNumber), (Ptr)&noWinFrame);
     itsApp->AddMessageLine("Status of " + playerToChange->GetPlayerName() +
                    " changed to " + std::string(newPresence == kzAvailable ? "available" : stateName));
+
+    int newColor = (newPresence == kzAvailable) ? kNeutralTeam : kBlackTeam;
+    itsApp->GetNet()->SetTeamColor(slot-1, newColor);
+
     return true;
 }
 

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -363,10 +363,12 @@ bool CommandManager::TogglePresence(int slot, PresenceType togglePresence, std::
 }
 
 bool CommandManager::LoadNamedLevel(VectorOfArgs vargs) {
+    static int loadNumber = 0;
     std::vector<std::string> levelSets = LevelDirNameListing();
     std::string levelSubstr = join_with(vargs, " ");
     std::transform(levelSubstr.begin(), levelSubstr.end(),levelSubstr.begin(), ::toupper);
 
+    std::vector<std::pair<std::string, std::string>> bestLevels = {};
     for(std::string set : levelSets) {
         nlohmann::json ledis = LoadLevelListFromJSON(set);
         for (auto &ld : ledis.items()) {
@@ -376,14 +378,26 @@ bool CommandManager::LoadNamedLevel(VectorOfArgs vargs) {
 
             // find levelSubstr anywhere within the level name
             if(levelUpper.find(levelSubstr) != std::string::npos) {
-                itsApp->levelWindow->SelectLevel(set, level);
-                itsApp->levelWindow->SendLoad();
-
-                return true;
+                // the shorter the match string, the better (e.g. match string "bwadi" picks "Bwadi" over "Bwadi Remix")
+                if (bestLevels.empty() || level.size() < bestLevels[0].second.size()) {
+                    bestLevels.clear();
+                    bestLevels.push_back({set, level});
+                    SDL_Log("/load leading candidate: %s/%s\n", set.c_str(), level.c_str());
+                } else if (!bestLevels.empty() && level.size() == bestLevels[0].second.size()) {
+                    bestLevels.push_back({set, level});
+                    SDL_Log("/load   equal candidate: %s/%s\n", set.c_str(), level.c_str());
+                } else {
+                    SDL_Log("/load         not using: %s/%s\n", set.c_str(), level.c_str());
+                }
             }
         }
     }
-    return false;
+    if (!bestLevels.empty()) {
+        int loadIndex = loadNumber++ % bestLevels.size();  // alternates between candidates
+        itsApp->levelWindow->SelectLevel(bestLevels[loadIndex].first, bestLevels[loadIndex].second);
+        itsApp->levelWindow->SendLoad();
+    }
+    return true;
 }
 
 bool CommandManager::LoadRandomLevel(VectorOfArgs matchArgs) {


### PR DESCRIPTION
Don't send packets with bad data buffer sizes.  Likewise, ignore received packets with bad sizes.

Make some BlockMoveData calls more robust.  For example, if somebody were to paste a large string into the password or username fields this will limit it to something <= 255 characters and not overwrite memory.