### PR TITLE
scoreKeeper remembers players who leave game

### DIFF
--- a/src/game/CFreeSolid.cpp
+++ b/src/game/CFreeSolid.cpp
@@ -226,9 +226,13 @@ void CFreeSolid::FrameAction() {
 
                     SecondaryDamage(teamColor, -1);
 
+                    // if part blew up, we're done here
+                    if (!partList[0]) {
+                        return;
+                    }
                     BuildPartProximityList(location,
-                        partList[0]->bigRadius + FDistanceOverEstimate(locOffset[0], locOffset[1], locOffset[2]),
-                        kSolidBit);
+                                           partList[0]->bigRadius + FDistanceOverEstimate(locOffset[0], locOffset[1], locOffset[2]),
+                                           kSolidBit);
                 }
 
                 //	Move back to where we were.

--- a/src/game/CScoreKeeper.h
+++ b/src/game/CScoreKeeper.h
@@ -49,6 +49,7 @@ public:
 
     AvaraScoreRecord localScores;
     AvaraScoreRecord netScores;
+    std::string playerNames[kMaxAvaraPlayers];    // maybe put this in PlayerScoreRecord?
     short exitCount;
 
     short resRefNum;

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -249,12 +249,10 @@ void CRosterWindow::UpdateRoster() {
     }
     else if (tabWidget->activeTab() == 2) {
         for (int i = 0; i < kMaxAvaraPlayers; i++) {
-            CPlayerManager *thisPlayer = theNet->playerTable[i];
-            const std::string theName((char *)thisPlayer->PlayerName() + 1, thisPlayer->PlayerName()[0]);
             AvaraScoreRecord theScores = theGame->scoreKeeper->netScores;
-            if(theName.size() > 0) {
+            scoreNames[i]->setValue(theGame->scoreKeeper->playerNames[i]);
+            if(theScores.player[i].lives >= 0) {
                 scoreTeams[i]->setValue(std::to_string(theNet->teamColors[i]));
-                scoreNames[i]->setValue(theName.c_str());
                 scoreExitRanks[i]->setValue(std::to_string(theScores.player[i].exitRank));
                 scoreScores[i]->setValue(std::to_string(theScores.player[i].points));
                 scoreKills[i]->setValue(std::to_string(theScores.player[i].kills));
@@ -262,7 +260,6 @@ void CRosterWindow::UpdateRoster() {
             }
             else {
                 scoreTeams[i]->setValue("");
-                scoreNames[i]->setValue("");
                 scoreExitRanks[i]->setValue("");
                 scoreScores[i]->setValue("");
                 scoreKills[i]->setValue("");


### PR DESCRIPTION
I noticed that when a player leaves a server after dying, the ScoreKeeper wouldn't know who was playing or it might mis-attribute the game to a newly joined player.  This fix makes the ScoreKeeper remember who started the game in each position. This also allows the Elo calculation to get the finishers correct for player ratings.