### PR TITLE
Fix segfault when entering '/l' with no args.

### DIFF
--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -617,7 +617,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
     nvgFillColor(ctx, nvgRGBA(255, 255, 255, 255));
     nvgFontSize(ctx, fontsz_m);
     nvgTextAlign(ctx, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
-    if(player->itsManager != NULL) {
+    if(player->itsManager != nullptr) {
         snprintf(scoreText, sizeof(scoreText), "%ld", itsGame->scores[player->itsManager->Slot()]);
         nvgText(ctx, g1X + 22.5, gY + full + 10.0, scoreText, NULL);
     }

--- a/src/gui/CServerWindow.cpp
+++ b/src/gui/CServerWindow.cpp
@@ -56,8 +56,8 @@ CServerWindow::CServerWindow(CApplication *app) : CWindow(app, "Server") {
 
     latencyBox = new nanogui::TextBox(this);
     latencyBox->setValue(std::to_string(app->Get<float>(kLatencyToleranceTag)).substr(0, 5));
-    latencyBox->setEditable(false);
-    latencyBox->setEnabled(false);
+    latencyBox->setEditable(true);
+    latencyBox->setEnabled(true);
     latencyBox->setCallback([this](std::string value) -> bool {
         double newLT = std::stod(value);
         // let SetFrameLatency() enforce limits on latencyTolerance AND set the pref
@@ -68,18 +68,24 @@ CServerWindow::CServerWindow(CApplication *app) : CWindow(app, "Server") {
         return true;
     });
 
-    autoLatencyBox = new nanogui::CheckBox(this, "Auto Latency", [app](bool checked) {
+    autoLatencyBox = new nanogui::CheckBox(this, "Auto Latency", [this, app](bool checked) {
         long options = app->Number(kServerOptionsTag);
-        if (checked)
+        if (checked) {
             options |= 1 << kUseAutoLatencyBit;
-        else
+            latencyBox->setEditable(false);
+            latencyBox->setEnabled(false);
+        }
+        else {
             options &= ~(long)(1 << kUseAutoLatencyBit);
+            latencyBox->setEditable(true);
+            latencyBox->setEnabled(true);
+        }
         app->Set(kServerOptionsTag, options);
         ((CAvaraAppImpl *)app)->GetNet()->ChangedServerOptions(options);
     });
     bool autoLatency = app->Number(kServerOptionsTag) & (1 << kUseAutoLatencyBit);
     autoLatencyBox->setChecked(autoLatency);
-    autoLatencyBox->setEnabled(false);
+    autoLatencyBox->setEnabled(true);
 
     std::vector<std::string> frameTimeOptions = {
         "64 ms (15.625 fps)", "32 ms (31.25 fps)", "16 ms (62.5 fps)", "8 ms (125 fps)"
@@ -109,7 +115,7 @@ bool CServerWindow::DoCommand(int theCommand) {
                     startBtn->setEnabled(true);
                     frameTimeBox->setEnabled(true);
                     startBtn->setCaption("Start Hosting");
-                    this->EnableLatencyOptions(false);
+                    this->EnableLatencyOptions(true);
                     break;
                 case kClientNet:
                     startBtn->setEnabled(false);

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -363,6 +363,13 @@ bool CommandManager::TogglePresence(int slot, PresenceType togglePresence, std::
 }
 
 bool CommandManager::LoadNamedLevel(VectorOfArgs vargs) {
+    if (vargs.size() == 0) {
+        std::string cmd = "/load";
+        std::string usage = TextCommand::UsageForCommand(cmd);
+        itsApp->AddMessageLine(usage);
+        return false;
+    }
+
     static int loadNumber = 0;
     std::vector<std::string> levelSets = LevelDirNameListing();
     std::string levelSubstr = join_with(vargs, " ");


### PR DESCRIPTION
Fix segfault when entering '/l' with no args.
Should fix #272 

LT field can be updated any time except when AutoLatency is checked and when you are a client connected to a server that is not yours.
Should fix #313 

Fix a null check that caused a segfault when a client is disconnected from a server that shutdown