### PR TITLE
Convert PlayerManager objects to use shared pointers

### DIFF
--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -58,7 +58,7 @@ enum HUDPreset {
 
 class CAbstractPlayer : public CRealMovers {
 public:
-    CPlayerManager *itsManager = 0;
+    std::shared_ptr<CPlayerManager> itsManager;
     CAbstractPlayer *nextPlayer = 0;
     PlayerConfigRecord defaultConfig {};
 

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -270,7 +270,7 @@ CAbstractPlayer *CAvaraGame::GetSpectatePlayer() {
 
 CAbstractPlayer *CAvaraGame::GetLocalPlayer() {
     for (int i = 0; i < kMaxAvaraPlayers; i++) {
-        CPlayerManager *mgr = itsNet->playerTable[i];
+        CPlayerManager *mgr = itsNet->playerTable[i].get();
         if (mgr && mgr->IsLocalPlayer()) {
             return mgr->GetPlayer();
         }
@@ -683,7 +683,7 @@ void CAvaraGame::StartIfReady() {
     if (itsNet->itsCommManager->myId == 0) {
         bool allReady = true;
         for (int i = 0; i < kMaxAvaraPlayers; i++) {
-            CPlayerManager *mgr = itsNet->playerTable[i];
+            CPlayerManager *mgr = itsNet->playerTable[i].get();
             if (mgr && mgr->LoadingStatus() == kLLoaded && mgr->Presence() == kzAvailable) {
                 allReady = false;
                 break;
@@ -1021,9 +1021,9 @@ void CAvaraGame::SpectatePrevious() {
 CPlayerManager *CAvaraGame::FindPlayerManager(CAbstractPlayer *thePlayer) {
     for (int i = 0; i < kMaxAvaraPlayers; i++)
         if(itsNet->playerTable[i] != NULL && itsNet->playerTable[i]->GetPlayer() == thePlayer)
-            return itsNet->playerTable[i];
+            return itsNet->playerTable[i].get();
 
-    return NULL;
+    return nullptr;
 }
 
 void CAvaraGame::StopGame() {
@@ -1056,10 +1056,10 @@ void CAvaraGame::Render(NVGcontext *ctx) {
 }
 
 CPlayerManager *CAvaraGame::GetPlayerManager(CAbstractPlayer *thePlayer) {
-    CPlayerManager *theManager = NULL;
+    CPlayerManager *theManager = nullptr;
 
     if (itsNet->playerCount < kMaxAvaraPlayers) {
-        theManager = itsNet->playerTable[itsNet->playerCount];
+        theManager = itsNet->playerTable[itsNet->playerCount].get();
         theManager->SetPlayer(thePlayer);
         itsNet->playerCount++;
     }

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -109,7 +109,7 @@ void CHUD::DrawScore(std::vector<CPlayerManager*>& thePlayers, int chudHeight, C
         int16_t previousScore = -32768;
         for (int i = 0; i < kMaxAvaraPlayers; i++) {
             int playerTableIndex = sortedPlayers[i].second;
-            CPlayerManager *thisPlayer = net->playerTable[playerTableIndex];
+            CPlayerManager *thisPlayer = net->playerTable[playerTableIndex].get();
             const std::string playerName((char *)thisPlayer->PlayerName() + 1, thisPlayer->PlayerName()[0]);
             std::string ping = "--";
             longTeamColor = *ColorManager::getTeamColor(net->teamColors[playerTableIndex] + 1);
@@ -305,7 +305,7 @@ void CHUD::Render(CViewParameters *view, NVGcontext *ctx) {
     float teamColorRGB[3];
     float colorBoxAlpha = 1.0;
     for (int i = 0; i < kMaxAvaraPlayers; i++) {
-        CPlayerManager *thisPlayer = net->playerTable[i];
+        CPlayerManager *thisPlayer = net->playerTable[i].get();
         std::string playerName((char *)thisPlayer->PlayerName() + 1, thisPlayer->PlayerName()[0]);
         if (playerName.length() < 1) continue;
 

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -73,7 +73,7 @@ public:
     // CRosterWindow	*theRoster;
 
     short playerCount;
-    CPlayerManager *playerTable[kMaxAvaraPlayers];
+    std::shared_ptr<CPlayerManager> playerTable[kMaxAvaraPlayers];
 
     char teamColors[kMaxAvaraPlayers];
     int8_t slotToPosition[kMaxAvaraPlayers];
@@ -123,7 +123,7 @@ public:
 
     ~CNetManager() { Dispose(); };
     virtual void INetManager(CAvaraGame *theGame);
-    virtual CPlayerManager* CreatePlayerManager(short);
+    virtual std::shared_ptr<CPlayerManager> CreatePlayerManager(short);
     virtual void LevelReset();
     virtual void Dispose();
     virtual Boolean ConfirmNetChange();

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -149,7 +149,7 @@ uint32_t CPlayerManagerImpl::DoMouseControl(Point *deltaMouse, Boolean doCenter)
 }
 
 Boolean CPlayerManagerImpl::TestKeyPressed(short funcCode) {
-    CPlayerManagerImpl* localManager = ((CPlayerManagerImpl*)itsGame->GetLocalPlayer()->itsManager);
+    CPlayerManagerImpl* localManager = ((CPlayerManagerImpl*)itsGame->GetLocalPlayer()->itsManager.get());
     return TESTFUNC(funcCode, localManager->keysDown);
 }
 
@@ -1013,7 +1013,7 @@ CAbstractPlayer *CPlayerManagerImpl::ChooseActor(CAbstractPlayer *actorList, sho
         if (actorList->teamColor == myTeamColor) { //	Good enough for me.
 
             itsPlayer = actorList;
-            itsPlayer->itsManager = this;
+            itsPlayer->itsManager = shared_from_this();
             itsPlayer->didIncarnateMasked = true;
             itsPlayer->PlayerWasMoved();
             itsPlayer->BuildPartProximityList(itsPlayer->location, itsPlayer->proximityRadius, kSolidBit);
@@ -1039,7 +1039,7 @@ CAbstractPlayer *CPlayerManagerImpl::ChooseActor(CAbstractPlayer *actorList, sho
         itsPlayer->EndScript();
         itsPlayer->isInLimbo = true;
         itsPlayer->limboCount = 0;
-        itsPlayer->itsManager = this;
+        itsPlayer->itsManager = shared_from_this();
 
         itsPlayer->teamMask = myTeamMask;
         itsPlayer->Reincarnate();
@@ -1065,7 +1065,7 @@ Boolean CPlayerManagerImpl::IncarnateInAnyColor() {
         itsPlayer->EndScript();
         itsPlayer->isInLimbo = true;
         itsPlayer->limboCount = 0;
-        itsPlayer->itsManager = this;
+        itsPlayer->itsManager = shared_from_this();
 
         itsPlayer->teamMask = 1 << i;  // set in case Incarnators discriminate on color
         itsPlayer->Reincarnate();
@@ -1091,7 +1091,7 @@ CAbstractPlayer *CPlayerManagerImpl::TakeAnyActor(CAbstractPlayer *actorList) {
     playerColor = actorList->teamColor;
 
     itsPlayer = actorList;
-    itsPlayer->itsManager = this;
+    itsPlayer->itsManager = shared_from_this();
     itsPlayer->AddToGame();
 
     return nextPlayer;

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -143,7 +143,7 @@ public:
     virtual bool GetShowScoreboard() = 0;
 };
 
-class CPlayerManagerImpl : public CDirectObject, public CPlayerManager {
+class CPlayerManagerImpl : public CDirectObject, public CPlayerManager, public std::enable_shared_from_this<CPlayerManagerImpl> {
 private:
 
     CAbstractPlayer *itsPlayer;

--- a/src/game/CScoreKeeper.cpp
+++ b/src/game/CScoreKeeper.cpp
@@ -142,7 +142,7 @@ void CScoreKeeper::PlayerIntros() {
     CPlayerManager *thePlayer;
 
     for (i = 0; i < kMaxAvaraPlayers; i++) {
-        thePlayer = theNet->playerTable[i];
+        thePlayer = theNet->playerTable[i].get();
         if (thePlayer->GetPlayer()) {
             localScores.player[i].lives = thePlayer->GetPlayer()->lives;
             localScores.player[i].team = thePlayer->GetPlayer()->teamColor;
@@ -169,7 +169,7 @@ void CScoreKeeper::NetResultsUpdate() {
     CPlayerManager *thePlayer;
 
     for (i = 0; i < kMaxAvaraPlayers; i++) {
-        thePlayer = theNet->playerTable[i];
+        thePlayer = theNet->playerTable[i].get();
         offset = i * PLAYER_SCORE_FIELD_COUNT;
         if (thePlayer->GetPlayer()) {
             if (thePlayer->Presence() == kzSpectating) {
@@ -268,7 +268,7 @@ void CScoreKeeper::ResetScores() {
         localScores.player[i].exitRank = 0;
         localScores.player[i].kills = 0;
 
-        thePlayer = itsGame->itsNet->playerTable[i];
+        thePlayer = itsGame->itsNet->playerTable[i].get();
         if (thePlayer->GetPlayer() == NULL) {
             localScores.player[i].serverWins = 0;
         }

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -195,7 +195,7 @@ void CRosterWindow::UpdateRoster() {
     if (tabWidget->activeTab() == 0) {
         long maxRtt = 0;
         for (int i = 0; i < kMaxAvaraPlayers; i++) {
-            CPlayerManager *thisPlayer = ((CAvaraAppImpl *)gApplication)->GetNet()->playerTable[i];
+            CPlayerManager *thisPlayer = ((CAvaraAppImpl *)gApplication)->GetNet()->playerTable[i].get();
 
             std::string theName((char *)thisPlayer->PlayerName() + 1, thisPlayer->PlayerName()[0]);
             if (i != theNet->itsCommManager->myId && theName.length() > 0) {

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -335,7 +335,7 @@ bool CommandManager::TogglePresence(int slot, PresenceType togglePresence, std::
         }
     }
 
-    CPlayerManager* playerToChange = itsApp->GetNet()->playerTable[slot-1];
+    CPlayerManager* playerToChange = itsApp->GetNet()->playerTable[slot-1].get();
     if(playerToChange->LoadingStatus() == kLActive || playerToChange->LoadingStatus() == kLPaused) {
         itsApp->AddMessageLine(
             "State can not be changed on players in a game.",
@@ -517,7 +517,7 @@ bool CommandManager::DisplayRatings(VectorOfArgs vargs) {
     if (vargs.size() == 0) {
         // there must be an easier way to get the player names...
         for (int i = 0; i < kMaxAvaraPlayers; i++) {
-            CPlayerManager *mgr = itsApp->GetNet()->playerTable[i];
+            CPlayerManager *mgr = itsApp->GetNet()->playerTable[i].get();
             auto name = mgr->GetPlayerName();
             if (!name.empty()) {
                 vargs.push_back(name);


### PR DESCRIPTION
Convert PlayerManager and PlayerManagerImpl objects to shared pointers
This fixes a segfault that occurs for clients that are still connected to a server when it shuts down