### PR TITLE
reduce auto-LT churn

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1070,8 +1070,8 @@ CPlayerManager *CAvaraGame::GetPlayerManager(CAbstractPlayer *thePlayer) {
 // FrameLatency is slightly different than LatencyTolerance.  It is in terms of integer frames
 // at the current frame rate.
 long CAvaraGame::RoundTripToFrameLatency(long roundTrip) {
-    // half of the roundTripTime in units of frameTime, rounded
-    return (roundTrip + frameTime) / (2*frameTime);
+    // half of the roundTripTime in units of frameTime, rounded up (ceil)
+    return (roundTrip/2 + frameTime) / frameTime;
 }
 
 // "frameLatency" is the integer number of frames to delay;
@@ -1090,7 +1090,7 @@ void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayer
         static int reduceLatencyCounter = 0;
         static int increaseLatencyCounter = 0;
         if (newLatency < latencyTolerance) {
-            static const int REDUCE_LATENCY_COUNT = 5;
+            static const int REDUCE_LATENCY_COUNT = 8;
             // need REDUCE_LATENCY_COUNT consecutive requests to reduce latency
             if (maxChange == MAX_LATENCY || ++reduceLatencyCounter >= REDUCE_LATENCY_COUNT) {
                 latencyTolerance = std::max(latencyTolerance-maxChange, std::max(newLatency, double(0.0)));
@@ -1098,7 +1098,7 @@ void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayer
                 increaseLatencyCounter = 0;
             }
         } else {
-            static const int INCREASE_LATENCY_COUNT = 2;
+            static const int INCREASE_LATENCY_COUNT = 1;
             if (maxChange == MAX_LATENCY || ++increaseLatencyCounter >= INCREASE_LATENCY_COUNT) {
                 latencyTolerance = std::min(latencyTolerance+maxChange, std::min(newLatency, double(MAX_LATENCY)));
                 reduceLatencyCounter = 0;

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -38,8 +38,9 @@
 #define AUTOLATENCYPERIOD 3840  // msec (divisible by 64)
 #define AUTOLATENCYDELAY  448   // msec (divisible by 64)
 #define LOWERLATENCYCOUNT   2
-#define HIGHERLATENCYCOUNT  12    // 4*(10/240) frames at fps=16ms, 1*10/60 frames at fps=64ms, works for all fps values
-#define DECREASELATENCYPERIOD (itsGame->TimeToFrameCount(AUTOLATENCYPERIOD*8))  // 30.72 seconds
+#define HIGHERLATENCYCOUNT  (0.25 * AUTOLATENCYPERIOD / itsGame->frameTime)       // 25% of frames
+#define DECREASELATENCYPERIOD (itsGame->TimeToFrameCount(AUTOLATENCYPERIOD*16))  // 16 consecutive votes ≈ 61 sec
+
 
 #if ROUTE_THRU_SERVER
     #define kAvaraNetVersion 666
@@ -810,7 +811,7 @@ void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
                     DBG_Log("lt+", "   >addOneLatency keeping = %hd\n", addOneLatency);
                     subtractOneCheck = frameNumber + DECREASELATENCYPERIOD;
                 } else if (addOneLatency > 0 && frameNumber >= subtractOneCheck) {
-                    // if no significant waiting seen for 8 CONSECUTIVE autoLatency votes, about 30 seconds, let it creep back down 1 fps frame
+                    // if no significant waiting seen for DECREASELATENCYPERIOD, let it creep back down 1 fps frame
                     addOneLatency--;
                     DBG_Log("lt+", "  --addOneLatency decreased = %hd\n", addOneLatency);
                     subtractOneCheck = frameNumber + DECREASELATENCYPERIOD;

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -121,7 +121,7 @@ public:
     //char msgBuffer[kMaxChatMessageBufferLen];
     std::vector<char> msgBuffer;
 
-    ~CNetManager() { Dispose(); };
+    virtual ~CNetManager() { Dispose(); };
     virtual void INetManager(CAvaraGame *theGame);
     virtual std::shared_ptr<CPlayerManager> CreatePlayerManager(short);
     virtual void LevelReset();

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -1906,10 +1906,10 @@ long CUDPComm::GetMaxRoundTrip(short distribution, short *slowPlayerId) {
 
     for (conn = connections; conn; conn = conn->next) {
         if (conn->port && (distribution & (1 << conn->myId))) {
-            // add in 2.58*stdev (~99% prob) but max it at CLASSICFRAMETIME (don't add more than 0.5 to LT)
+            // add in 3.0*stdev (~99.7% prob) but max it at CLASSICFRAMETIME (don't add more than 0.5 to LT)
             // note: is this really a erlang distribution?  if so, what's the proper equation?
             float stdev = sqrt(conn->varRoundTripTime);
-            float rtt = conn->meanRoundTripTime + std::min(2.58*stdev, (1.0*CLASSICFRAMECLOCK));
+            float rtt = conn->meanRoundTripTime + std::min(3.0*stdev, (1.0*CLASSICFRAMECLOCK));
             if (rtt > maxTrip) {
                 maxTrip = rtt;
                 if (slowPlayerId != nullptr) {

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -123,8 +123,8 @@ private:
 
 class TestNetManager : public CNetManager {
 public:
-    CPlayerManager* CreatePlayerManager(short id) {
-        return new TestPlayerManager(itsGame);
+    std::shared_ptr<CPlayerManager> CreatePlayerManager(short id) {
+        return std::make_shared<TestPlayerManager>(itsGame);
     }
 };
 


### PR DESCRIPTION
Biggest change is ceil on RoundTripToFrameLatency() calculation instead of round.  That helps to prevent LT being set too low then having to increase right away.

Also increased period for how often LT can be reduced.  And tweaked threshold for when to add 1 to LT so that it doesn't immediately go back up to previous LT as often.