### PR TITLE
Add text displays and lives to the new HUD

### DIFF
--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -205,12 +205,15 @@ public:
     CScaledBSP *grenadeLabel = 0;
     CScaledBSP *missileLabel = 0;
     CScaledBSP *boosterLabel = 0;
+    CScaledBSP *livesLabel = 0;
     CScaledBSP *grenadeBox[4] = {0, 0, 0, 0};
     CScaledBSP *missileBox[4] = {0, 0, 0, 0};
     CScaledBSP *boosterBox[4] = {0, 0, 0, 0};
+    CScaledBSP *livesBox[4] = {0, 0, 0, 0};
     CScaledBSP *grenadeMeter[4] = {0, 0, 0, 0};
     CScaledBSP *missileMeter[4] = {0, 0, 0, 0};
     CScaledBSP *boosterMeter[4] = {0, 0, 0, 0};
+    CScaledBSP *livesMeter[4] = {0, 0, 0, 0};
 
     // HUD Layout Prefs
     int layout;
@@ -219,6 +222,7 @@ public:
     int gaugeBSP;
     float arrowDistance;
     float arrowScale;
+    float livesPosition[2];
     float boosterPosition[2];
     float grenadePosition[2];
     float missilePosition[2];
@@ -226,6 +230,7 @@ public:
     float energyPosition[2];
     float offsetMultiplier;
     float boosterSpacing;
+    float livesSpacing;
     float weaponSpacing;
 
     virtual void BeginScript();

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -207,6 +207,7 @@ void CAvaraAppImpl::drawAll() {
 void CAvaraAppImpl::GameStarted(std::string set, std::string level) {
     animatePreview = false;
     itsGame->itsView->showTransparent = false;
+    itsGame->IncrementGameCounter();
     MessageLine(kmStarted, MsgAlignment::Center);
     levelWindow->AddRecent(set, level);
 }
@@ -359,13 +360,14 @@ void CAvaraAppImpl::AddMessageLine(
 
     msg.align = align;
     msg.category = category;
+    msg.gameId = itsGame->currentGameId;
 
     // split string on newlines
     while(std::getline(iss, line)) {
         SDL_Log("Message: %s", line.c_str());
         msg.text = line;
         messageLines.push_back(msg);
-        if (messageLines.size() > 5) {
+        if (messageLines.size() > 500) {
             messageLines.pop_front();
         }
     }

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -83,6 +83,10 @@ void CAvaraGame::InitLocatorTable() {
     }
 }
 
+void CAvaraGame::IncrementGameCounter() {
+    currentGameId++;
+}
+
 std::unique_ptr<CNetManager> CAvaraGame::CreateNetManager() {
     return std::make_unique<CNetManager>();
 }
@@ -159,7 +163,7 @@ void CAvaraGame::IAvaraGame(CAvaraApp *theApp) {
 
     nextPingTime = 0;
 
-    showOldHUD = gApplication->Get<bool>(kShowOldHUD);
+    showClassicHUD = gApplication->Get<bool>(kShowClassicHUD);
     showNewHUD = gApplication->Get<bool>(kShowNewHUD);
     // CalcGameRect();
 
@@ -1050,8 +1054,15 @@ void CAvaraGame::Render(NVGcontext *ctx) {
     AvaraGLSetDepthTest(false);
     hudWorld->Render(itsView);
     AvaraGLSetAmbient(ToFloat(itsView->ambientLight), itsView->ambientLightColor);
-    if (showOldHUD)
+
+    if (showClassicHUD) {
         hud->Render(itsView, ctx);
+    }
+
+    if (showNewHUD) {
+        hud->RenderNewHUD(itsView, ctx);
+    }
+
     AvaraGLSetDepthTest(true);
 }
 

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -84,6 +84,8 @@ public:
     bool isClassicFrame;
     int32_t frameAdjust;
 
+    int currentGameId = 0; // Increments when a new game starts
+
     FrameNumber topSentFrame;
 
     FrameTime frameTime; //	In milliseconds.
@@ -183,7 +185,7 @@ public:
     Boolean keysFromStdin;
     Boolean keysToStdout;
 
-    Boolean showOldHUD;
+    Boolean showClassicHUD;
     Boolean showNewHUD;
 
     // Moved here from GameLoop so it can run on the normal event loop
@@ -201,6 +203,7 @@ public:
     virtual std::unique_ptr<CNetManager> CreateNetManager();
 
     virtual void InitLocatorTable();
+    virtual void IncrementGameCounter();
 
     virtual CAbstractActor *FindIdent(long ident);
     virtual void GetIdent(CAbstractActor *theActor);

--- a/src/game/CHUD.h
+++ b/src/game/CHUD.h
@@ -14,6 +14,7 @@ public:
     virtual ~CHUD() {}
 
     void Render(CViewParameters *view, NVGcontext *ctx);
+    void RenderNewHUD(CViewParameters *view, NVGcontext *ctx);
     void DrawLevelName(CViewParameters *view, NVGcontext *ctx);
     void DrawPaused(CViewParameters *view, NVGcontext *ctx);
     void DrawScore(std::vector<CPlayerManager*>& thePlayers, int chudHeight, CViewParameters *view, NVGcontext *ctx);

--- a/src/game/Messages.h
+++ b/src/game/Messages.h
@@ -18,4 +18,5 @@ struct MsgLine {
     std::string text;
     MsgAlignment align;
     MsgCategory category;
+    int gameId;
 };

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -50,11 +50,24 @@ using json = nlohmann::json;
 #define kHUDCriticalColor "hudCriticalColor"
 #define kHUDAlpha "hudAlpha"
 #define kHUDPreset "hudPreset"
+#define kHUDInertia "hudInertia"
 #define kHUDArrowStyle "hudArrowStyle"
 #define kHUDArrowScale "hudArrowScale"
 #define kHUDArrowDistance "hudArrowDistance"
 #define kHUDShowMissileLock "hudShowMissileLock"
-#define kShowOldHUD "showOldHUD"
+#define kHUDShowShieldGauge "hudShowShieldGauge"
+#define kHUDShowEnergyGauge "hudShowEnergyGauge"
+#define kHUDShowBoosterCount "hudShowBoosterCount"
+#define kHUDShowGrenadeCount "hudShowGrenadeCount"
+#define kHUDShowMissileCount "hudShowMissileCount"
+#define kHUDShowLivesCount "hudShowLivesCount"
+#define kHUDShowLevelMessages "hudShowLevelMessages"
+#define kHUDShowSystemMessages "hudShowSystemMessages"
+#define kHUDShowPlayerList "hudShowPlayerList"
+#define kHUDShowDirArrow "hudShowDirArrow"
+#define kHUDShowScore "hudShowScore"
+#define kHUDShowTime "hudShowTime"
+#define kShowClassicHUD "showClassicHUD"
 #define kShowNewHUD "showNewHUD"
 
 // Network & Tracker
@@ -136,12 +149,24 @@ static json defaultPrefs = {
     {kHUDWarningColor, "#edd62d"},
     {kHUDCriticalColor, "#fa1313"},
     {kHUDAlpha, 1.0},
-    {kHUDPreset, 1},
+    {kHUDPreset, 2},
+    {kHUDInertia, 1.0},
     {kHUDArrowScale, 1.0},
     {kHUDArrowDistance, 8.0},
     {kHUDArrowStyle, 2},
     {kHUDShowMissileLock, true},
-    {kShowOldHUD, true},
+    {kHUDShowShieldGauge, true},
+    {kHUDShowEnergyGauge, true},
+    {kHUDShowBoosterCount, true},
+    {kHUDShowGrenadeCount, true},
+    {kHUDShowMissileCount, true},
+    {kHUDShowLivesCount, true},
+    {kHUDShowSystemMessages, true},
+    {kHUDShowLevelMessages, true},
+    {kHUDShowPlayerList, true},
+    {kHUDShowScore, true},
+    {kHUDShowTime, true},
+    {kShowClassicHUD, false},
     {kShowNewHUD, true},
     {kFrameTimeTag, 16},
     {kLastAddress, ""},


### PR DESCRIPTION
- Added Messages
- Messages in the new HUD layout are split into System and Level messages. This helps keep messages relevant to the level's objective visible to the player.
- Added a game counter
- Messages are marked with the current value of the game counter. Currently used to reset the message display when a new game starts.
- Increased the amount of stored system/level/error messages from 5 to 500

- Added the player list
- Added lives
- Added score and time

- new HUD elements can be enabled while classic HUD mode is also enabled
- New prefs
  - HUD Inertia: customize how much the HUD moves during a game
  - Individually show/hide each element in the new HUD (does not apply to classic HUD)

Split Message Displays
![image](https://github.com/avaraline/Avara/assets/1258387/e90792d9-f9bc-49f5-a868-c24712a4db99)

New Lives Display
![image](https://github.com/avaraline/Avara/assets/1258387/0562fa3e-9e42-49b4-87dc-bd46ecb02849)