### PR TITLE
use std::ceil instead of cleverness

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1071,7 +1071,7 @@ CPlayerManager *CAvaraGame::GetPlayerManager(CAbstractPlayer *thePlayer) {
 // at the current frame rate.
 long CAvaraGame::RoundTripToFrameLatency(long roundTrip) {
     // half of the roundTripTime in units of frameTime, rounded up (ceil)
-    return (roundTrip/2 + frameTime) / frameTime;
+    return std::ceil(roundTrip/2.0/frameTime);
 }
 
 // "frameLatency" is the integer number of frames to delay;


### PR DESCRIPTION
This allows LT to go to zero when playing locally and means that all exact LT boundaries will not be rounded up.