### PR TITLE
Add score events for ball games and fix score msg bugs

### DIFF
--- a/src/game/AvaraScoreInterface.h
+++ b/src/game/AvaraScoreInterface.h
@@ -58,6 +58,7 @@ typedef enum {
     ksiExitBonus,
     ksiGoodyBonus,
 
+    ksiGrabBall,
     ksiHoldBall,
     ksiScoreGoal
 

--- a/src/game/CBall.cpp
+++ b/src/game/CBall.cpp
@@ -401,10 +401,19 @@ void CBall::FrameAction() {
                 ChangeOwnership(theOwner->GetActorScoringId(), theOwner->teamColor);
                 watchTeams = ~(1 << teamColor);
 
+                if (lastOwner != theOwner->GetActorScoringId()) {
+                    itsGame->scoreReason = ksiGrabBall;
+                    itsGame->Score(
+                        theOwner->teamColor, theOwner->GetActorScoringId(), 0, 0, 0, -1);
+                    lastOwner = theOwner->GetActorScoringId();  // Only need to display the score message once
+                }
+
                 DoSound(reprogramSound, partList[0]->sphereGlobCenter, reprogramVolume, FIX1);
             }
 
             ownerChangeCount = -32767;
+        } else {
+            lastOwner = -1;
         }
     }
 

--- a/src/game/CBall.h
+++ b/src/game/CBall.h
@@ -50,6 +50,7 @@ public:
     long ownerChangeCount;
     long ownerChangeTime;
     short ownerScoringId;
+    short lastOwner;
     ARGBColor origLongColor = 0;
 
     short origTeam;

--- a/src/game/CScoreKeeper.cpp
+++ b/src/game/CScoreKeeper.cpp
@@ -251,10 +251,14 @@ void CScoreKeeper::Score(ScoreInterfaceReasons reason,
         iface.winFrame = itsGame->frameNumber;
     }
 
+    if(iface.scoreReason == ksiGrabBall) {
+        event.scoreType = ksiGrabBall;
+        itsGame->AddScoreNotify(event);
+    }
+
     if(iface.scoreReason == ksiHoldBall) {
         event.scoreType = ksiHoldBall;
-        itsGame->AddScoreNotify(event);
-        SDL_Log("CAvaraGame::Score Event: HOLD BALL!!");
+        //itsGame->AddScoreNotify(event);
     }
 
     if(iface.scoreReason == ksiScoreGoal) {
@@ -281,7 +285,7 @@ void CScoreKeeper::Score(ScoreInterfaceReasons reason,
         localScores.teamPoints[team] += points;
     }
 
-    SDL_Log("CAvaraGame::Score Event: player:%d, hit:%d, reason:%d,\n", iface.playerID, iface.scoreID, iface.scoreReason);
+    //SDL_Log("CAvaraGame::Score Event: player:%d, hit:%d, reason:%d,\n", iface.playerID, iface.scoreID, iface.scoreReason);
 }
 
 void CScoreKeeper::ResetScores() {


### PR DESCRIPTION
Scoring a goal with a ball creates a UI notify event
Added a new notify event when a player picks up a ball
Team colors are shown next to player names in the notify event list
Fixed a few bugs with the notify event queue

![image](https://github.com/avaraline/Avara/assets/1258387/f193bdd2-33b4-4339-9855-9b86ebd36c7c)
![image2](https://github.com/avaraline/Avara/assets/1258387/637f4f7d-f9fa-442d-b148-eec063d6cecd)
