### PR TITLE
Improved tracking for sources of explosion damage to accurately show correct weapon in the kill feed

### DIFF
--- a/src/game/AvaraScoreInterface.h
+++ b/src/game/AvaraScoreInterface.h
@@ -50,6 +50,7 @@ typedef enum {
     ksiGrenadeHit,
     ksiMissileHit,
     ksiMineBlast,
+    ksiParasiteBlast,
     ksiSelfDestructBlast,
     ksiObjectCollision, //	Running into a moving door for instance (not supported yet)
     ksiSecondaryDamage,

--- a/src/game/CAbstractActor.cpp
+++ b/src/game/CAbstractActor.cpp
@@ -724,7 +724,7 @@ void CAbstractActor::PostMortemBlast(short scoreTeam, short scoreId, Boolean doD
         Dispose();
 }
 
-bool CAbstractActor::SecondaryDamage(short scoreTeam, short scoreColor) {
+bool CAbstractActor::SecondaryDamage(short scoreTeam, short scoreColor, ScoreInterfaceReasons damageSource) {
     CAbstractActor *blastToo;
     bool imDead = false;
 
@@ -735,7 +735,7 @@ bool CAbstractActor::SecondaryDamage(short scoreTeam, short scoreColor) {
     while ((blastToo = gCurrentGame->postMortemList)) {
         gCurrentGame->postMortemList = blastToo->postMortemLink;
         if (blastToo != this) {
-            gCurrentGame->scoreReason = ksiSecondaryDamage;
+            gCurrentGame->scoreReason = damageSource;
         }
         if (blastToo == this) {
             imDead = true;

--- a/src/game/CAbstractActor.h
+++ b/src/game/CAbstractActor.h
@@ -175,7 +175,7 @@ public:
 
     virtual void RadiateDamage(BlastHitRecord *blastRecord);
     virtual void PostMortemBlast(short scoreTeam, short scoreId, Boolean doDispose);
-    virtual bool SecondaryDamage(short scoreTeam, short scoreColor);
+    virtual bool SecondaryDamage(short scoreTeam, short scoreColor, ScoreInterfaceReasons damageSource);
 
     virtual CSmartPart *DoCollisionTest(CSmartPart **hitList);
     virtual void BuildPartProximityList(Fixed *origin, Fixed range, MaskType filterMask);

--- a/src/game/CAbstractMissile.cpp
+++ b/src/game/CAbstractMissile.cpp
@@ -82,7 +82,7 @@ void CAbstractMissile::FrameAction() {
             }
             anActor = hitRec.closestHit->theOwner;
             anActor->WasHit(&hitRec, energy);
-            SecondaryDamage(hitRec.team, hitRec.playerId);
+            SecondaryDamage(hitRec.team, hitRec.playerId, ksiMissileHit);
         }
 
         Deactivate();

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -1308,7 +1308,7 @@ void CAbstractPlayer::KeyboardControl(FunctionTable *ft) {
 
                 WasDestroyed();
                 itsGame->scoreReason = ksiSelfDestructBlast;
-                SecondaryDamage(teamColor, GetActorScoringId());
+                SecondaryDamage(teamColor, GetActorScoringId(), ksiSelfDestructBlast);
                 didSelfDestruct = true;
             }
         }

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -163,7 +163,6 @@ void CAvaraGame::IAvaraGame(CAvaraApp *theApp) {
 
     nextPingTime = 0;
 
-    showClassicHUD = gApplication->Get<bool>(kShowClassicHUD);
     showNewHUD = gApplication->Get<bool>(kShowNewHUD);
     // CalcGameRect();
 
@@ -1084,12 +1083,10 @@ void CAvaraGame::Render(NVGcontext *ctx) {
     hudWorld->Render(itsView);
     AvaraGLSetAmbient(ToFloat(itsView->ambientLight), itsView->ambientLightColor);
 
-    if (showClassicHUD) {
-        hud->Render(itsView, ctx);
-    }
-
     if (showNewHUD) {
         hud->RenderNewHUD(itsView, ctx);
+    } else {
+        hud->Render(itsView, ctx);
     }
 
     AvaraGLSetDepthTest(true);

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -187,7 +187,6 @@ public:
     Boolean keysFromStdin;
     Boolean keysToStdout;
 
-    Boolean showClassicHUD;
     Boolean showNewHUD;
 
     // Moved here from GameLoop so it can run on the normal event loop

--- a/src/game/CBall.cpp
+++ b/src/game/CBall.cpp
@@ -494,7 +494,7 @@ void CBall::FrameAction() {
         switch (actionCommand) {
             case kDoSelfDestruct:
                 WasDestroyed();
-                SecondaryDamage(teamColor, -1);
+                SecondaryDamage(teamColor, -1, ksiObjectCollision);
                 return; //	*** return after dispose! ***
             case kDoRelease:
                 looseFrame = itsGame->FramesFromNow(100);

--- a/src/game/CDoorActor.cpp
+++ b/src/game/CDoorActor.cpp
@@ -105,7 +105,7 @@ void CDoorActor::TouchDamage() {
             }
         }
 
-        SecondaryDamage(teamColor, -1);
+        SecondaryDamage(teamColor, -1, ksiObjectCollision);
     }
 }
 

--- a/src/game/CFreeSolid.cpp
+++ b/src/game/CFreeSolid.cpp
@@ -224,7 +224,7 @@ void CFreeSolid::FrameAction() {
                         }
                     }
 
-                    if (SecondaryDamage(teamColor, -1)) {
+                    if (SecondaryDamage(teamColor, -1, ksiObjectCollision)) {
                         // just deallocated myself so return
                         return;
                     }

--- a/src/game/CHUD.h
+++ b/src/game/CHUD.h
@@ -20,6 +20,7 @@ public:
     void DrawPaused(CViewParameters *view, NVGcontext *ctx);
     void DrawScore(std::vector<CPlayerManager*>& thePlayers, int chudHeight, CViewParameters *view, NVGcontext *ctx);
     void DrawShadowBox(NVGcontext *ctx, int x, int y, int height, int width);
+    void DrawKillFeed(NVGcontext *ctx, CNetManager *net, int bufferWidth, float fontSize);
     void LoadImages(NVGcontext *ctx);
     void DrawImage(NVGcontext* ctx, int image, float alpha, float sx, float sy, float sw, float sh, float x, float y, float w, float h);
 

--- a/src/game/CMineActor.cpp
+++ b/src/game/CMineActor.cpp
@@ -181,7 +181,7 @@ void CMineActor::FrameAction() {
         if (activated) {
             WasDestroyed();
             itsGame->scoreReason = ksiMineBlast;
-            SecondaryDamage(teamColor, -1);
+            SecondaryDamage(teamColor, -1, ksiMineBlast);
             return;
         } else {
             lookNextTime = phase + lookTime;

--- a/src/game/CParasite.cpp
+++ b/src/game/CParasite.cpp
@@ -208,7 +208,7 @@ void CParasite::FrameAction() {
 
         if (blastPower >= maxPower) {
             WasDestroyed();
-            SecondaryDamage(teamColor, -1);
+            SecondaryDamage(teamColor, -1, ksiParasiteBlast);
             return;
         }
     } else {

--- a/src/game/CScoreKeeper.cpp
+++ b/src/game/CScoreKeeper.cpp
@@ -239,6 +239,7 @@ void CScoreKeeper::Score(ScoreInterfaceReasons reason,
             event.scoreType = ksiKillBonus;
             event.weaponUsed = itsGame->killReason;
             itsGame->AddScoreNotify(event);
+            SDL_Log("CAvaraGame::Kill Event: player:%lu, team:%lu, hit:%lu, hitTeam:%lu, weapon: %d, reason:%lu\n", iface.playerID, iface.playerTeam, iface.scoreID, iface.scoreTeam, event.weaponUsed, iface.scoreReason);
 
             iface.consoleLine = destStr;
             iface.consoleJustify = static_cast<long>(MsgAlignment::Center);
@@ -254,6 +255,7 @@ void CScoreKeeper::Score(ScoreInterfaceReasons reason,
     if(iface.scoreReason == ksiGrabBall) {
         event.scoreType = ksiGrabBall;
         itsGame->AddScoreNotify(event);
+        SDL_Log("CAvaraGame::Grab Ball Event: player:%lu, team:%lu, hit:%lu, hitTeam:%lu, reason:%lu\n", iface.playerID, iface.playerTeam, iface.scoreID, iface.scoreTeam, iface.scoreReason);
     }
 
     if(iface.scoreReason == ksiHoldBall) {
@@ -264,7 +266,7 @@ void CScoreKeeper::Score(ScoreInterfaceReasons reason,
     if(iface.scoreReason == ksiScoreGoal) {
         event.scoreType = ksiScoreGoal;
         itsGame->AddScoreNotify(event);
-        SDL_Log("CAvaraGame::Score Event: GOAL!!");
+        SDL_Log("CAvaraGame::Score Goal Event: player:%lu, team:%lu, hit:%lu, hitTeam:%lu, reason:%lu\n", iface.playerID, iface.playerTeam, iface.scoreID, iface.scoreTeam, iface.scoreReason);
     }
 
     iface.scorePoints = points;
@@ -285,7 +287,6 @@ void CScoreKeeper::Score(ScoreInterfaceReasons reason,
         localScores.teamPoints[team] += points;
     }
 
-    //SDL_Log("CAvaraGame::Score Event: player:%d, hit:%d, reason:%d,\n", iface.playerID, iface.scoreID, iface.scoreReason);
 }
 
 void CScoreKeeper::ResetScores() {

--- a/src/game/CWeapon.cpp
+++ b/src/game/CWeapon.cpp
@@ -134,13 +134,19 @@ void CWeapon::ShowTarget() {}
 
 void CWeapon::Explode() {
     Vector temp = {0, FIX1, 0, 0};
+    ScoreInterfaceReasons source = ksiNoReason;
 
     WasDestroyed();
 
     itsDepot->FireSlivers(
         15, location, temp, partList[0]->bigRadius >> 2, blastPower << 1, 160, 20, 0, itsDepot->smartSight);
 
-    SecondaryDamage(teamColor, ownerSlot);
+    if (weaponKind == 0) {
+        source = ksiGrenadeHit;
+    } else if (weaponKind == 1) {
+        source = ksiMissileHit;
+    }
+    SecondaryDamage(teamColor, ownerSlot, source);
 }
 
 void CWeapon::PostMortemBlast(short scoreTeam, short scoreColor, Boolean doDispose) {

--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -101,15 +101,23 @@ std::vector<std::string> CApplication::Matches(const std::string matchStr) {
     return results;
 }
 
-void CApplication::Update(const std::string name, std::string &value) {
+bool CApplication::Update(const std::string name, std::string &value) {
     // construct json from the inputs and update the internal JSON object
     if (_prefs.at(name).is_string()) {
         // wrap string values in quotes
         value = '"' + value + '"';
     }
-    json updatePref = json::parse("{ \"" + name + "\": " + value + "}");
-    _prefs.update(updatePref);
-    WritePrefs(_prefs);
+    try {
+        json updatePref = json::parse("{ \"" + name + "\": " + value + "}");
+        _prefs.update(updatePref);
+        WritePrefs(_prefs);
+    }
+    catch (json::parse_error &ex) {
+        // User typed in the command to change a pref. The value type did not match for the given pref
+        SDL_Log("User input value '%s' did not parse to the correct type.", name.c_str());
+        return false;  // Did not update pref
+    }
+    return true;  // Successfully updated pref
 }
 
 void CApplication::SavePrefs() {

--- a/src/gui/CApplication.h
+++ b/src/gui/CApplication.h
@@ -44,7 +44,8 @@ public:
             return static_cast<T>(_prefs.at(name));
         }
         catch (json::type_error &ex) {
-            // Type from json didn't match requested type so use hardcoded default instead
+            // This error is when the prefs file was changed manually and the value has the wrong type
+            // Type from user prefs json file didn't match requested type so use hardcoded default instead
             SDL_Log("Type Error trying to read '%s'. Using default", name.c_str());
             return static_cast<T>(_defaultPrefs.at(name));
         }
@@ -63,7 +64,7 @@ public:
         PrefChanged(name);
     }
 
-    void Update(const std::string name, std::string &value);
+    bool Update(const std::string name, std::string &value);
     void SavePrefs();
 
 protected:

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -68,7 +68,6 @@ using json = nlohmann::json;
 #define kHUDShowScore "hudShowScore"
 #define kHUDShowTime "hudShowTime"
 #define kHUDShowKillFeed "hudShowKillFeed"
-#define kShowClassicHUD "showClassicHUD"
 #define kShowNewHUD "showNewHUD"
 
 // Network & Tracker
@@ -168,7 +167,6 @@ static json defaultPrefs = {
     {kHUDShowScore, true},
     {kHUDShowTime, true},
     {kHUDShowKillFeed, true},
-    {kShowClassicHUD, false},
     {kShowNewHUD, true},
     {kFrameTimeTag, 16},
     {kLastAddress, ""},

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -504,10 +504,13 @@ bool CommandManager::GetSetPreference(VectorOfArgs vargs) {
                 newValue += " " + vargs[i];
             }
             // update pref
-            itsApp->Update(prefName, newValue);
-            //write prefs
-            itsApp->AddMessageLine(prefName + " changed from " + oldValue + " to " + newValue);
-            itsApp->CApplication::PrefChanged(prefName);
+            bool success = itsApp->Update(prefName, newValue);
+
+            if (success) {
+                //write prefs
+                itsApp->AddMessageLine(prefName + " changed from " + oldValue + " to " + newValue);
+                itsApp->CApplication::PrefChanged(prefName);
+            }
         }
     }
     return true;


### PR DESCRIPTION
Improved tracking for sources of explosion damage. The kill feed more accurately shows the correct weapon used to get a kill when explosions were involved

The kill feed can be enabled even if the old UI layout is enabled

Fixed an crash caused when the `/pref` command is invoked to set a pref to an invalid value

Removed redundant `showClassicHud` pref.
- `showNewHud = true` : use new UI layout
- `showNewHud = false` : use old UI layout