### PR TITLE
Standardize KOTH and Captures units & messaging

### DIFF
--- a/levels/avaraline-strict-mode/alf/bwadi-koth.alf
+++ b/levels/avaraline-strict-mode/alf/bwadi-koth.alf
@@ -6,6 +6,7 @@
   <Wall x="0" y="4.01" z="0" w="hillSize" d="hillSize" h="0" color="#003399" />
 
   <set
+    pReqPointMultiplier="1"
     pHillX="0"
     pHillY="4"
     pHillZ="0"

--- a/levels/avaraline-strict-mode/alf/logic/_koth-rules.alf
+++ b/levels/avaraline-strict-mode/alf/logic/_koth-rules.alf
@@ -1,3 +1,4 @@
+<!-- @param number pReqPointMultiplier scale the amount of *real* points required to win (it will always *report* 100 and increments of 10) -->
 <!-- @param int pPulse event for a hill "pulse" -->
 <!-- @param int pPulseEnd event for the end of a hill "pulse"  -->
 <!-- @param int pGreenEnters event for when green is on the hill -->
@@ -11,6 +12,7 @@
 
 <set
   defaultLives="999"
+  kScaledPoints="round(pReqPointMultiplier * 26)"
   kSnText="snTextBlip"
   kTextVolume="0.3"
 />
@@ -22,192 +24,128 @@
 <Timer in.0="mGreenWins" in.1="mYellowWins" in.2="mRedWins" in.3="mPinkWins" in.4="mPurpleWins" in.5="mBlueWins" in.6="mBlackWins" in.7="mWhiteWins" wait="1" out="mGameEnds" />
 <Teleporter start="mGameEnds" y="-10" activeRange="10000" shape="0" win="0" cx="0" cz="0" />
 
-<Timer in.0="@start" in.1="pPulse" wait="15" out.0="pPulse" />
+<Timer in.0="@start" in.1="pPulse" wait="5" out.0="pPulse" />
 <Timer in="pPulse" wait="1" out="pPulseEnd" />
-<Timer in="pPulse" wait="10" out.0="mGreenClose" out.1="mYellowClose" out.2="mRedClose" out.3="mPinkClose" out.4="mPurpleClose" out.5="mBlueClose" out.6="mBlackClose" out.7="mWhiteClose" />
+<Timer in="pPulse" wait="4" out.0="mGreenClose" out.1="mYellowClose" out.2="mRedClose" out.3="mPinkClose" out.4="mPurpleClose" out.5="mBlueClose" out.6="mBlackClose" out.7="mWhiteClose" />
 
-<unique vars="mIncrement mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
-<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="20" closeSpeed="100" open="pGreenEnters" didOpen="mIncrement" close="mGreenClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(1)" cx="-7" cz="0" y="-10" />
-<Counter in="mIncrement" n="10" out="mAt10" restart="false" />
-<Counter in="mIncrement" n="20" out="mAt20" restart="false" />
-<Counter in="mIncrement" n="30" out="mAt30" restart="false" />
-<Counter in="mIncrement" n="40" out="mAt40" restart="false" />
-<Counter in="mIncrement" n="50" out="mAt50" restart="false" />
-<Counter in="mIncrement" n="60" out="mAt60" restart="false" />
-<Counter in="mIncrement" n="70" out="mAt70" restart="false" />
-<Counter in="mIncrement" n="80" out="mAt80" restart="false" />
-<Counter in="mIncrement" n="90" out="mAt90" restart="false" />
-<Counter in="mIncrement" n="100" out="mGreenWins" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Green team has 10 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Green team has 20 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Green team has 30 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Green team has 40 seconds!" />
+<unique vars="mIncrement mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
+<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="35" closeSpeed="100" open="pGreenEnters" didOpen="mIncrement" close="mGreenClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(1)" cx="-7" cz="0" y="-10" />
+<Counter in="mIncrement" out="mNotify" n="kScaledPoints" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mGreenWins" restart="false" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Green team has 10 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Green team has 20 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Green team has 30 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Green team has 40 points!" />
 <Text sound="kSnText" volume="kTextVolume" in="mAt50" showEveryone="true" text="Green team has made it halfway!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Green team has 60 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Green team has 70 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Green team has 80 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Green team has only 10 seconds to go!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Green team has 60 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Green team has 70 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Green team has 80 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Green team has only 10 points to go!" />
 <Text sound="kSnText" volume="kTextVolume" in="mGreenWins" showEveryone="true" text="Green team wins!" />
 
-<unique vars="mIncrement mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
-<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="20" closeSpeed="100" open="pYellowEnters" didOpen="mIncrement" close="mYellowClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(2)" cx="-5" cz="0" y="-10" />
-<Counter in="mIncrement" n="10" out="mAt10" restart="false" />
-<Counter in="mIncrement" n="20" out="mAt20" restart="false" />
-<Counter in="mIncrement" n="30" out="mAt30" restart="false" />
-<Counter in="mIncrement" n="40" out="mAt40" restart="false" />
-<Counter in="mIncrement" n="50" out="mAt50" restart="false" />
-<Counter in="mIncrement" n="60" out="mAt60" restart="false" />
-<Counter in="mIncrement" n="70" out="mAt70" restart="false" />
-<Counter in="mIncrement" n="80" out="mAt80" restart="false" />
-<Counter in="mIncrement" n="90" out="mAt90" restart="false" />
-<Counter in="mIncrement" n="100" out="mYellowWins" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Yellow team has 10 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Yellow team has 20 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Yellow team has 30 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Yellow team has 40 seconds!" />
+<unique vars="mIncrement mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
+<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="35" closeSpeed="100" open="pYellowEnters" didOpen="mIncrement" close="mYellowClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(2)" cx="-5" cz="0" y="-10" />
+<Counter in="mIncrement" out="mNotify" n="kScaledPoints" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mYellowWins" restart="false" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Yellow team has 10 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Yellow team has 20 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Yellow team has 30 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Yellow team has 40 points!" />
 <Text sound="kSnText" volume="kTextVolume" in="mAt50" showEveryone="true" text="Yellow team has made it halfway!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Yellow team has 60 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Yellow team has 70 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Yellow team has 80 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Yellow team has only 10 seconds to go!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Yellow team has 60 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Yellow team has 70 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Yellow team has 80 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Yellow team has only 10 points to go!" />
 <Text sound="kSnText" volume="kTextVolume" in="mYellowWins" showEveryone="true" text="Yellow team wins!" />
 
-<unique vars="mIncrement mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
-<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="20" closeSpeed="100" open="pRedEnters" didOpen="mIncrement" close="mRedClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(3)" cx="-3" cz="0" y="-10" />
-<Counter in="mIncrement" n="10" out="mAt10" restart="false" />
-<Counter in="mIncrement" n="20" out="mAt20" restart="false" />
-<Counter in="mIncrement" n="30" out="mAt30" restart="false" />
-<Counter in="mIncrement" n="40" out="mAt40" restart="false" />
-<Counter in="mIncrement" n="50" out="mAt50" restart="false" />
-<Counter in="mIncrement" n="60" out="mAt60" restart="false" />
-<Counter in="mIncrement" n="70" out="mAt70" restart="false" />
-<Counter in="mIncrement" n="80" out="mAt80" restart="false" />
-<Counter in="mIncrement" n="90" out="mAt90" restart="false" />
-<Counter in="mIncrement" n="100" out="mRedWins" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Red team has 10 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Red team has 20 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Red team has 30 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Red team has 40 seconds!" />
+<unique vars="mIncrement mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
+<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="35" closeSpeed="100" open="pRedEnters" didOpen="mIncrement" close="mRedClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(3)" cx="-3" cz="0" y="-10" />
+<Counter in="mIncrement" out="mNotify" n="kScaledPoints" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mRedWins" restart="false" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Red team has 10 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Red team has 20 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Red team has 30 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Red team has 40 points!" />
 <Text sound="kSnText" volume="kTextVolume" in="mAt50" showEveryone="true" text="Red team has made it halfway!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Red team has 60 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Red team has 70 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Red team has 80 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Red team has only 10 seconds to go!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Red team has 60 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Red team has 70 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Red team has 80 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Red team has only 10 points to go!" />
 <Text sound="kSnText" volume="kTextVolume" in="mRedWins" showEveryone="true" text="Red team wins!" />
 
-<unique vars="mIncrement mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
-<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="20" closeSpeed="100" open="pPinkEnters" didOpen="mIncrement" close="mPinkClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(4)" cx="-1" cz="0" y="-10" />
-<Counter in="mIncrement" n="10" out="mAt10" restart="false" />
-<Counter in="mIncrement" n="20" out="mAt20" restart="false" />
-<Counter in="mIncrement" n="30" out="mAt30" restart="false" />
-<Counter in="mIncrement" n="40" out="mAt40" restart="false" />
-<Counter in="mIncrement" n="50" out="mAt50" restart="false" />
-<Counter in="mIncrement" n="60" out="mAt60" restart="false" />
-<Counter in="mIncrement" n="70" out="mAt70" restart="false" />
-<Counter in="mIncrement" n="80" out="mAt80" restart="false" />
-<Counter in="mIncrement" n="90" out="mAt90" restart="false" />
-<Counter in="mIncrement" n="100" out="mPinkWins" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Pink team has 10 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Pink team has 20 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Pink team has 30 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Pink team has 40 seconds!" />
+<unique vars="mIncrement mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
+<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="35" closeSpeed="100" open="pPinkEnters" didOpen="mIncrement" close="mPinkClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(4)" cx="-1" cz="0" y="-10" />
+<Counter in="mIncrement" out="mNotify" n="kScaledPoints" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mPinkWins" restart="false" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Pink team has 10 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Pink team has 20 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Pink team has 30 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Pink team has 40 points!" />
 <Text sound="kSnText" volume="kTextVolume" in="mAt50" showEveryone="true" text="Pink team has made it halfway!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Pink team has 60 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Pink team has 70 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Pink team has 80 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Pink team has only 10 seconds to go!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Pink team has 60 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Pink team has 70 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Pink team has 80 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Pink team has only 10 points to go!" />
 <Text sound="kSnText" volume="kTextVolume" in="mPinkWins" showEveryone="true" text="Pink team wins!" />
 
-<unique vars="mIncrement mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
-<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="20" closeSpeed="100" open="pPurpleEnters" didOpen="mIncrement" close="mPurpleClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(5)" cx="1" cz="0" y="-10" />
-<Counter in="mIncrement" n="10" out="mAt10" restart="false" />
-<Counter in="mIncrement" n="20" out="mAt20" restart="false" />
-<Counter in="mIncrement" n="30" out="mAt30" restart="false" />
-<Counter in="mIncrement" n="40" out="mAt40" restart="false" />
-<Counter in="mIncrement" n="50" out="mAt50" restart="false" />
-<Counter in="mIncrement" n="60" out="mAt60" restart="false" />
-<Counter in="mIncrement" n="70" out="mAt70" restart="false" />
-<Counter in="mIncrement" n="80" out="mAt80" restart="false" />
-<Counter in="mIncrement" n="90" out="mAt90" restart="false" />
-<Counter in="mIncrement" n="100" out="mPurpleWins" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Purple team has 10 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Purple team has 20 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Purple team has 30 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Purple team has 40 seconds!" />
+<unique vars="mIncrement mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
+<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="35" closeSpeed="100" open="pPurpleEnters" didOpen="mIncrement" close="mPurpleClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(5)" cx="1" cz="0" y="-10" />
+<Counter in="mIncrement" out="mNotify" n="kScaledPoints" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mPurpleWins" restart="false" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Purple team has 10 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Purple team has 20 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Purple team has 30 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Purple team has 40 points!" />
 <Text sound="kSnText" volume="kTextVolume" in="mAt50" showEveryone="true" text="Purple team has made it halfway!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Purple team has 60 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Purple team has 70 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Purple team has 80 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Purple team has only 10 seconds to go!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Purple team has 60 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Purple team has 70 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Purple team has 80 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Purple team has only 10 points to go!" />
 <Text sound="kSnText" volume="kTextVolume" in="mPurpleWins" showEveryone="true" text="Purple team wins!" />
 
-<unique vars="mIncrement mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
-<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="20" closeSpeed="100" open="pBlueEnters" didOpen="mIncrement" close="mBlueClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(6)" cx="3" cz="0" y="-10" />
-<Counter in="mIncrement" n="10" out="mAt10" restart="false" />
-<Counter in="mIncrement" n="20" out="mAt20" restart="false" />
-<Counter in="mIncrement" n="30" out="mAt30" restart="false" />
-<Counter in="mIncrement" n="40" out="mAt40" restart="false" />
-<Counter in="mIncrement" n="50" out="mAt50" restart="false" />
-<Counter in="mIncrement" n="60" out="mAt60" restart="false" />
-<Counter in="mIncrement" n="70" out="mAt70" restart="false" />
-<Counter in="mIncrement" n="80" out="mAt80" restart="false" />
-<Counter in="mIncrement" n="90" out="mAt90" restart="false" />
-<Counter in="mIncrement" n="100" out="mBlueWins" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Blue team has 10 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Blue team has 20 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Blue team has 30 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Blue team has 40 seconds!" />
+<unique vars="mIncrement mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
+<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="35" closeSpeed="100" open="pBlueEnters" didOpen="mIncrement" close="mBlueClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(6)" cx="3" cz="0" y="-10" />
+<Counter in="mIncrement" out="mNotify" n="kScaledPoints" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mBlueWins" restart="false" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Blue team has 10 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Blue team has 20 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Blue team has 30 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Blue team has 40 points!" />
 <Text sound="kSnText" volume="kTextVolume" in="mAt50" showEveryone="true" text="Blue team has made it halfway!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Blue team has 60 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Blue team has 70 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Blue team has 80 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Blue team has only 10 seconds to go!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Blue team has 60 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Blue team has 70 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Blue team has 80 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Blue team has only 10 points to go!" />
 <Text sound="kSnText" volume="kTextVolume" in="mBlueWins" showEveryone="true" text="Blue team wins!" />
 
-<unique vars="mIncrement mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
-<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="20" closeSpeed="100" open="pBlackEnters" didOpen="mIncrement" close="mBlackClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(7)" cx="5" cz="0" y="-10" />
-<Counter in="mIncrement" n="10" out="mAt10" restart="false" />
-<Counter in="mIncrement" n="20" out="mAt20" restart="false" />
-<Counter in="mIncrement" n="30" out="mAt30" restart="false" />
-<Counter in="mIncrement" n="40" out="mAt40" restart="false" />
-<Counter in="mIncrement" n="50" out="mAt50" restart="false" />
-<Counter in="mIncrement" n="60" out="mAt60" restart="false" />
-<Counter in="mIncrement" n="70" out="mAt70" restart="false" />
-<Counter in="mIncrement" n="80" out="mAt80" restart="false" />
-<Counter in="mIncrement" n="90" out="mAt90" restart="false" />
-<Counter in="mIncrement" n="100" out="mBlackWins" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Black team has 10 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Black team has 20 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Black team has 30 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Black team has 40 seconds!" />
+<unique vars="mIncrement mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
+<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="35" closeSpeed="100" open="pBlackEnters" didOpen="mIncrement" close="mBlackClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(7)" cx="5" cz="0" y="-10" />
+<Counter in="mIncrement" out="mNotify" n="kScaledPoints" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mBlackWins" restart="false" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="Black team has 10 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="Black team has 20 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="Black team has 30 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="Black team has 40 points!" />
 <Text sound="kSnText" volume="kTextVolume" in="mAt50" showEveryone="true" text="Black team has made it halfway!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Black team has 60 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Black team has 70 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Black team has 80 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Black team has only 10 seconds to go!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="Black team has 60 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="Black team has 70 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="Black team has 80 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="Black team has only 10 points to go!" />
 <Text sound="kSnText" volume="kTextVolume" in="mBlackWins" showEveryone="true" text="Black team wins!" />
 
-<unique vars="mIncrement mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
-<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="20" closeSpeed="100" open="pWhiteEnters" didOpen="mIncrement" close="mWhiteClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(8)" cx="7" cz="0" y="-10" />
-<Counter in="mIncrement" n="10" out="mAt10" restart="false" />
-<Counter in="mIncrement" n="20" out="mAt20" restart="false" />
-<Counter in="mIncrement" n="30" out="mAt30" restart="false" />
-<Counter in="mIncrement" n="40" out="mAt40" restart="false" />
-<Counter in="mIncrement" n="50" out="mAt50" restart="false" />
-<Counter in="mIncrement" n="60" out="mAt60" restart="false" />
-<Counter in="mIncrement" n="70" out="mAt70" restart="false" />
-<Counter in="mIncrement" n="80" out="mAt80" restart="false" />
-<Counter in="mIncrement" n="90" out="mAt90" restart="false" />
-<Counter in="mIncrement" n="100" out="mWhiteWins" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="White team has 10 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="White team has 20 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="White team has 30 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="White team has 40 seconds!" />
+<unique vars="mIncrement mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
+<Door yon="0.001" shape="bspSliver0" deltaY="3" openSpeed="35" closeSpeed="100" open="pWhiteEnters" didOpen="mIncrement" close="mWhiteClose" openSound="0" stopSound="0" closeSound="0" hitSound="0" color="team(8)" cx="7" cz="0" y="-10" />
+<Counter in="mIncrement" out="mNotify" n="kScaledPoints" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mWhiteWins" restart="false" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt10" showEveryone="true" text="White team has 10 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt20" showEveryone="true" text="White team has 20 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt30" showEveryone="true" text="White team has 30 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt40" showEveryone="true" text="White team has 40 points!" />
 <Text sound="kSnText" volume="kTextVolume" in="mAt50" showEveryone="true" text="White team has made it halfway!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="White team has 60 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="White team has 70 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="White team has 80 seconds!" />
-<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="White team has only 10 seconds to go!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt60" showEveryone="true" text="White team has 60 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt70" showEveryone="true" text="White team has 70 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt80" showEveryone="true" text="White team has 80 points!" />
+<Text sound="kSnText" volume="kTextVolume" in="mAt90" showEveryone="true" text="White team has only 10 points to go!" />
 <Text sound="kSnText" volume="kTextVolume" in="mWhiteWins" showEveryone="true" text="White team wins!" />
 
 <!-- Hill ownership must be exclusive! -->

--- a/levels/avaraline-strict-mode/alf/logic/capture-rules.alf
+++ b/levels/avaraline-strict-mode/alf/logic/capture-rules.alf
@@ -1,8 +1,8 @@
-<!-- @param number pReqPointMultiplier scale the amount of *real* points required to win (it will always *report* 150 and increments of 15) -->
+<!-- @param number pReqPointMultiplier scale the amount of *real* points required to win (it will always *report* 100 and increments of 10) -->
 
 <set
   defaultLives="999"
-  kScaledPoints="round(pReqPointMultiplier * 120)"
+  kScaledPoints="round(pReqPointMultiplier * 104)"
   kSnText="snTextBlip"
   kTextVolume="0.3"
 />
@@ -17,122 +17,114 @@
 <Timer in.0="mGreenWins" in.1="mYellowWins" in.2="mRedWins" in.3="mPinkWins" in.4="mPurpleWins" in.5="mBlueWins" in.6="mBlackWins" in.7="mWhiteWins" wait="1" out="mGameEnds" />
 <Teleporter start="mGameEnds" y="-10" activeRange="10000" shape="0" win="0" cx="0" cz="0" />
 
-<unique vars="mNotify mAt15 mAt30 mAt45 mAt60 mAt75 mAt90 mAt105 mAt120 mAt135 mAt150" />
+<unique vars="mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
 <Counter in="pGreenPoint" out="mNotify" n="kScaledPoints" />
-<Distributor in="mNotify" out.0="mAt15" out.1="mAt30" out.2="mAt45" out.3="mAt60" out.4="mAt75" out.5="mAt90" out.6="mAt105" out.7="mAt120" out.8="mAt135" out.9="mAt150" restart="false" />
-<And in="mAt150" out="mGreenWins" />
-<Text showEveryone="true" text="Green has 15 points." in="mAt15" sound="kSnText" volume="kTextVolume" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mGreenWins" restart="false" />
+<Text showEveryone="true" text="Green has 10 points." in="mAt10" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Green has 20 points." in="mAt20" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Green has 30 points." in="mAt30" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Green has 45 points." in="mAt45" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Green has 40 points." in="mAt40" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Green team has made it halfway!" in="mAt50" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Green has 60 points." in="mAt60" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Green has 75 points." in="mAt75" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Green has 90 points." in="mAt90" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Green has 105 points." in="mAt105" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Green has 120 points." in="mAt120" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Green has 135 points." in="mAt135" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Green has 150 points. Green team wins!" in="mAt150" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Green has 70 points." in="mAt70" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Green has 80 points." in="mAt80" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Green team has only 10 points to go!" in="mAt90" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Green team wins!" in="mGreenWins" sound="kSnText" volume="kTextVolume" />
 
-<unique vars="mNotify mAt15 mAt30 mAt45 mAt60 mAt75 mAt90 mAt105 mAt120 mAt135 mAt150" />
+<unique vars="mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
 <Counter in="pYellowPoint" out="mNotify" n="kScaledPoints" />
-<Distributor in="mNotify" out.0="mAt15" out.1="mAt30" out.2="mAt45" out.3="mAt60" out.4="mAt75" out.5="mAt90" out.6="mAt105" out.7="mAt120" out.8="mAt135" out.9="mAt150" restart="false" />
-<And in="mAt150" out="mYellowWins" />
-<Text showEveryone="true" text="Yellow has 15 points." in="mAt15" sound="kSnText" volume="kTextVolume" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mYellowWins" restart="false" />
+<Text showEveryone="true" text="Yellow has 10 points." in="mAt10" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Yellow has 20 points." in="mAt20" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Yellow has 30 points." in="mAt30" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Yellow has 45 points." in="mAt45" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Yellow has 40 points." in="mAt40" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Yellow team has made it halfway!" in="mAt50" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Yellow has 60 points." in="mAt60" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Yellow has 75 points." in="mAt75" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Yellow has 90 points." in="mAt90" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Yellow has 105 points." in="mAt105" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Yellow has 120 points." in="mAt120" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Yellow has 135 points." in="mAt135" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Yellow has 150 points. Yellow team wins!" in="mAt150" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Yellow has 70 points." in="mAt70" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Yellow has 80 points." in="mAt80" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Yellow team has only 10 points to go!" in="mAt90" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Yellow team wins!" in="mYellowWins" sound="kSnText" volume="kTextVolume" />
 
-<unique vars="mNotify mAt15 mAt30 mAt45 mAt60 mAt75 mAt90 mAt105 mAt120 mAt135 mAt150" />
+<unique vars="mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
 <Counter in="pRedPoint" out="mNotify" n="kScaledPoints" />
-<Distributor in="mNotify" out.0="mAt15" out.1="mAt30" out.2="mAt45" out.3="mAt60" out.4="mAt75" out.5="mAt90" out.6="mAt105" out.7="mAt120" out.8="mAt135" out.9="mAt150" restart="false" />
-<And in="mAt150" out="mRedWins" />
-<Text showEveryone="true" text="Red has 15 points." in="mAt15" sound="kSnText" volume="kTextVolume" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mRedWins" restart="false" />
+<Text showEveryone="true" text="Red has 10 points." in="mAt10" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Red has 20 points." in="mAt20" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Red has 30 points." in="mAt30" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Red has 45 points." in="mAt45" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Red has 40 points." in="mAt40" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Red team has made it halfway!" in="mAt50" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Red has 60 points." in="mAt60" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Red has 75 points." in="mAt75" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Red has 90 points." in="mAt90" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Red has 105 points." in="mAt105" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Red has 120 points." in="mAt120" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Red has 135 points." in="mAt135" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Red has 150 points. Red team wins!" in="mAt150" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Red has 70 points." in="mAt70" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Red has 80 points." in="mAt80" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Red team has only 10 points to go!" in="mAt90" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Red team wins!" in="mRedWins" sound="kSnText" volume="kTextVolume" />
 
-<unique vars="mNotify mAt15 mAt30 mAt45 mAt60 mAt75 mAt90 mAt105 mAt120 mAt135 mAt150" />
+<unique vars="mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
 <Counter in="pPinkPoint" out="mNotify" n="kScaledPoints" />
-<Distributor in="mNotify" out.0="mAt15" out.1="mAt30" out.2="mAt45" out.3="mAt60" out.4="mAt75" out.5="mAt90" out.6="mAt105" out.7="mAt120" out.8="mAt135" out.9="mAt150" restart="false" />
-<And in="mAt150" out="mPinkWins" />
-<Text showEveryone="true" text="Pink has 15 points." in="mAt15" sound="kSnText" volume="kTextVolume" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mPinkWins" restart="false" />
+<Text showEveryone="true" text="Pink has 10 points." in="mAt10" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Pink has 20 points." in="mAt20" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Pink has 30 points." in="mAt30" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Pink has 45 points." in="mAt45" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Pink has 40 points." in="mAt40" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Pink team has made it halfway!" in="mAt50" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Pink has 60 points." in="mAt60" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Pink has 75 points." in="mAt75" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Pink has 90 points." in="mAt90" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Pink has 105 points." in="mAt105" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Pink has 120 points." in="mAt120" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Pink has 135 points." in="mAt135" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Pink has 150 points. Pink team wins!" in="mAt150" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Pink has 70 points." in="mAt70" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Pink has 80 points." in="mAt80" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Pink team has only 10 points to go!" in="mAt90" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Pink team wins!" in="mPinkWins" sound="kSnText" volume="kTextVolume" />
 
-<unique vars="mNotify mAt15 mAt30 mAt45 mAt60 mAt75 mAt90 mAt105 mAt120 mAt135 mAt150" />
+<unique vars="mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
 <Counter in="pPurplePoint" out="mNotify" n="kScaledPoints" />
-<Distributor in="mNotify" out.0="mAt15" out.1="mAt30" out.2="mAt45" out.3="mAt60" out.4="mAt75" out.5="mAt90" out.6="mAt105" out.7="mAt120" out.8="mAt135" out.9="mAt150" restart="false" />
-<And in="mAt150" out="mPurpleWins" />
-<Text showEveryone="true" text="Purple has 15 points." in="mAt15" sound="kSnText" volume="kTextVolume" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mPurpleWins" restart="false" />
+<Text showEveryone="true" text="Purple has 10 points." in="mAt10" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Purple has 20 points." in="mAt20" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Purple has 30 points." in="mAt30" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Purple has 45 points." in="mAt45" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Purple has 40 points." in="mAt40" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Purple team has made it halfway!" in="mAt50" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Purple has 60 points." in="mAt60" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Purple has 75 points." in="mAt75" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Purple has 90 points." in="mAt90" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Purple has 105 points." in="mAt105" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Purple has 120 points." in="mAt120" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Purple has 135 points." in="mAt135" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Purple has 150 points. Purple team wins!" in="mAt150" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Purple has 70 points." in="mAt70" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Purple has 80 points." in="mAt80" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Purple team has only 10 points to go!" in="mAt90" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Purple team wins!" in="mPurpleWins" sound="kSnText" volume="kTextVolume" />
 
-<unique vars="mNotify mAt15 mAt30 mAt45 mAt60 mAt75 mAt90 mAt105 mAt120 mAt135 mAt150" />
+<unique vars="mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
 <Counter in="pBluePoint" out="mNotify" n="kScaledPoints" />
-<Distributor in="mNotify" out.0="mAt15" out.1="mAt30" out.2="mAt45" out.3="mAt60" out.4="mAt75" out.5="mAt90" out.6="mAt105" out.7="mAt120" out.8="mAt135" out.9="mAt150" restart="false" />
-<And in="mAt150" out="mBlueWins" />
-<Text showEveryone="true" text="Blue has 15 points." in="mAt15" sound="kSnText" volume="kTextVolume" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mBlueWins" restart="false" />
+<Text showEveryone="true" text="Blue has 10 points." in="mAt10" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Blue has 20 points." in="mAt20" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Blue has 30 points." in="mAt30" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Blue has 45 points." in="mAt45" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Blue has 40 points." in="mAt40" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Blue team has made it halfway!" in="mAt50" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Blue has 60 points." in="mAt60" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Blue has 75 points." in="mAt75" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Blue has 90 points." in="mAt90" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Blue has 105 points." in="mAt105" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Blue has 120 points." in="mAt120" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Blue has 135 points." in="mAt135" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Blue has 150 points. Blue team wins!" in="mAt150" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Blue has 70 points." in="mAt70" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Blue has 80 points." in="mAt80" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Blue team has only 10 points to go!" in="mAt90" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Blue team wins!" in="mBlueWins" sound="kSnText" volume="kTextVolume" />
 
-<unique vars="mNotify mAt15 mAt30 mAt45 mAt60 mAt75 mAt90 mAt105 mAt120 mAt135 mAt150" />
+<unique vars="mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
 <Counter in="pBlackPoint" out="mNotify" n="kScaledPoints" />
-<Distributor in="mNotify" out.0="mAt15" out.1="mAt30" out.2="mAt45" out.3="mAt60" out.4="mAt75" out.5="mAt90" out.6="mAt105" out.7="mAt120" out.8="mAt135" out.9="mAt150" restart="false" />
-<And in="mAt150" out="mBlackWins" />
-<Text showEveryone="true" text="Black has 15 points." in="mAt15" sound="kSnText" volume="kTextVolume" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mBlackWins" restart="false" />
+<Text showEveryone="true" text="Black has 10 points." in="mAt10" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Black has 20 points." in="mAt20" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Black has 30 points." in="mAt30" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Black has 45 points." in="mAt45" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Black has 40 points." in="mAt40" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Black team has made it halfway!" in="mAt50" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="Black has 60 points." in="mAt60" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Black has 75 points." in="mAt75" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Black has 90 points." in="mAt90" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Black has 105 points." in="mAt105" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Black has 120 points." in="mAt120" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Black has 135 points." in="mAt135" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="Black has 150 points. Black team wins!" in="mAt150" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Black has 70 points." in="mAt70" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Black has 80 points." in="mAt80" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Black team has only 10 points to go!" in="mAt90" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="Black team wins!" in="mBlackWins" sound="kSnText" volume="kTextVolume" />
 
-<unique vars="mNotify mAt15 mAt30 mAt45 mAt60 mAt75 mAt90 mAt105 mAt120 mAt135 mAt150" />
+<unique vars="mNotify mAt10 mAt20 mAt30 mAt40 mAt50 mAt60 mAt70 mAt80 mAt90" />
 <Counter in="pWhitePoint" out="mNotify" n="kScaledPoints" />
-<Distributor in="mNotify" out.0="mAt15" out.1="mAt30" out.2="mAt45" out.3="mAt60" out.4="mAt75" out.5="mAt90" out.6="mAt105" out.7="mAt120" out.8="mAt135" out.9="mAt150" restart="false" />
-<And in="mAt150" out="mWhiteWins" />
-<Text showEveryone="true" text="White has 15 points." in="mAt15" sound="kSnText" volume="kTextVolume" />
+<Distributor in="mNotify" out.0="mAt10" out.1="mAt20" out.2="mAt30" out.3="mAt40" out.4="mAt50" out.5="mAt60" out.6="mAt70" out.7="mAt80" out.8="mAt90" out.9="mWhiteWins" restart="false" />
+<Text showEveryone="true" text="White has 10 points." in="mAt10" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="White has 20 points." in="mAt20" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="White has 30 points." in="mAt30" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="White has 45 points." in="mAt45" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="White has 40 points." in="mAt40" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="White team has made it halfway!" in="mAt50" sound="kSnText" volume="kTextVolume" />
 <Text showEveryone="true" text="White has 60 points." in="mAt60" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="White has 75 points." in="mAt75" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="White has 90 points." in="mAt90" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="White has 105 points." in="mAt105" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="White has 120 points." in="mAt120" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="White has 135 points." in="mAt135" sound="kSnText" volume="kTextVolume" />
-<Text showEveryone="true" text="White has 150 points. White team wins!" in="mAt150" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="White has 70 points." in="mAt70" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="White has 80 points." in="mAt80" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="White team has only 10 points to go!" in="mAt90" sound="kSnText" volume="kTextVolume" />
+<Text showEveryone="true" text="White team wins!" in="mWhiteWins" sound="kSnText" volume="kTextVolume" />

--- a/levels/avaraline-strict-mode/alf/logic/koth.alf
+++ b/levels/avaraline-strict-mode/alf/logic/koth.alf
@@ -1,3 +1,4 @@
+<!-- @param number pReqPointMultiplier scale the amount of *real* points required to win (it will always *report* 100 and increments of 10) -->
 <!-- @param number pHillX the x-coordinate for the hill -->
 <!-- @param number pHillY the y-coordinate for the hill -->
 <!-- @param number pHillZ the z-coordinate for the hill -->

--- a/levels/avaraline-strict-mode/alf/stratocaster-hss-koth.alf
+++ b/levels/avaraline-strict-mode/alf/stratocaster-hss-koth.alf
@@ -5,6 +5,7 @@
   <Wall x="0" y="4.01" z="0" w="hillSize" d="hillSize" h="0" color="#ffcc33" />
 
   <set
+    pReqPointMultiplier="1"
     pHillX="0"
     pHillY="4"
     pHillZ="0"


### PR DESCRIPTION
Instead of reporting time in seconds in KOTH, I've moved to using "points" as I was in captures. I've also standardized reporting intervals to every ten points (was previously fifteen in Captures), with a max goal of 100. However, the true value of these "points" is still scaleable under the hood via the `pReqPointMultiplier` parameter, which was the main motivation for this change on the KOTH side. Both game modes also underwent minor simplifications to reduce the number of game objects in use.

Unscaled KOTH games still require a team to be on the hill for 100 seconds in order to win, so functionally there is no gameplay difference.

Unscaled Captures games now acquire 10 points for every ~40 seconds a single capture point is being held, so more or less exactly 4x slower than unscaled KOTH games. This seems appropriate given you don't need to be standing on it to accrue time, and there are likely multiple capture points per level.