### PR TITLE
Initiate ready check when a player switches to away/spectator

### DIFF
--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -1553,8 +1553,12 @@ void CAbstractPlayer::PlayerAction() {
                         Reincarnate();
                     } else {
                         itsManager->DeadOrDone();
-                        if ((itsGame->GetSpectatePlayer() == NULL && itsManager->IsLocalPlayer()) ||                // Player is out of lives
-                            (itsGame->GetSpectatePlayer() != NULL && itsGame->GetSpectatePlayer()->lives == 0)) {    // Spectate player is out of lives
+
+                        // Auto spectate another player if:
+                        //   - The player runs out of lives
+                        //   - The player being spectated runs out of lives
+                        if ((itsGame->GetSpectatePlayer() == NULL && itsManager->IsLocalPlayer()) ||
+                            (itsGame->GetSpectatePlayer() != NULL && itsGame->GetSpectatePlayer()->lives == 0)) {
                             itsGame->SpectateNext();
                         }
                     }

--- a/src/game/CHUD.cpp
+++ b/src/game/CHUD.cpp
@@ -842,7 +842,7 @@ void CHUD::DrawKillFeed(NVGcontext *ctx, CNetManager *net, int bufferWidth, floa
                     nvgFillColor(ctx, BACKGROUND_COLOR);
                     nvgFill(ctx);
 
-                    ARGBColor longTeamColor = *ColorManager::getTeamColor(net->teamColors[event.team]);
+                    ARGBColor longTeamColor = *ColorManager::getTeamColor(event.team);
                     longTeamColor.ExportGLFloats(teamColorRGB, 3);
 
                     nvgBeginPath(ctx);
@@ -886,7 +886,7 @@ void CHUD::DrawKillFeed(NVGcontext *ctx, CNetManager *net, int bufferWidth, floa
                     nvgFillColor(ctx, BACKGROUND_COLOR);
                     nvgFill(ctx);
 
-                    ARGBColor longTeamColor = *ColorManager::getTeamColor(net->teamColors[event.team]);
+                    ARGBColor longTeamColor = *ColorManager::getTeamColor(event.team);
                     longTeamColor.ExportGLFloats(teamColorRGB, 3);
 
                     nvgBeginPath(ctx);

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -1101,6 +1101,12 @@ void CPlayerManagerImpl::SetPlayerStatus(LoadingState newStatus, PresenceType ne
 
     loadingStatus = newStatus;
     presence = newPresence;
+    
+    // Check if the game is ready to start if a player set themselves to away or spectator
+    // Only the server can start the game this way to prevent multiple game start commands
+    if ((newPresence == kzSpectating || newPresence == kzAway) && theNetManager->itsCommManager->myId == 0) {
+        SetPlayerReady(true);
+    }
 }
 
 void CPlayerManagerImpl::SetPlayerReady(bool isReady) {


### PR DESCRIPTION
When a player switches their status to away/spectator and all other players have the ready status then automatically start the game.

Also fix a bug in the kill feed with team colors for ball events