### PR TITLE
Fix bug with wall crush events when using the text kill feed

### DIFF
--- a/src/game/CScoreKeeper.cpp
+++ b/src/game/CScoreKeeper.cpp
@@ -255,7 +255,7 @@ void CScoreKeeper::Score(ScoreInterfaceReasons reason,
                 iface.consoleLine = destStr;
                 iface.consoleJustify = static_cast<long>(MsgAlignment::Center);
                 itsGame->itsApp->ComposeParamLine(
-                    destStr, kmKilledByCollision, itsGame->itsNet->playerTable[hitPlayer]->PlayerName(), NULL);
+                    destStr, kmKilledByCollision, itsGame->itsNet->playerTable[player]->PlayerName(), NULL);
             }
 
             event.scoreType = ksiKillBonus;


### PR DESCRIPTION
Fix incorrect reference when sending text message for a player killed by a free solid