### PR TITLE
Fixed audio during spectate free roam camera and other fixes

### DIFF
--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -1629,9 +1629,9 @@ void CAbstractPlayer::PlayerAction() {
 
                         // Auto spectate another player if:
                         //   - The player runs out of lives
-                        //   - The player being spectated runs out of lives
+                        //   - The player being spectated runs out of lives (check that players limbo timer to prevent fast transition)
                         if ((itsGame->GetSpectatePlayer() == NULL && itsManager->IsLocalPlayer()) ||
-                            (itsGame->GetSpectatePlayer() != NULL && itsGame->GetSpectatePlayer()->lives == 0)) {
+                            (itsGame->GetSpectatePlayer() != NULL && itsGame->GetSpectatePlayer()->lives == 0 && itsGame->GetSpectatePlayer()->limboCount <= 0)) {
                             itsGame->SpectateNext();
                         }
                     }

--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -205,8 +205,8 @@ void CAbstractPlayer::LoadFreeCam() {
     SetFreeCamState(false);
 }
 
-void CAbstractPlayer::WriteDBG(int index, float val) {
-    freeCamDBG[index] = val;
+void CAbstractPlayer::WriteDBG(float val) {
+    freeCamDBG.push_back(val);
 }
 
 void CAbstractPlayer::ReplacePartColors() {
@@ -1329,7 +1329,8 @@ void CAbstractPlayer::KeyboardControl(FunctionTable *ft) {
             if (TESTFUNC(kfuLoadMissile, ft->down))
                 ArmSmartMissile();
         }
-        else if(lives == 0) {
+        else if(lives == 0 && limboCount < 0) {
+            // These controls only function after the limbo pause
             if (itsManager->IsLocalPlayer() && TESTFUNC(kfuSpectateNext, ft->down)) {
                 itsGame->SpectateNext();
                 if (freeView) {
@@ -1429,9 +1430,9 @@ void CAbstractPlayer::KeyboardControl(FunctionTable *ft) {
         if (TESTFUNC(kfuDebug2, ft->down))
             debug2Flag = !debug2Flag;
 
-        if (TESTFUNC(kfuZoomIn, ft->held))
+        if (TESTFUNC(kfuZoomIn, ft->held) && !freeView)
             fieldOfView -= FOVSTEP;
-        if (TESTFUNC(kfuZoomOut, ft->held))
+        if (TESTFUNC(kfuZoomOut, ft->held) && !freeView)
             fieldOfView += FOVSTEP;
 
 #define LOOKSTEP FpsCoefficient2(0x1000L)
@@ -1623,6 +1624,7 @@ void CAbstractPlayer::PlayerAction() {
                         }
                         Reincarnate();
                     } else {
+                        limboCount = -1; // No need for limboCount to continue counting down at this point
                         itsManager->DeadOrDone();
 
                         // Auto spectate another player if:

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -243,6 +243,8 @@ public:
     float boosterSpacing;
     float livesSpacing;
     float weaponSpacing;
+    Boolean showHud; // Store pref to detect if the user changes it during a game
+    int hudPreset; // Store pref to detect if the user changes it during a game
 
     virtual void BeginScript();
     virtual CAbstractActor *EndScript();
@@ -282,6 +284,7 @@ public:
     virtual void PlaceHUDParts();
     
     //
+    virtual void DashboardReloadCheck();
     virtual void LoadDashboardParts();
     virtual CScaledBSP* DashboardPart(uint16_t id);
     virtual CScaledBSP* DashboardPart(uint16_t id, Fixed scale);

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -184,7 +184,7 @@ public:
     Fixed supportTraction = 0;
     Fixed supportFriction = 0;
 
-    std::deque<int> freeCamDBG;
+    std::deque<float> freeCamDBG;
 
     //	Hud parts:
     CBSPPart *dirArrow = 0;

--- a/src/game/CAbstractPlayer.h
+++ b/src/game/CAbstractPlayer.h
@@ -184,7 +184,7 @@ public:
     Fixed supportTraction = 0;
     Fixed supportFriction = 0;
 
-    double freeCamDBG[18] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    std::deque<int> freeCamDBG;
 
     //	Hud parts:
     CBSPPart *dirArrow = 0;
@@ -255,7 +255,7 @@ public:
     virtual void LoadParts();
     virtual void LoadScout();
     virtual void LoadFreeCam();
-    virtual void WriteDBG(int index, float val);
+    virtual void WriteDBG(float val);
     virtual void StartSystems();
     virtual void LevelReset();
 

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1021,6 +1021,7 @@ void CAvaraGame::StopGame() {
 
 void CAvaraGame::Render() {
     //if (gameStatus == kPlayingStatus || gameStatus == kPauseStatus || gameStatus == kWinStatus || gameStatus == kLoseStatus) {
+    showNewHUD = gApplication ? gApplication->Get<bool>(kShowNewHUD) : false;
     ViewControl();
     gRenderer->RenderFrame();
 }

--- a/src/game/CFreeCam.cpp
+++ b/src/game/CFreeCam.cpp
@@ -10,6 +10,7 @@
 CFreeCam::CFreeCam(CAbstractPlayer *thePlayer) {
     itsPlayer = thePlayer;
     itsGame = thePlayer->itsGame;
+    itsSoundLink = gHub->GetSoundLink();
 
     camSpeed = 350;
     radius = FIX3(25000);
@@ -154,10 +155,26 @@ void CFreeCam::ViewControl(FunctionTable *ft) {
 void CFreeCam::FrameAction() {
 }
 
+void CFreeCam::ControlSoundPoint(CViewParameters *vp) {
+    Fixed theRight[] = {FIX(-1), 0, 0};
+
+    // This hard-coded data matches the vector data used for ControlSoundPoint() in AbstractPlayer.cpp
+    // The matrix data from viewParams differs from the hard-coded data in a way that makes the sound not play in the correct channels
+    theRight[0] = FIX3(707);
+    theRight[1] = 0;
+    theRight[2] = FIX3(707);
+
+    gHub->SetMixerLink(itsSoundLink);
+    gHub->UpdateRightVector(theRight);
+}
+
 void CFreeCam::ControlViewPoint() {
     auto vp = gRenderer->viewParams;
 
     vp->LookFrom(vp->fromPoint[0], vp->fromPoint[1], vp->fromPoint[2]);
     vp->LookAt(vp->atPoint[0], vp->atPoint[1], vp->atPoint[2]);
     vp->PointCamera();
+
+    UpdateSoundLink(itsSoundLink, vp->fromPoint, speed, itsGame->soundTime);
+    ControlSoundPoint(vp);
 }

--- a/src/game/CFreeCam.cpp
+++ b/src/game/CFreeCam.cpp
@@ -158,12 +158,14 @@ void CFreeCam::FrameAction() {
 void CFreeCam::ControlSoundPoint(CViewParameters *vp) {
     Fixed theRight[] = {FIX(-1), 0, 0};
 
-    // This hard-coded data matches the vector data used for ControlSoundPoint() in AbstractPlayer.cpp
-    // The matrix data from viewParams differs from the hard-coded data in a way that makes the sound not play in the correct channels
+    // For whatever reason, the viewParams matrix data didn't
+    // provide the correct vector to make the sound play in the correct channels
+    // so I copied the values used for the RightVector in ControlSoundPoint() in AbstractPlayer.cpp
     theRight[0] = FIX3(707);
     theRight[1] = 0;
     theRight[2] = FIX3(707);
-
+    
+    UpdateSoundLink(itsSoundLink, vp->fromPoint, speed, itsGame->soundTime);
     gHub->SetMixerLink(itsSoundLink);
     gHub->UpdateRightVector(theRight);
 }
@@ -175,6 +177,5 @@ void CFreeCam::ControlViewPoint() {
     vp->LookAt(vp->atPoint[0], vp->atPoint[1], vp->atPoint[2]);
     vp->PointCamera();
 
-    UpdateSoundLink(itsSoundLink, vp->fromPoint, speed, itsGame->soundTime);
     ControlSoundPoint(vp);
 }

--- a/src/game/CFreeCam.h
+++ b/src/game/CFreeCam.h
@@ -27,4 +27,5 @@ public:
     virtual Boolean IsAttached();
     virtual void SetAttached(Boolean attach);
     virtual void ControlViewPoint();
+    virtual void ControlSoundPoint(CViewParameters* vp);
 };


### PR DESCRIPTION
Audio should now work correctly when spectating with the free roam camera

If the user switches 'showNewHud' or 'hudPreset' prefs during a game, the HUD is automatically updated to reflect the new setting

All scout controls are now disabled while in spectator mode

A player can't use spectate controls until the limbo timer is complete. This delay keeps the player from activating spectator mode too soon after they die which creates a jarring and unexpected transition for a player after they run out of lives.

Auto spectate will use the limbo timer so that the switch doesn't happen too quickly when the spectate player is out of lives.