### PR TITLE
decrease Elo adjustment as num players increase

### DIFF
--- a/src/game/PlayerRatingsSimpleElo.h
+++ b/src/game/PlayerRatingsSimpleElo.h
@@ -32,6 +32,9 @@ struct PlayerResult {
     int teamId;
 //    int lives;
 //    long score;
+    bool operator==(const PlayerResult &rhs) {
+        return playerId == rhs.playerId;
+    }
 };
 
 struct Rating {

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -95,6 +95,7 @@ using json = nlohmann::json;
 
 // other
 #define kGoodGamePhrases "ggs"
+#define kShowElo "showElo"
 
 // Key names are from https://wiki.libsdl.org/SDL_Scancode
 static json defaultPrefs = {
@@ -194,6 +195,7 @@ static json defaultPrefs = {
     {kIgnoreCustomGoodySound, false},
     {kThrottle, 0},
     {kGoodGamePhrases, {}},
+    {kShowElo, false},
 };
 
 


### PR DESCRIPTION
Divide the adjustment amount by sqrt(numPlayers-1) to account for increased randomness of multi-player games.

Also added boolean pref, "showElo", to show Elo adjustments after each game.