### PR TITLE
avoid frags caused by dead player aborting

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -453,7 +453,7 @@ void CAvaraGame::RunFrameActions() {
     }
 
     thePlayer = playerList;
-    while (thePlayer && statusRequest != kAbortStatus) { // itsNet->ProcessQueue();
+    while (thePlayer) {
         nextPlayer = thePlayer->nextPlayer;
         thePlayer->PlayerAction();
         thePlayer = nextPlayer;

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -527,8 +527,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
     static int ASK_INTERVAL = MSEC_TO_TICK_COUNT(500);
     static int WAITING_MESSAGE_COUNT = 4;
 
-    // if player is finished don't wait for their frames to sync up
-    if (frameFuncs[i].validFrame != itsGame->frameNumber && itsPlayer->lives > 0) {
+    if (frameFuncs[i].validFrame != itsGame->frameNumber) {
         long firstTime = askAgainTime = TickCount();
         long quickTick = firstTime;
         long giveUpTime = firstTime + MSEC_TO_TICK_COUNT(15000);


### PR DESCRIPTION
When a player aborted a game after their last life their client would send an asynchronous message letting other players knowing they are out.  But this could sometimes result in a race condition where other players wouldn't be able to handle the abort keystroke which allows it to clean up and set the `isOut` flag.  The result of this was that the aborted player would be counted by some players and not others which messed up the fragmentation checksum.