### PR TITLE
kill some spectator frags

### DIFF
--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -1384,10 +1384,12 @@ void CAbstractPlayer::KeyboardControl(FunctionTable *ft) {
             }
         }
 
-        // Disable scout controls while spectating
-        if (winFrame < 0 && !freeView && itsGame->GetSpectatePlayer() == NULL) {
+        // Disable local scout controls while spectating (players in the game still control their scouts)
+        if (winFrame < 0 && !itsManager->IsDeadOrDone()) {
             Boolean doRelease = false;
 
+//            SDL_Log("keys> fn=%d: down=%08x, held=%08x, up=%08x\n",
+//                    itsGame->frameNumber, ft->down, ft->held, ft->up);
             if (TESTFUNC(kfuScoutView, ft->down)) {
                 if (!scoutView && !scoutIdent) {
                     doRelease = true;

--- a/src/game/CGoody.cpp
+++ b/src/game/CGoody.cpp
@@ -202,6 +202,6 @@ void CGoody::FrameAction() {
     // the goody heading can make a difference in determing a collision with a Hector
     // FRandSeed += heading;
     UpdateFRandSeed((uint32_t)heading);
-    // SDL_Log("fn = %ld, goody=%ld: heading = %8d, FRandSeed = %10d\n",
+    // SDL_Log("fn = %d, goody=%ld: heading = %8d, FRandSeed = %10d\n",
     //         itsGame->frameNumber, ident, heading, (Fixed)FRandSeed);
 }


### PR DESCRIPTION
A bunch of spectator frags were being caused by processing the spectator's scout controls and/or not respecting the scout controls of players still in the game.