### PR TITLE
more frag fixes

### DIFF
--- a/src/game/CGlowActors.cpp
+++ b/src/game/CGlowActors.cpp
@@ -65,9 +65,14 @@ void CGlowActors::FrameAction() {
         }
     }
 
-    // both the server and client update the FRandSeed here, if they get out of sync
+    // all clients update their FRandSeed here, if they get out of sync
     // then this number will be different and will be noticed in CNetManager::AutoLatencyControl
-    uint32_t locsum = location[0] + location[1] + location[2];
-    UpdateFRandSeed(locsum);
-    // SDL_Log("frameNumber = %u, FRandSeed = %10d, locsum = %8d, Actor = %s", gCurrentGame->frameNumber, (Fixed)FRandSeed, locsum, typeid(*this).name());
+    uint32_t locsum = 0;
+    if (maskBits & kSolidBit) {
+        // only add "solid" objects to the checksum because the location of
+        // non-solid objects (invisible/limbo/dead) isn't relevant and could cause frags
+        uint32_t locsum = location[0] + location[1] + location[2];
+        UpdateFRandSeed(locsum);
+    }
+//    SDL_Log("fn = %u, FRandSeed = %10d, locsum = %8d, Actor = %s", gCurrentGame->frameNumber, (Fixed)FRandSeed, locsum, typeid(*this).name());
 }

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -1134,7 +1134,9 @@ void CPlayerManagerImpl::AbortRequest() {
 
 void CPlayerManagerImpl::RemoveFromGame() {
     theNetManager->activePlayersDistribution &= ~(1 << slot);
-    theNetManager->itsCommManager->SendUrgentPacket(kdEveryone, kpRemoveMeFromGame, 0, 0, 0, 0, 0);
+    // let inactive players know (not sure if this is even necessary)
+    uint16_t dist = kdEveryone & ~theNetManager->activePlayersDistribution;
+    theNetManager->itsCommManager->SendPacket(dist, kpRemoveMeFromGame, 0, 0, 0, 0, 0);
 }
 
 void CPlayerManagerImpl::DeadOrDone() {


### PR DESCRIPTION
The crux of abort/frag problems is/was that the notification of the abort was asynchronous.  But the other players in the game don't need to get the async message because they will get the abort key press so stop sending that message to active players.

Also, there's no good reason to keep updating the frag checksum for players who are out of the game.  This was also related to the previous problem where players were adding in the location checksum and stopping that addition at different times.  This fix is really extra insurance that an aborted or dead player won't cause frags.