### PR TITLE
default Goody angle to zero

### DIFF
--- a/src/game/CGoody.cpp
+++ b/src/game/CGoody.cpp
@@ -202,6 +202,6 @@ void CGoody::FrameAction() {
     // the goody heading can make a difference in determing a collision with a Hector
     // FRandSeed += heading;
     UpdateFRandSeed((uint32_t)heading);
-    // SDL_Log("fn = %d, goody=%ld: heading = %8d, FRandSeed = %10d\n",
-    //         itsGame->frameNumber, ident, heading, (Fixed)FRandSeed);
+    // SDL_Log("fn = %d, goody=%ld: heading = %8d, FRandSeed = %10d, grenades=%d, missiles=%d\n",
+    //         itsGame->frameNumber, ident, heading, (Fixed)FRandSeed, grenades, missiles);
 }

--- a/src/level/LevelLoader.cpp
+++ b/src/level/LevelLoader.cpp
@@ -267,6 +267,9 @@ struct ALFWalker: pugi::xml_tree_walker {
 
             lastArcAngle = (900 - arcAngle) % 360;
             lastDomeAngle = 360 - arcAngle;
+        } else {
+            lastArcAngle = 0;
+            lastDomeAngle = 0;
         }
 
         return true;


### PR DESCRIPTION
In fact, all objects with "angle" would just pull the last value parsed, for any object.  This will set it to zero if not set in the current ALF node.