### PR TITLE
make FramesFromNow() accept a float arg

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1135,7 +1135,7 @@ void CAvaraGame::IncrementFrame(bool firstFrame) {
     isClassicFrame = (frameNumber % (CLASSICFRAMETIME / frameTime) == 0);
 }
 
-FrameNumber CAvaraGame::FramesFromNow(FrameNumber classicFrameCount) {
+FrameNumber CAvaraGame::FramesFromNow(double classicFrameCount) {
     return frameNumber + classicFrameCount / fpsScale;
 }
 

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -269,7 +269,7 @@ public:
     virtual FrameNumber NextFrameForPeriod(long period, long referenceFrame = 0);
     virtual void SetFrameTime(int32_t ft);
     virtual void IncrementFrame(bool firstFrame = false);
-    virtual FrameNumber FramesFromNow(FrameNumber classicFrames);
+    virtual FrameNumber FramesFromNow(double classicFrames);
     virtual void SetSpawnOrder(SpawnOrder order);
 
     void SetKeysFromStdin() { keysFromStdin = true; };


### PR DESCRIPTION
Well, this is embarrassing.

Most of the time FrameFromNow() is passed an integer.  But there's an important call that passes a float on this check:
    while (FramesFromNow(latencyTolerance) > topSentFrame) {
        itsNet->FrameAction();
    }

Passing latencyTolerance as an integer was truncating the LT.  For example, an LT=1.5 would be treated as LT=1 and result in less than the full LT of frames being sent on time.