### PR TITLE
fix level-loading crashes

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -142,6 +142,7 @@ void CAvaraGame::IAvaraGame(CAvaraApp *theApp) {
     statusRequest = kNoVehicleStatus;
 
     nextPingTime = 0;
+    nextLoadTime = 0;
 
     showNewHUD = gApplication ? gApplication->Get<bool>(kShowNewHUD) : false;
     // CalcGameRect();
@@ -841,6 +842,16 @@ bool CAvaraGame::GameTick() {
         static uint32_t pingInterval = 1000; // msec
         itsNet->SendPingCommand(3);
         nextPingTime = startTime + pingInterval;
+    }
+
+    int randLoadPeriod = Debug::GetValue("rload"); // randomly load a level every `rload` seconds
+    if (randLoadPeriod > 0) {
+        if (startTime > nextLoadTime) {
+            auto p = CPlayerManagerImpl::LocalPlayer();
+            auto *tui = itsApp->GetTui();
+            tui->ExecuteMatchingCommand("/rand", p);
+            nextLoadTime = startTime + 1000*randLoadPeriod;
+        }
     }
 
     // Not playing? Nothing to do!

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -179,6 +179,7 @@ public:
 
     uint32_t nextScheduledFrame;
     uint32_t nextPingTime;
+    uint32_t nextLoadTime;
     long lastFrameTime;
     Boolean canPreSend;
 

--- a/vendor/nanogui/nanogui/screen.h
+++ b/vendor/nanogui/nanogui/screen.h
@@ -188,6 +188,8 @@ public:
     void moveWindowToFront(Window *window);
     void drawWidgets();
 
+    virtual void removeNotifyParent(const Widget *w) override;
+
 protected:
     SDL_Window *mSDLWindow;
     uint32_t mWindowID;

--- a/vendor/nanogui/nanogui/widget.h
+++ b/vendor/nanogui/nanogui/widget.h
@@ -63,10 +63,16 @@ public:
     /// Set the position relative to the parent widget
     void setPosition(const Vector2i &pos) { mPos = pos; }
 
+    /// return position of parent or zeros if no parent
+    Vector2i parentPosition() const {
+        static Vector2i zeroPos = {};
+        return mParent ?
+            (mParent->absolutePosition()) : zeroPos;
+    }
+
     /// Return the absolute position on screen
     Vector2i absolutePosition() const {
-        return mParent ?
-            (parent()->absolutePosition() + mPos) : mPos;
+        return parentPosition() + mPos;
     }
 
     /// Return the size of the widget
@@ -147,6 +153,9 @@ public:
 
     /// Remove a child widget by value
     void removeChild(const Widget *widget);
+
+    /// notify other widgets/parents
+    virtual void removeNotifyParent(const Widget *w);
 
     /// Retrieves the child at the specific position
     const Widget* childAt(int index) const { return mChildren[index]; }

--- a/vendor/nanogui/screen.cpp
+++ b/vendor/nanogui/screen.cpp
@@ -444,7 +444,7 @@ bool Screen::cursorPosCallbackEvent(double x, double y) {
             }
         } else {
             ret = mDragWidget->mouseDragEvent(
-                p - mDragWidget->parent()->absolutePosition(), p - mMousePos,
+                p - mDragWidget->parentPosition(), p - mMousePos,
                 mMouseState, mModifiers);
         }
 
@@ -482,7 +482,7 @@ bool Screen::mouseButtonCallbackEvent(int button, int action, int modifiers) {
         if (mDragActive && action == SDL_RELEASED &&
             dropWidget != mDragWidget)
             mDragWidget->mouseButtonEvent(
-                mMousePos - mDragWidget->parent()->absolutePosition(), button,
+                mMousePos - mDragWidget->parentPosition(), button,
                 false, mModifiers);
 
         if (dropWidget != nullptr && dropWidget->cursor() != mCursor) {
@@ -692,6 +692,17 @@ bool Screen::handleSDLEvent(SDL_Event &event) {
             break;
     }
     return false;
+}
+
+
+void Screen::removeNotifyParent(const Widget *w) {
+    // remove widget from various places before deletion
+    if (w == mDragWidget) {
+        mDragWidget = nullptr;
+        mDragActive = false;
+    }
+    mFocusPath.erase(std::remove(mFocusPath.begin(), mFocusPath.end(), w), mFocusPath.end());
+    Widget::removeNotifyParent(w);
 }
 
 NAMESPACE_END(nanogui)

--- a/vendor/nanogui/widget.cpp
+++ b/vendor/nanogui/widget.cpp
@@ -160,8 +160,19 @@ void Widget::removeChild(const Widget *widget) {
 
 void Widget::removeChild(int index) {
     Widget *widget = mChildren[index];
+    removeNotifyParent(widget);
     mChildren.erase(mChildren.begin() + index);
     widget->decRef();
+}
+
+// climb the tree and let everyone (Screen) know this object is being removed.
+// ideally we would change everything to use shared_ptr<Widget> and maybe some weak_ptr references...
+// but, i'm lazy and this code should all get replaced soon (right?)
+void Widget::removeNotifyParent(const Widget *w) {
+    if (mParent) {
+        mParent->removeNotifyParent(w);
+    }
+    return;
 }
 
 int Widget::childIndex(Widget *widget) const {


### PR DESCRIPTION
When new levels are loaded the Hull and Level/Set menus are re-created from scratch.  This would leave dangling pointers in `nanogui::Screen` (`mDragWidget` and `mFocusPath`).  The "best" fix would probably be to replace all `Widget` pointers with `shared_ptr<Widget>`.  But this is a quick fix that gets the job done.

I also added `/dbg rload X` which will load a new level every X seconds.  This was useful for recreating this bug but also might be useful for discovering other random level-load issues in the future so I left it in.