### PR TITLE
Fix window resize

### DIFF
--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -562,7 +562,7 @@ void CAbstractPlayer::LoadDashboardParts() {
     dashboardSpinSpeed = ToFixed(100);
     dashboardSpinHeading = 0;
 
-    int layout = itsGame->itsApp->Get(kHUDPreset);
+    layout = itsGame->itsApp->Get(kHUDPreset);
     //float alpha = itsGame->itsApp->Get(kHUDAlpha);
     //Fixed hudAlpha = FIX1 * alpha;
 
@@ -718,21 +718,22 @@ void CAbstractPlayer::RenderDashboard() {
         // Lastly set relativeImpulse based on the impact location of the hit to bump the HUD
         Fixed hitAngle = FOneArcTan2(dSpeed[2], dSpeed[0]);
         Fixed angleDiff = hitAngle - viewYaw;
+        float magnitude = ToFloat(VectorLength(3, dSpeed));
         
         if (angleDiff > 0) {
             // Hit from the right side
-            relativeImpulse[0] = FIX(1.0);
+            relativeImpulse[0] = FIX(1.0*magnitude);
         } else if (angleDiff < 0) {
             // Hit from the left side
-            relativeImpulse[0] = FIX(-1.0);
+            relativeImpulse[0] = FIX(-1.0*magnitude);
         }
 
         if (dSpeed[1] > FIX(.5)) {
             // Hit from the top
-            relativeImpulse[1] = FIX(1.0);
+            relativeImpulse[1] = FIX(1.0*magnitude);
         } else if (dSpeed[1] < FIX(-.5)) {
             // Hit from the bottom
-            relativeImpulse[1] = FIX(-1.0);
+            relativeImpulse[1] = FIX(-1.0*magnitude);
         }
 
         pidReset(&pMotionX);
@@ -924,11 +925,7 @@ void CAbstractPlayer::DashboardPosition(CScaledBSP *part, bool autoRot, float x,
     // X/Y Coordinates on the screen are roughly described as a percentage of the screen away from the bottom and the left
     // (-1.0, -1.0) is the bottom left of the screen
     // (1.0, 1.0) is the top right of the screen
-
-
-    // TODO: Adjust these until it looks good, then go multiply 
-    // all the DashboardPosition parameters by these numbers, and
-    // then delete these
+    
     float scale_x = 11.12;
     float scale_y = 8.23;
     Fixed hud_dist = (FIX3(6000) * 25)/8;

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -200,8 +200,9 @@ void CAvaraAppImpl::RenderContents() {
 }
 
 void CAvaraAppImpl::WindowResized(int width, int height) {
-    gRenderer->UpdateViewRect(width, height, mPixelRatio);
-    gRenderer->ApplyFrameBuffer();
+    // Only update if the resolution is actually changing
+    if (gRenderer->viewParams->viewPixelDimensions.h != width || gRenderer->viewParams->viewPixelDimensions.v != height)
+        gRenderer->UpdateViewRect(width, height, mPixelRatio);
     //performLayout();
 }
 

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -201,6 +201,7 @@ void CAvaraAppImpl::RenderContents() {
 
 void CAvaraAppImpl::WindowResized(int width, int height) {
     gRenderer->UpdateViewRect(width, height, mPixelRatio);
+    gRenderer->ApplyFrameBuffer();
     //performLayout();
 }
 

--- a/src/render/AbstractRenderer.h
+++ b/src/render/AbstractRenderer.h
@@ -40,11 +40,6 @@ public:
     virtual void ApplyProjection() = 0;
 
     /**
-     * Update the frame buffer with the currently configured resolution and FOV.
-     */
-    virtual void ApplyFrameBuffer() = 0;
-
-    /**
      * Reset the renderer's state back to its defaults.
      */
     virtual void LevelReset();
@@ -108,7 +103,7 @@ public:
      * @param height The height in pixels.
      * @param pixelRatio The pixel ratio.
      */
-    void UpdateViewRect(int width, int height, float pixelRatio);
+    virtual void UpdateViewRect(int width, int height, float pixelRatio) = 0;
 protected:
     float fov = 50.0f;
 };

--- a/src/render/AbstractRenderer.h
+++ b/src/render/AbstractRenderer.h
@@ -40,6 +40,11 @@ public:
     virtual void ApplyProjection() = 0;
 
     /**
+     * Update the frame buffer with the currently configured resolution and FOV.
+     */
+    virtual void ApplyFrameBuffer() = 0;
+
+    /**
      * Reset the renderer's state back to its defaults.
      */
     virtual void LevelReset();

--- a/src/render/ModernOpenGLRenderer.cpp
+++ b/src/render/ModernOpenGLRenderer.cpp
@@ -252,9 +252,6 @@ void ModernOpenGLRenderer::ApplyProjection()
 {
     SDL_GL_GetDrawableSize(this->window, &resolution[0], &resolution[1]);
 
-    //viewParams->viewPixelDimensions.h = resolution[0];
-    //viewParams->viewPixelDimensions.v = resolution[1];
-
     glm::mat4 proj = glm::scale(
         glm::perspective(
             glm::radians(fov),

--- a/src/render/ModernOpenGLRenderer.cpp
+++ b/src/render/ModernOpenGLRenderer.cpp
@@ -252,6 +252,9 @@ void ModernOpenGLRenderer::ApplyProjection()
 {
     SDL_GL_GetDrawableSize(this->window, &resolution[0], &resolution[1]);
 
+    //viewParams->viewPixelDimensions.h = resolution[0];
+    //viewParams->viewPixelDimensions.v = resolution[1];
+
     glm::mat4 proj = glm::scale(
         glm::perspective(
             glm::radians(fov),
@@ -273,6 +276,14 @@ void ModernOpenGLRenderer::ApplyProjection()
     hudShader->Use();
     hudShader->SetMat4("proj", proj);
     glCheckErrors();
+}
+
+void ModernOpenGLRenderer::ApplyFrameBuffer()
+{
+    GLsizei w, h;
+    SDL_GL_GetDrawableSize(window, &w, &h);
+    MakeFramebuffer(0, w, h);
+    MakeFramebuffer(1, w, h);
 }
 
 void ModernOpenGLRenderer::LevelReset()

--- a/src/render/ModernOpenGLRenderer.cpp
+++ b/src/render/ModernOpenGLRenderer.cpp
@@ -177,9 +177,6 @@ ModernOpenGLRenderer::ModernOpenGLRenderer(SDL_Window *window) : AbstractRendere
     glBindVertexArray(0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-    MakeFramebuffer(0, w, h);
-    MakeFramebuffer(1, w, h);
-
     // Configure alpha blending.
     glEnable(GL_BLEND);
     glBlendFuncSeparate(GL_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE);
@@ -275,12 +272,15 @@ void ModernOpenGLRenderer::ApplyProjection()
     glCheckErrors();
 }
 
-void ModernOpenGLRenderer::ApplyFrameBuffer()
+void ModernOpenGLRenderer::UpdateViewRect(int width, int height, float pixelRatio)
 {
+    AbstractRenderer::UpdateViewRect(width, height, pixelRatio);
+
     GLsizei w, h;
     SDL_GL_GetDrawableSize(window, &w, &h);
-    MakeFramebuffer(0, w, h);
-    MakeFramebuffer(1, w, h);
+
+    AdjustFramebuffer(0, w, h);
+    AdjustFramebuffer(1, w, h);
 }
 
 void ModernOpenGLRenderer::LevelReset()
@@ -575,8 +575,13 @@ std::unique_ptr<OpenGLShader> ModernOpenGLRenderer::LoadShader(const std::string
     return std::make_unique<OpenGLShader>(*vertPath, *fragPath);
 }
 
-void ModernOpenGLRenderer::MakeFramebuffer(short index, GLsizei width, GLsizei height)
+void ModernOpenGLRenderer::AdjustFramebuffer(short index, GLsizei width, GLsizei height)
 {
+    // Remove previous bound objects
+    glDeleteTextures(1, &texture[index]);
+    glDeleteFramebuffers(1, &fbo[index]);
+    glDeleteRenderbuffers(1, &rbo[index]);
+
     // Create a framebuffer, texture, and renderbuffer for the HUD.
     glGenFramebuffers(1, &fbo[index]);
     glBindFramebuffer(GL_FRAMEBUFFER, fbo[index]);

--- a/src/render/ModernOpenGLRenderer.h
+++ b/src/render/ModernOpenGLRenderer.h
@@ -19,7 +19,6 @@ public:
     virtual void AddPart(CBSPPart *part) override;
     virtual void ApplyLights() override;
     virtual void ApplyProjection() override;
-    virtual void ApplyFrameBuffer() override;
     virtual void LevelReset() override;
     virtual std::unique_ptr<VertexData> NewVertexDataInstance() override;
     virtual void OverheadPoint(Fixed *pt, Fixed *extent) override;
@@ -27,6 +26,7 @@ public:
     virtual void RemoveHUDPart(CBSPPart *part) override;
     virtual void RemovePart(CBSPPart *part) override;
     virtual void RenderFrame() override;
+    virtual void UpdateViewRect(int width, int height, float pixelRatio) override;
 private:
     SDL_Window *window;
     
@@ -55,6 +55,6 @@ private:
     void Draw(OpenGLShader &shader, const CBSPPart &part, float defaultAmbient, bool useAlphaBuffer = false);
     void IgnoreDirectionalLights(OpenGLShader &shader, bool yn);
     std::unique_ptr<OpenGLShader> LoadShader(const std::string &vertFile, const std::string &fragFile);
-    void MakeFramebuffer(short index, GLsizei width, GLsizei height);
+    void AdjustFramebuffer(short index, GLsizei width, GLsizei height);
     void SetTransforms(const CBSPPart &part);
 };

--- a/src/render/ModernOpenGLRenderer.h
+++ b/src/render/ModernOpenGLRenderer.h
@@ -19,6 +19,7 @@ public:
     virtual void AddPart(CBSPPart *part) override;
     virtual void ApplyLights() override;
     virtual void ApplyProjection() override;
+    virtual void ApplyFrameBuffer() override;
     virtual void LevelReset() override;
     virtual std::unique_ptr<VertexData> NewVertexDataInstance() override;
     virtual void OverheadPoint(Fixed *pt, Fixed *extent) override;

--- a/src/render/NullRenderer.h
+++ b/src/render/NullRenderer.h
@@ -14,6 +14,7 @@ public:
     virtual void AddPart(CBSPPart *part) override {};
     virtual void ApplyLights() override {};
     virtual void ApplyProjection() override {};
+    virtual void ApplyFrameBuffer() override {};
     virtual std::unique_ptr<VertexData> NewVertexDataInstance() override {
         return nullptr;
     };

--- a/src/render/NullRenderer.h
+++ b/src/render/NullRenderer.h
@@ -14,7 +14,6 @@ public:
     virtual void AddPart(CBSPPart *part) override {};
     virtual void ApplyLights() override {};
     virtual void ApplyProjection() override {};
-    virtual void ApplyFrameBuffer() override {};
     virtual std::unique_ptr<VertexData> NewVertexDataInstance() override {
         return nullptr;
     };

--- a/src/render/NullRenderer.h
+++ b/src/render/NullRenderer.h
@@ -32,4 +32,5 @@ public:
     virtual void RemoveHUDPart(CBSPPart *part) override {};
     virtual void RemovePart(CBSPPart *part) override {};
     virtual void RenderFrame() override {};
+    virtual void UpdateViewRect(int width, int height, float pixelRatio) override {};
 };


### PR DESCRIPTION
Fix resizing the window so that the game screen stays perfectly framed by the window.

This fix is accomplished by updating the FrameBuffer during a Window Resize event. This FrameBuffer update uses the same code as when the FrameBuffer is first initialized.