### PR TITLE
attempt to fix scout crash

### DIFF
--- a/src/game/CAbstractPlayer.cpp
+++ b/src/game/CAbstractPlayer.cpp
@@ -1569,7 +1569,7 @@ void CAbstractPlayer::FrameAction() {
 
         if (doIncarnateSound) {
             IncarnateSound();
-            if (itsManager->Presence() == kzAvailable && 
+            if (itsScout && itsManager->Presence() == kzAvailable &&
                 itsScout->action == kScoutInactive) {
                 itsScout->ToggleState(kScoutUp);
             }


### PR DESCRIPTION
Pretty stupid mistake, but we need to check for the scout's presence before automatically engaging `ToggleState(kScoutUp)`