### PR TITLE
Fix wall/ramp/yonbox alignment issues (#426)

### DIFF
--- a/src/compat/Types.h
+++ b/src/compat/Types.h
@@ -43,6 +43,14 @@ struct Rect {
 };
 typedef struct Rect Rect;
 
+struct RectDouble {
+    double top;
+    double left;
+    double bottom;
+    double right;
+};
+typedef struct RectDouble RectDouble;
+
 typedef int16_t OSErr;
 typedef uint32_t OSType;
 

--- a/src/compat/Types.h
+++ b/src/compat/Types.h
@@ -36,20 +36,12 @@ typedef uint16_t port_num;
 typedef int32_t ClockTick;   // integer counter returned by UDPComm::GetClock()
 
 struct Rect {
-    int16_t top;
-    int16_t left;
-    int16_t bottom;
-    int16_t right;
+    Fixed top;
+    Fixed left;
+    Fixed bottom;
+    Fixed right;
 };
 typedef struct Rect Rect;
-
-struct RectDouble {
-    double top;
-    double left;
-    double bottom;
-    double right;
-};
-typedef struct RectDouble RectDouble;
 
 typedef int16_t OSErr;
 typedef uint32_t OSType;

--- a/src/game/CRamp.cpp
+++ b/src/game/CRamp.cpp
@@ -11,7 +11,7 @@
 
 #include "CSmartBox.h"
 
-extern RectDouble gLastBoxRect;
+extern Rect gLastBoxRect;
 extern Fixed gLastBoxRounding;
 
 static void SolveOrientation(Fixed x, Fixed y, Fixed h, Fixed *w, Fixed *angle) {
@@ -62,9 +62,9 @@ CAbstractActor *CRamp::EndScript() {
         maskBits |= kSolidBit + kDoorIgnoreBit;
 
         deltaY = ReadFixedVar(iDeltaY);
-        dims[0] = FIX(gLastBoxRect.right - gLastBoxRect.left);
+        dims[0] = gLastBoxRect.right - gLastBoxRect.left;
         dims[1] = ReadFixedVar(iThickness);
-        dims[2] = FIX(gLastBoxRect.bottom - gLastBoxRect.top);
+        dims[2] = gLastBoxRect.bottom - gLastBoxRect.top;
 
         if (dims[0] > LOCATORRECTSIZE)
             dims[0] = LOCATORRECTSIZE;
@@ -77,8 +77,8 @@ CAbstractActor *CRamp::EndScript() {
             heading += 0x8000;
         }
 
-        location[0] = FIX((gLastBoxRect.right + gLastBoxRect.left) / 2);
-        location[2] = FIX((gLastBoxRect.bottom + gLastBoxRect.top) / 2);
+        location[0] = (gLastBoxRect.right + gLastBoxRect.left) / 2;
+        location[2] = (gLastBoxRect.bottom + gLastBoxRect.top) / 2;
 
         partCount = 1;
 

--- a/src/game/CRamp.cpp
+++ b/src/game/CRamp.cpp
@@ -77,8 +77,8 @@ CAbstractActor *CRamp::EndScript() {
             heading += 0x8000;
         }
 
-        location[0] = (gLastBoxRect.right + gLastBoxRect.left) / 2;
-        location[2] = (gLastBoxRect.bottom + gLastBoxRect.top) / 2;
+        location[0] = (gLastBoxRect.right + gLastBoxRect.left) >> 1;
+        location[2] = (gLastBoxRect.bottom + gLastBoxRect.top) >> 1;
 
         partCount = 1;
 

--- a/src/game/CRamp.cpp
+++ b/src/game/CRamp.cpp
@@ -11,7 +11,7 @@
 
 #include "CSmartBox.h"
 
-extern Rect gLastBoxRect;
+extern RectDouble gLastBoxRect;
 extern Fixed gLastBoxRounding;
 
 static void SolveOrientation(Fixed x, Fixed y, Fixed h, Fixed *w, Fixed *angle) {
@@ -62,9 +62,9 @@ CAbstractActor *CRamp::EndScript() {
         maskBits |= kSolidBit + kDoorIgnoreBit;
 
         deltaY = ReadFixedVar(iDeltaY);
-        dims[0] = FMulDivNZ(gLastBoxRect.right - gLastBoxRect.left, FIX(5), 72);
+        dims[0] = FIX(gLastBoxRect.right - gLastBoxRect.left);
         dims[1] = ReadFixedVar(iThickness);
-        dims[2] = FMulDivNZ(gLastBoxRect.bottom - gLastBoxRect.top, FIX(5), 72);
+        dims[2] = FIX(gLastBoxRect.bottom - gLastBoxRect.top);
 
         if (dims[0] > LOCATORRECTSIZE)
             dims[0] = LOCATORRECTSIZE;
@@ -77,8 +77,8 @@ CAbstractActor *CRamp::EndScript() {
             heading += 0x8000;
         }
 
-        location[0] = FMulDivNZ(gLastBoxRect.right + gLastBoxRect.left, FIX(5), 144);
-        location[2] = FMulDivNZ(gLastBoxRect.bottom + gLastBoxRect.top, FIX(5), 144);
+        location[0] = FIX((gLastBoxRect.right + gLastBoxRect.left) / 2);
+        location[2] = FIX((gLastBoxRect.bottom + gLastBoxRect.top) / 2);
 
         partCount = 1;
 

--- a/src/game/CWallActor.cpp
+++ b/src/game/CWallActor.cpp
@@ -50,12 +50,12 @@ void CWallActor::MakeWallFromRect(Rect *theRect, Fixed height, short decimateWal
 
             smallRect = *theRect;
             if (smallRect.right - smallRect.left > smallRect.bottom - smallRect.top) {
-                smallRect.left += (smallRect.right - smallRect.left) / 2;
+                smallRect.left += (smallRect.right - smallRect.left) >> 1;
                 theRect->right = smallRect.left;
                 newDecim = decimateWalls | kEastWall;
                 decimateWalls |= kWestWall;
             } else {
-                smallRect.top += (smallRect.bottom - smallRect.top) / 2;
+                smallRect.top += (smallRect.bottom - smallRect.top) >> 1;
                 theRect->bottom = smallRect.top;
                 newDecim = decimateWalls | kNorthWall;
                 decimateWalls |= kSouthWall;

--- a/src/game/CWallActor.cpp
+++ b/src/game/CWallActor.cpp
@@ -20,7 +20,7 @@ CWallActor *lastWallActor = 0;
 #define kEastWall 4
 #define kWestWall 8
 
-void CWallActor::MakeWallFromRect(RectDouble *theRect, Fixed height, short decimateWalls, Boolean isOrigWall) {
+void CWallActor::MakeWallFromRect(Rect *theRect, Fixed height, short decimateWalls, Boolean isOrigWall) {
     Boolean tooBig;
     Fixed centerX, centerZ;
     Vector dim;
@@ -37,15 +37,15 @@ void CWallActor::MakeWallFromRect(RectDouble *theRect, Fixed height, short decim
     partYon = ReadFixedVar(iWallYon);
 
     do {
-        dim[0] = FIX(theRect->right - theRect->left);
+        dim[0] = theRect->right - theRect->left;
         dim[1] = 0;
-        dim[2] = FIX(theRect->bottom - theRect->top);
+        dim[2] = theRect->bottom - theRect->top;
 
         tooBig =
             dim[0] > LOCATORRECTSIZE || dim[2] > LOCATORRECTSIZE; // VectorLength(3, dim) > LOCATORRECTSIZE/5;
         if (tooBig) {
             CWallActor *otherWall;
-            RectDouble smallRect;
+            Rect smallRect;
             short newDecim;
 
             smallRect = *theRect;
@@ -66,8 +66,8 @@ void CWallActor::MakeWallFromRect(RectDouble *theRect, Fixed height, short decim
         }
     } while (tooBig);
 
-    centerX = FIX((theRect->right + theRect->left) / 2);
-    centerZ = FIX((theRect->bottom + theRect->top) / 2);
+    centerX = (theRect->right + theRect->left) / 2;
+    centerZ = (theRect->bottom + theRect->top) / 2;
 
     dim[0] = dim[0] / 2;
     dim[2] = dim[2] / 2;

--- a/src/game/CWallActor.cpp
+++ b/src/game/CWallActor.cpp
@@ -20,7 +20,7 @@ CWallActor *lastWallActor = 0;
 #define kEastWall 4
 #define kWestWall 8
 
-void CWallActor::MakeWallFromRect(Rect *theRect, Fixed height, short decimateWalls, Boolean isOrigWall) {
+void CWallActor::MakeWallFromRect(RectDouble *theRect, Fixed height, short decimateWalls, Boolean isOrigWall) {
     Boolean tooBig;
     Fixed centerX, centerZ;
     Vector dim;
@@ -37,25 +37,25 @@ void CWallActor::MakeWallFromRect(Rect *theRect, Fixed height, short decimateWal
     partYon = ReadFixedVar(iWallYon);
 
     do {
-        dim[0] = FDivNZ(theRect->right - theRect->left, 72);
+        dim[0] = FIX(theRect->right - theRect->left);
         dim[1] = 0;
-        dim[2] = FDivNZ(theRect->bottom - theRect->top, 72);
+        dim[2] = FIX(theRect->bottom - theRect->top);
 
         tooBig =
-            dim[0] > LOCATORRECTSIZE / 5 || dim[2] > LOCATORRECTSIZE / 5; // VectorLength(3, dim) > LOCATORRECTSIZE/5;
+            dim[0] > LOCATORRECTSIZE || dim[2] > LOCATORRECTSIZE; // VectorLength(3, dim) > LOCATORRECTSIZE/5;
         if (tooBig) {
             CWallActor *otherWall;
-            Rect smallRect;
+            RectDouble smallRect;
             short newDecim;
 
             smallRect = *theRect;
             if (smallRect.right - smallRect.left > smallRect.bottom - smallRect.top) {
-                smallRect.left += (smallRect.right - smallRect.left) >> 1;
+                smallRect.left += (smallRect.right - smallRect.left) / 2;
                 theRect->right = smallRect.left;
                 newDecim = decimateWalls | kEastWall;
                 decimateWalls |= kWestWall;
             } else {
-                smallRect.top += (smallRect.bottom - smallRect.top) >> 1;
+                smallRect.top += (smallRect.bottom - smallRect.top) / 2;
                 theRect->bottom = smallRect.top;
                 newDecim = decimateWalls | kNorthWall;
                 decimateWalls |= kSouthWall;
@@ -66,11 +66,11 @@ void CWallActor::MakeWallFromRect(Rect *theRect, Fixed height, short decimateWal
         }
     } while (tooBig);
 
-    centerX = FMulDivNZ(theRect->right + theRect->left, FIX(5), 144);
-    centerZ = FMulDivNZ(theRect->bottom + theRect->top, FIX(5), 144);
+    centerX = FIX((theRect->right + theRect->left) / 2);
+    centerZ = FIX((theRect->bottom + theRect->top) / 2);
 
-    dim[0] = dim[0] * 5 / 2;
-    dim[2] = dim[2] * 5 / 2;
+    dim[0] = dim[0] / 2;
+    dim[2] = dim[2] / 2;
     if (height) {
         dim[1] = (1 + height) >> 1;
         //dim[1] = (1 + height * ReadFixedVar(iPixelToThickness)) >> 1;

--- a/src/game/CWallActor.h
+++ b/src/game/CWallActor.h
@@ -12,5 +12,5 @@
 
 class CWallActor : public CAbstractActor {
 public:
-    virtual void MakeWallFromRect(RectDouble *theRect, Fixed height, short decimateWalls, Boolean isOrigWall);
+    virtual void MakeWallFromRect(Rect *theRect, Fixed height, short decimateWalls, Boolean isOrigWall);
 };

--- a/src/game/CWallActor.h
+++ b/src/game/CWallActor.h
@@ -12,5 +12,5 @@
 
 class CWallActor : public CAbstractActor {
 public:
-    virtual void MakeWallFromRect(Rect *theRect, Fixed height, short decimateWalls, Boolean isOrigWall);
+    virtual void MakeWallFromRect(RectDouble *theRect, Fixed height, short decimateWalls, Boolean isOrigWall);
 };

--- a/src/game/CYonBox.cpp
+++ b/src/game/CYonBox.cpp
@@ -9,7 +9,7 @@
 
 #include "CYonBox.h"
 
-extern Rect gLastBoxRect;
+extern RectDouble gLastBoxRect;
 extern Fixed gLastBoxRounding;
 
 void CYonBox::BeginScript() {
@@ -22,11 +22,11 @@ CAbstractActor *CYonBox::EndScript() {
     if (CAbstractYon::EndScript()) {
         Fixed deltaY;
 
-        minBounds[0] = FMulDivNZ(gLastBoxRect.left, FIX(5), 72);
-        minBounds[2] = FMulDivNZ(gLastBoxRect.top, FIX(5), 72);
+        minBounds[0] = FIX(gLastBoxRect.left);
+        minBounds[2] = FIX(gLastBoxRect.top);
 
-        maxBounds[0] = FMulDivNZ(gLastBoxRect.right, FIX(5), 72);
-        maxBounds[2] = FMulDivNZ(gLastBoxRect.bottom, FIX(5), 72);
+        maxBounds[0] = FIX(gLastBoxRect.right);
+        maxBounds[2] = FIX(gLastBoxRect.bottom);
 
         deltaY = ReadFixedVar(iDeltaY);
         if (deltaY <= 0) {

--- a/src/game/CYonBox.cpp
+++ b/src/game/CYonBox.cpp
@@ -9,7 +9,7 @@
 
 #include "CYonBox.h"
 
-extern RectDouble gLastBoxRect;
+extern Rect gLastBoxRect;
 extern Fixed gLastBoxRounding;
 
 void CYonBox::BeginScript() {
@@ -22,11 +22,11 @@ CAbstractActor *CYonBox::EndScript() {
     if (CAbstractYon::EndScript()) {
         Fixed deltaY;
 
-        minBounds[0] = FIX(gLastBoxRect.left);
-        minBounds[2] = FIX(gLastBoxRect.top);
+        minBounds[0] = gLastBoxRect.left;
+        minBounds[2] = gLastBoxRect.top;
 
-        maxBounds[0] = FIX(gLastBoxRect.right);
-        maxBounds[2] = FIX(gLastBoxRect.bottom);
+        maxBounds[0] = gLastBoxRect.right;
+        maxBounds[2] = gLastBoxRect.bottom;
 
         deltaY = ReadFixedVar(iDeltaY);
         if (deltaY <= 0) {

--- a/src/level/LevelLoader.cpp
+++ b/src/level/LevelLoader.cpp
@@ -227,10 +227,10 @@ struct ALFWalker: pugi::xml_tree_walker {
 
         if (!node.attribute("x").empty() && !node.attribute("z").empty() &&
             !node.attribute("w").empty() && !node.attribute("d").empty()) {
-            Fixed boxCenterX = FIX(ReadDoubleVar("x")),
-                  boxCenterZ = FIX(ReadDoubleVar("z")),
-                  boxWidth = FIX(ReadDoubleVar("w")),
-                  boxDepth = FIX(ReadDoubleVar("d"));
+            Fixed boxCenterX = ToFixed(ReadDoubleVar("x")),
+                  boxCenterZ = ToFixed(ReadDoubleVar("z")),
+                  boxWidth = ToFixed(ReadDoubleVar("w")),
+                  boxDepth = ToFixed(ReadDoubleVar("d"));
             Fixed boxLeft = boxCenterX - (boxWidth / 2),
                   boxRight = boxLeft + boxWidth,
                   boxTop = boxCenterZ - (boxDepth / 2),

--- a/src/level/LevelLoader.cpp
+++ b/src/level/LevelLoader.cpp
@@ -39,7 +39,7 @@ static short lastArcAngle;
 static FixedPoint2D lastOvalPoint;
 static Fixed lastOvalRadius;
 
-RectDouble gLastBoxRect;
+Rect gLastBoxRect;
 Fixed gLastBoxRounding;
 
 static FixedPoint2D lastDomeCenter;
@@ -227,14 +227,14 @@ struct ALFWalker: pugi::xml_tree_walker {
 
         if (!node.attribute("x").empty() && !node.attribute("z").empty() &&
             !node.attribute("w").empty() && !node.attribute("d").empty()) {
-            double boxCenterX = ReadDoubleVar("x"),
-                   boxCenterZ = ReadDoubleVar("z"),
-                   boxWidth = ReadDoubleVar("w"),
-                   boxDepth = ReadDoubleVar("d");
-            double boxLeft = boxCenterX - (boxWidth / 2.0),
-                   boxRight = boxLeft + boxWidth,
-                   boxTop = boxCenterZ - (boxDepth / 2.0),
-                   boxBottom = boxTop + boxDepth;
+            Fixed boxCenterX = FIX(ReadDoubleVar("x")),
+                  boxCenterZ = FIX(ReadDoubleVar("z")),
+                  boxWidth = FIX(ReadDoubleVar("w")),
+                  boxDepth = FIX(ReadDoubleVar("d"));
+            Fixed boxLeft = boxCenterX - (boxWidth / 2),
+                  boxRight = boxLeft + boxWidth,
+                  boxTop = boxCenterZ - (boxDepth / 2),
+                  boxBottom = boxTop + boxDepth;
             gLastBoxRect.top = boxTop;
             gLastBoxRect.left = boxLeft;
             gLastBoxRect.bottom = boxBottom;

--- a/src/level/LevelLoader.cpp
+++ b/src/level/LevelLoader.cpp
@@ -27,7 +27,6 @@
 #include <regex>
 
 #define POINTTOUNIT(pt) (pt * 20480 / 9)
-#define UNITPOINTS (double)14.4 // 72 / 5
 
 typedef struct {
     Fixed v;
@@ -40,7 +39,7 @@ static short lastArcAngle;
 static FixedPoint2D lastOvalPoint;
 static Fixed lastOvalRadius;
 
-Rect gLastBoxRect;
+RectDouble gLastBoxRect;
 Fixed gLastBoxRounding;
 
 static FixedPoint2D lastDomeCenter;
@@ -228,18 +227,18 @@ struct ALFWalker: pugi::xml_tree_walker {
 
         if (!node.attribute("x").empty() && !node.attribute("z").empty() &&
             !node.attribute("w").empty() && !node.attribute("d").empty()) {
-            double boxCenterX = ReadDoubleVar("x") * UNITPOINTS,
-                   boxCenterZ = ReadDoubleVar("z") * UNITPOINTS,
-                   boxWidth = ReadDoubleVar("w") * UNITPOINTS,
-                   boxDepth = ReadDoubleVar("d") * UNITPOINTS;
+            double boxCenterX = ReadDoubleVar("x"),
+                   boxCenterZ = ReadDoubleVar("z"),
+                   boxWidth = ReadDoubleVar("w"),
+                   boxDepth = ReadDoubleVar("d");
             double boxLeft = boxCenterX - (boxWidth / 2.0),
                    boxRight = boxLeft + boxWidth,
                    boxTop = boxCenterZ - (boxDepth / 2.0),
                    boxBottom = boxTop + boxDepth;
-            gLastBoxRect.top = std::lround(boxTop);
-            gLastBoxRect.left = std::lround(boxLeft);
-            gLastBoxRect.bottom = std::lround(boxBottom);
-            gLastBoxRect.right = std::lround(boxRight);
+            gLastBoxRect.top = boxTop;
+            gLastBoxRect.left = boxLeft;
+            gLastBoxRect.bottom = boxBottom;
+            gLastBoxRect.right = boxRight;
         }
 
         if (!node.attribute("cx").empty() && !node.attribute("cz").empty()) {


### PR DESCRIPTION
The level loader was unnecessarily aligning rectangle orientation and dimensions to pixel boundaries (as defined by Avara classic's PICT parser). This resulted in subtle rounding-induced distortions to wall, ramp, and yon box geometry. This PR removes the pixel alignment logic.

Walls and ramps now render without alignment issues.

<img width="1884" alt="Screenshot 2025-02-06 at 8 51 01 PM" src="https://github.com/user-attachments/assets/1fb704c0-e230-4e45-8958-741ce8422cb6" />

<img width="1556" alt="Screenshot 2025-02-06 at 8 52 09 PM" src="https://github.com/user-attachments/assets/060d693a-b13d-4d3b-bd09-17a09258ceb0" />

<img width="1885" alt="Screenshot 2025-02-06 at 9 22 13 PM" src="https://github.com/user-attachments/assets/56e1cf16-f71f-4b68-8591-9e63546154a0" />
