### PR TITLE
client-to-client hole punching

### DIFF
--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -398,6 +398,7 @@ void CNetManager::DisconnectSome(short mask) {
 }
 
 void CNetManager::HandleDisconnect(short slotId, short why) {
+    DBG_Log("login+", "HandleDisconnect called for slot #%d, why=%d", slotId, why);
     itsCommManager->DisconnectSlot(slotId);
 
     if (slotId == itsCommManager->myId) {

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -626,7 +626,7 @@ Boolean CUDPComm::PacketHandler(PacketInfo *thePacket) {
         case kpPacketProtocolTOC:
             if (!isServing && thePacket->p3 == seed) {
                 ReadFromTOC(thePacket);
-                DBG_Log("login", "sending kpPacketProtocolTOC to kdEveryone\n");
+                DBG_Log("login+", "sending kpPacketProtocolControl to kdEveryone with cramData = %d\n", cramData);
                 SendPacket(kdEveryone, kpPacketProtocolControl, udpCramInfo, cramData, 0, 0, NULL);
             }
             break;
@@ -647,6 +647,7 @@ Boolean CUDPComm::PacketHandler(PacketInfo *thePacket) {
             }
             break;
         case kpPacketProtocolControl:
+            DBG_Log("login+", "received kpPacketProtocolControl from %d with cramData = %d\n", thePacket->sender, thePacket->p2);
             connections->ReceiveControlPacket(thePacket);
             break;
         case kpKickClient:

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -764,6 +764,7 @@ void CUDPConnection::MarkOpenConnections(CompleteAddress *table) {
             table++;
         }
 
+        DBG_Log("login", "%s no longer in connection table, marking as GONE", FormatHostPort(ipAddr, port).c_str());
         port = 0;
         ipAddr = 0;
         myId = -1;
@@ -849,10 +850,10 @@ void CUDPConnection::FreshClient(ip_addr remoteHost, port_num remotePort, uint16
     ipAddr = ipAddrExt = remoteHost;
     port = remotePort;
 
-    // Normal client-client Avara packets will do the hole-punching for us, so this is unnecessary.
-    // But maybe this could speed things up?
-    // IPaddress addr = { remoteHost, remotePort };
-    // Punch(addr);
+    // Normal client-client Avara packets will do the hole-punching for us, so this is unnecessary?
+    // Sometimes the hole needs to be punched between clients such as when they are both behind double-NAT.
+    IPaddress addr = { remoteHost, remotePort };
+    RequestPunch(addr);
 }
 
 Boolean CUDPConnection::AreYouDone() {


### PR DESCRIPTION
Oftentimes clients behind double-NAT have a hard time connecting to each other. In addition to server-to-client hole punching, let's try client-to-client.