### PR TITLE
ping clients who haven't finished logging in

### DIFF
--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -684,6 +684,10 @@ void CUDPComm::ReadComplete(UDPpacket *packet) {
         char *inEnd;
         short inLen;
 
+        #if PACKET_DEBUG > 2
+            SDL_Log("CUDPComm::ReadComplete raw packet from=%s\n", FormatAddr(packet->address).c_str());
+        #endif
+
         #if SIMULATE_LATENCY_ON_CLIENTS
             SIMULATE_LATENCY_CODE("read")
         #endif


### PR DESCRIPTION
I noticed that we were only pinging clients that have successfully logged all the way in.  Maybe it will help to ping clients that are having troubles connecting?  Or maybe it won't help at all.  We'll find out.

I made it so that it only sends a 1-way "poke" to those clients like we do with in-game players.