### PR TITLE
Fixes to Auto LT

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -686,7 +686,6 @@ void CAvaraGame::ReadGamePrefs() {
     }
     sensitivity = pow(2.0, gApplication->Get<double>(kMouseSensitivityTag));
     SDL_Log("mouse sensitivity multiplier = %.2lf\n", sensitivity);
-    latencyTolerance = gApplication->Get<double>(kLatencyToleranceTag);
 }
 
 void CAvaraGame::ResumeGame() {
@@ -1091,9 +1090,6 @@ void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayer
         // make prettier version of the LT string (C++ sucks with strings)
         std::ostringstream ltOss;
         ltOss << std::fixed << std::setprecision(int(1/(2*fpsScale))) << latencyTolerance;
-
-        // save as application preference (which also makes it show up on the UI)
-        gApplication->Set(kLatencyToleranceTag, latencyTolerance);
 
         // if it changed
         if (latencyTolerance != oldLatency && statusRequest == kPlayingStatus) {

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1071,7 +1071,7 @@ void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayer
         static int reduceLatencyCounter = 0;
         static int increaseLatencyCounter = 0;
         if (newLatency < latencyTolerance) {
-            static const int REDUCE_LATENCY_COUNT = 8;
+            static const int REDUCE_LATENCY_COUNT = 2;
             // need REDUCE_LATENCY_COUNT consecutive requests to reduce latency
             if (maxChange == MAX_LATENCY || ++reduceLatencyCounter >= REDUCE_LATENCY_COUNT) {
                 latencyTolerance = std::max(latencyTolerance-maxChange, std::max(newLatency, double(0.0)));

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -171,6 +171,7 @@ public:
     double sensitivity;
 
     double latencyTolerance;
+    short initialFrameLatency = 0;
 
     ScoreInterfaceReasons scoreReason;
     ScoreInterfaceReasons killReason;

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -40,7 +40,7 @@
 #define AUTOLATENCYDELAY  448   // msec (divisible by 64)
 #define LOWERLATENCYCOUNT   2
 #define HIGHERLATENCYCOUNT  (0.25 * AUTOLATENCYPERIOD / itsGame->frameTime)       // 25% of frames
-#define DECREASELATENCYPERIOD (itsGame->TimeToFrameCount(AUTOLATENCYPERIOD*16))  // 16 consecutive votes ≈ 61 sec
+#define DECREASELATENCYPERIOD (itsGame->TimeToFrameCount(AUTOLATENCYPERIOD*4))    // 4 consecutive votes ≈ 15 sec
 
 
 #if ROUTE_THRU_SERVER
@@ -824,6 +824,9 @@ void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
                 // but addOneLatency helps account for deficiencies in the calculation by measuring how often clients had to wait too long for packets to arrive
                 short maxFrameLatency = addOneLatency + itsGame->RoundTripToFrameLatency(maxRoundTripLatency);
 
+                // treat kLatencyToleranceTag as upper limit when in AutoLT mode
+                maxFrameLatency = std::min<short>(maxFrameLatency, gApplication->Get<double>(kLatencyToleranceTag)/itsGame->fpsScale);
+
                 DBG_Log("lt", "  fn=%d RTT=%d, Classic LT=%.2lf, add=%lf --> FL=%d\n",
                         frameNumber, maxRoundTripLatency,
                         (maxRoundTripLatency) / (2.0*CLASSICFRAMETIME), addOneLatency*itsGame->fpsScale, maxFrameLatency);
@@ -1303,6 +1306,7 @@ void CNetManager::DoConfig(short senderSlot) {
         // transmitting latencyTolerance in terms of frameLatency to keep it as a short value on transmission
         itsGame->SetFrameTime(theConfig->frameTime);
         itsGame->SetFrameLatency(theConfig->frameLatency, -1);
+        SDL_Log("DoConfig LT = %lf\n", itsGame->latencyTolerance);
         itsGame->SetSpawnOrder((SpawnOrder)theConfig->spawnOrder);
         latencyVoteFrame = itsGame->NextFrameForPeriod(AUTOLATENCYPERIOD);
     }
@@ -1311,9 +1315,12 @@ void CNetManager::DoConfig(short senderSlot) {
 void CNetManager::UpdateLocalConfig() {
     CPlayerManager *thePlayerManager = playerTable[itsCommManager->myId].get();
 
-    config.frameLatency = gApplication
-        ? gApplication->Get<float>(kLatencyToleranceTag) / itsGame->fpsScale
-        : 0;
+    if (IsAutoLatencyEnabled()) {
+        config.frameLatency = itsGame->initialFrameLatency;
+    } else {
+        config.frameLatency = gApplication
+            ? gApplication->Get<float>(kLatencyToleranceTag) / itsGame->fpsScale : 0;
+    }
     config.frameTime = itsGame->frameTime;
     config.spawnOrder = gApplication ? gApplication->Get<short>(kSpawnOrder) : ksHybrid;
     config.hullType = gApplication ? gApplication->Number(kHullTypeTag) : 0;

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -40,7 +40,7 @@
 #define AUTOLATENCYDELAY  448   // msec (divisible by 64)
 #define LOWERLATENCYCOUNT   2
 #define HIGHERLATENCYCOUNT  (0.25 * AUTOLATENCYPERIOD / itsGame->frameTime)       // 25% of frames
-#define DECREASELATENCYPERIOD (itsGame->TimeToFrameCount(AUTOLATENCYPERIOD*4))    // 4 consecutive votes ≈ 15 sec
+#define DECREASELATENCYPERIOD (itsGame->TimeToFrameCount(AUTOLATENCYPERIOD*2))    // 2 consecutive votes ≈ 7.7 sec
 
 
 #if ROUTE_THRU_SERVER
@@ -932,7 +932,7 @@ void CNetManager::SendPingCommand(int pingTrips) {
     // there & back = 2 trips... send less to/from players in game
     // a "poke" is a one-way ping, for just keeping the connection open with less traffic
     int pokeTrips = 1;
-    int pokeDist = activePlayersDistribution;
+    int pokeDist = itsGame->IsPlaying() ? activePlayersDistribution : 0;
 
     // send periodic poke to those who have NOT finished logging in in hopes that it will help get their connection going
     pokeDist |= ~totalDistribution;
@@ -1315,11 +1315,10 @@ void CNetManager::DoConfig(short senderSlot) {
 void CNetManager::UpdateLocalConfig() {
     CPlayerManager *thePlayerManager = playerTable[itsCommManager->myId].get();
 
+    config.frameLatency = gApplication
+        ? gApplication->Get<float>(kLatencyToleranceTag) / itsGame->fpsScale : 0;
     if (IsAutoLatencyEnabled()) {
-        config.frameLatency = itsGame->initialFrameLatency;
-    } else {
-        config.frameLatency = gApplication
-            ? gApplication->Get<float>(kLatencyToleranceTag) / itsGame->fpsScale : 0;
+        config.frameLatency = std::min<short>(config.frameLatency, itsGame->initialFrameLatency);
     }
     config.frameTime = itsGame->frameTime;
     config.spawnOrder = gApplication ? gApplication->Get<short>(kSpawnOrder) : ksHybrid;

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -229,8 +229,8 @@ void CRosterWindow::UpdateRoster() {
 
         if (maxRtt > 0 && theNet->IsAutoLatencyEnabled() && !theGame->IsPlaying()) {
             // set initial frame latency from client ping/RTT times
-            maxRtt = std::min(maxRtt+CLASSICFRAMETIME, long(CLASSICFRAMETIME*2*4));  // max of 4 LT on the UI
-            theGame->SetFrameLatency(theGame->RoundTripToFrameLatency(maxRtt), -1);
+            maxRtt = std::min(maxRtt+CLASSICFRAMETIME, long(CLASSICFRAMETIME*2*2.5));  // max of 2.5 LT
+            theGame->initialFrameLatency = theGame->RoundTripToFrameLatency(maxRtt);
         }
 
         if (theGame->loadedFilename.compare(currentLevel) != 0) {

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -229,7 +229,7 @@ void CRosterWindow::UpdateRoster() {
 
         if (maxRtt > 0 && theNet->IsAutoLatencyEnabled() && !theGame->IsPlaying()) {
             // set initial frame latency from client ping/RTT times
-            maxRtt = std::min(maxRtt+CLASSICFRAMETIME, long(CLASSICFRAMETIME*2*2.5));  // max of 2.5 LT
+            maxRtt = std::min(maxRtt, long(CLASSICFRAMETIME*2*2.5));  // max of 2.5 LT
             theGame->initialFrameLatency = theGame->RoundTripToFrameLatency(maxRtt);
         }
 

--- a/src/gui/CServerWindow.cpp
+++ b/src/gui/CServerWindow.cpp
@@ -60,25 +60,25 @@ CServerWindow::CServerWindow(CApplication *app) : CWindow(app, "Server") {
     latencyBox->setEnabled(true);
     latencyBox->setCallback([this](std::string value) -> bool {
         double newLT = std::stod(value);
-        // let SetFrameLatency() enforce limits on latencyTolerance AND set the pref
+        // let SetFrameLatency() enforce limits on latencyTolerance
         gCurrentGame->SetFrameLatency(std::ceil(newLT/gCurrentGame->fpsScale), -1);
 
         // it might be modified on a bad input so retrieve the computed value
         latencyBox->setValue(std::to_string(gCurrentGame->latencyTolerance).substr(0, 5));
+
+        // save the pref
+        gApplication->Set(kLatencyToleranceTag, gCurrentGame->latencyTolerance);
+
         return true;
     });
 
-    autoLatencyBox = new nanogui::CheckBox(this, "Auto Latency", [this, app](bool checked) {
+    autoLatencyBox = new nanogui::CheckBox(this, "Auto Latency", [&, app](bool checked) {
         long options = app->Number(kServerOptionsTag);
         if (checked) {
             options |= 1 << kUseAutoLatencyBit;
-            latencyBox->setEditable(false);
-            latencyBox->setEnabled(false);
         }
         else {
             options &= ~(long)(1 << kUseAutoLatencyBit);
-            latencyBox->setEditable(true);
-            latencyBox->setEnabled(true);
         }
         app->Set(kServerOptionsTag, options);
         ((CAvaraAppImpl *)app)->GetNet()->ChangedServerOptions(options);

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -28,7 +28,7 @@
 #define kMaxReceiveQueueLength kMaxTransmitQueueLength   // receive as much as is sent
 
 #define RTTSMOOTHFACTOR_UP 100
-#define RTTSMOOTHFACTOR_DOWN 200
+#define RTTSMOOTHFACTOR_DOWN 100
 #define COUNTSMOOTHFACTOR 1000
 
 #define MAX_RESENDS_WITHOUT_RECEIVE 3

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -391,6 +391,12 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, int32_t when) {
                         myId, thePacket->packet.command, roundTrip, meanRoundTripTime, sqrt(varRoundTripTime), uint16_t(maxValid));
             #endif
         } else if (commandMultiplier > 0) {
+            if (thePacket->packet.command == kpPing) {
+                // decrease ping roundTrip by about 20% because pings aren't as fast as urgent game packets and we
+                // want to start the game at about the right LT (based on average ping times)
+                roundTrip *= 0.8;
+            }
+
             // compute an exponential moving average & variance of the roundTrip time
             // see: https://fanf2.user.srcf.net/hermes/doc/antiforgery/stats.pdf
             float difference = roundTrip - meanRoundTripTime;


### PR DESCRIPTION
When Auto LT is turned on, interpret the `latencyTolerance` setting as a MAX value.  Otherwise, interpret it as a fixed LT setting.

Also allow the RTT values to go down almost as fast as they go up.

More accurate calculation of true LT.
