### PR TITLE
more fixes to auto-LT

### DIFF
--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -96,6 +96,7 @@ public:
 
     short serverOptions;
     short loaderSlot;
+    short maxAutoLatency;  // max frame latency for auto-LT
 
     PlayerConfigRecord config {};
 

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -105,7 +105,7 @@ static json defaultPrefs = {
     // {kJoystickModeTag, false},
     {kInvertYAxisTag, false},
     {kMouseSensitivityTag, 0},
-    {kLatencyToleranceTag, 1.0},
+    {kLatencyToleranceTag, 2.5},  // 2.5 = max for auto latency
     {kHullTypeTag, 0}, // 0 = light, 1 = medium, 2 = heavy
     {kServerOptionsTag, 129}, // 1 = allow load, 128 = auto latency
     {kDefaultUDPPort, 19567},


### PR DESCRIPTION
The biggest problem was that it would use the local player's latencyTolerance setting as the max value instead of what the server sent over.  This could result in weird stuff happening when the LT started changing. Also, a value of 0 or less is ignored in case somebody unknowingly tries to force it to go faster than it can.