### PR TITLE
server sends initial LT value

### DIFF
--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -511,7 +511,7 @@ void CAvaraAppImpl::TrackerUpdate() {
     std::string gitv = std::string(GIT_VERSION);
     trackerState["version"]["git"] = gitv;
     trackerState["version"]["net"] = kAvaraNetVersion;
-    trackerState["description"] = gitv.substr(0, 6) + (gitv.length() > 8 ? "*: " : ": ") + String(kServerDescription);
+    trackerState["description"] = gitv.substr(0, 6) + (gitv.length() > 8 ? "\\*: " : ": ") + String(kServerDescription);
     trackerState["password"] = String(kServerPassword).length() > 0 ? true : false;
 
     DBG_Log("tracker", "%s", trackerState.dump().c_str());

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -34,7 +34,7 @@
 
 #define kMaxLatencyTolerance 8
 
-#define kAvaraNetVersion 13
+#define kAvaraNetVersion 14
 
 
 enum { kNullNet, kServerNet, kClientNet };

--- a/src/game/PlayerConfig.h
+++ b/src/game/PlayerConfig.h
@@ -18,9 +18,9 @@ struct PlayerConfigRecord {
     short numBoosters {};
     short hullType {};
     short frameLatency {};
+    short maxFrameLatency {};
     short frameTime {};
     short spawnOrder {};
-    short _spare {};
     ARGBColor hullColor { (*ColorManager::getMarkerColor(0)).WithA(0xff) };
     ARGBColor trimColor { (*ColorManager::getMarkerColor(1)).WithA(0xff) };
     ARGBColor cockpitColor { (*ColorManager::getMarkerColor(2)).WithA(0xff) };


### PR DESCRIPTION
Instead of everyone calculating the initial LT, the server sends both the LT and the maxLT values for auto-LT mode.

Changed kAvaraNetVersion because it changes the data sent via the kpStartSynch packet.