### PR TITLE
Re-enable depth test before rendering HUD

### DIFF
--- a/src/render/ModernOpenGLRenderer.cpp
+++ b/src/render/ModernOpenGLRenderer.cpp
@@ -406,6 +406,7 @@ void ModernOpenGLRenderer::RenderFrame()
     glBindFramebuffer(GL_FRAMEBUFFER, fbo[0]);
     glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glEnable(GL_DEPTH_TEST);
 
     hudShader->Use();
     hudWorld->PrepareForRender();


### PR DESCRIPTION
Depth testing is disabled on line [399](https://github.com/avaraline/Avara/compare/main...skedastik:Avara:fix/reenable-hud-depth-test?expand=1#diff-adb08e545c2564eb84986d5fe88ca08bb7cd5e96d07f5ba72e426c8821cbc3d3R399) but not reenabled prior to rendering the HUD.

This means HUD parts will be rendered without depth testing until a HUD part with `ignoreDepthTesting` set to `true` is encountered per logic on line [544](https://github.com/avaraline/Avara/compare/main...skedastik:Avara:fix/reenable-hud-depth-test?expand=1#diff-adb08e545c2564eb84986d5fe88ca08bb7cd5e96d07f5ba72e426c8821cbc3d3R544).

This doesn't observably affect the main branch, but it's definitely a bug. It's causing issues in my level editing fork as I've augmented the HUD:

The x/z axes are a HUD element composed of a single BSP. Note that triangles are currently rendered out of order even though the corresponding HUD part does *not* have `ignoreDepthTesting` set to `true`:

<img width="448" alt="Screenshot 2025-02-27 at 7 41 44 PM" src="https://github.com/user-attachments/assets/409fd26d-5125-414d-8445-45c5d229dc02" />

The HUD element is rendered correctly after the fix:

<img width="268" alt="Screenshot 2025-02-27 at 7 27 19 PM" src="https://github.com/user-attachments/assets/5dc73db2-fc2e-4e41-8e12-1e04388e5dc8" />