### PR TITLE
autoLT refactor, again

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -1058,37 +1058,16 @@ long CAvaraGame::RoundTripToFrameLatency(long roundTrip) {
 
 // "frameLatency" is the integer number of frames to delay;
 // latencyTolerance is the number of classic (64ms) frames (= frameLatency * fpsScale).
-void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayerManager* slowPlayer) {
+void CAvaraGame::SetFrameLatency(short newFrameLatency, CPlayerManager* slowPlayer) {
     double newLatency = newFrameLatency * fpsScale;
     if (latencyTolerance != newLatency) {
-        #define MAX_LATENCY (8)   // in classic units
-        if (maxChange < 0) {
-            // allow latency to jump to any value
-            maxChange = MAX_LATENCY;
-        }
+        static const double MAX_LATENCY = 8.0;
 
         double oldLatency = latencyTolerance;
+        latencyTolerance = newLatency;
 
-        static int reduceLatencyCounter = 0;
-        static int increaseLatencyCounter = 0;
-        if (newLatency < latencyTolerance) {
-            static const int REDUCE_LATENCY_COUNT = 2;
-            // need REDUCE_LATENCY_COUNT consecutive requests to reduce latency
-            if (maxChange == MAX_LATENCY || ++reduceLatencyCounter >= REDUCE_LATENCY_COUNT) {
-                latencyTolerance = std::max(latencyTolerance-maxChange, newLatency);
-                reduceLatencyCounter = 0;
-                increaseLatencyCounter = 0;
-            }
-        } else {
-            static const int INCREASE_LATENCY_COUNT = 1;
-            if (maxChange == MAX_LATENCY || ++increaseLatencyCounter >= INCREASE_LATENCY_COUNT) {
-                latencyTolerance = std::min(latencyTolerance+maxChange, newLatency);
-                reduceLatencyCounter = 0;
-                increaseLatencyCounter = 0;
-            }
-        }
         // make sure it's always between 0 and MAX_LATENCY
-        latencyTolerance = std::min(std::max(latencyTolerance, 0.0), double(MAX_LATENCY));
+        latencyTolerance = std::min(std::max(latencyTolerance, 0.0), MAX_LATENCY);
 
         // make prettier version of the LT string (C++ sucks with strings)
         std::ostringstream ltOss;
@@ -1107,6 +1086,11 @@ void CAvaraGame::SetFrameLatency(short newFrameLatency, short maxChange, CPlayer
             itsApp->AddMessageLine(oss.str());
         }
     }
+}
+
+short CAvaraGame::FrameLatency(void) {
+    // example for 16ms frame: 1.75 LT --> 7 frames
+    return latencyTolerance / fpsScale;
 }
 
 FrameNumber CAvaraGame::TimeToFrameCount(long timeInMsec) {

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -266,7 +266,8 @@ public:
     virtual CPlayerManager *FindPlayerManager(CAbstractPlayer *thePlayer);
 
     virtual long RoundTripToFrameLatency(long rtt);
-    virtual void SetFrameLatency(short newFrameLatency, short maxChange = 2, CPlayerManager *slowPlayer = nullptr);
+    virtual void SetFrameLatency(short newFrameLatency, CPlayerManager *slowPlayer = nullptr);
+    virtual short FrameLatency();
     virtual FrameNumber TimeToFrameCount(long timeInMsec);
     virtual FrameNumber NextFrameForPeriod(long period, long referenceFrame = 0);
     virtual void SetFrameTime(int32_t ft);

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -828,7 +828,7 @@ void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
                     addOneLatency = std::max<short>(0, (curFrameLatency - rttFrameLatency));
                     addOneLatency = std::min<short>(addOneLatency, addOneLimit);
                     reduceLatencyCounter = 0;
-                    DBG_Log("lt+", "  ==addOneLatency = %hd, reduceLatencyCounter = %d\n", addOneLatency, reduceLatencyCounter);
+                    DBG_Log("lt+", "  ==addOneLatency = %hd\n", addOneLatency);
                 } else if (++reduceLatencyCounter >= 2) {   // autoLatencyVote <= LOWERLATENCYCOUNT
                     // allow LT to decrease but still possible to increase if RTT jumps
                     // Examples:
@@ -845,6 +845,11 @@ void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
                         // reset counter only if the FrameLatency will change
                         reduceLatencyCounter = 0;
                     }
+                } else /* (reduceLatencyCounter < 2) */ {
+                    // try to keep LT where it is until the counter says we can change it
+                    addOneLatency = std::max<short>(0, (curFrameLatency - rttFrameLatency));
+                    addOneLatency = std::min<short>(addOneLatency, addOneLimit);
+                    DBG_Log("lt+", "  <<addOneLatency = %hd, reduceLatencyCounter = %d\n", addOneLatency, reduceLatencyCounter);
                 }
 
                 short newFrameLatency = rttFrameLatency + addOneLatency;

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -34,7 +34,7 @@
 
 #define kMaxLatencyTolerance 8
 
-#define kAvaraNetVersion 14
+#define kAvaraNetVersion 15
 
 
 enum { kNullNet, kServerNet, kClientNet };
@@ -112,7 +112,7 @@ public:
     FrameNumber latencyVoteFrame;
     short maxRoundTripLatency;
     short addOneLatency;
-    long subtractOneCheck;
+    short reduceLatencyCounter;
     CPlayerManager *maxPlayer;
     Boolean latencyVoteOpen;
     std::map<int32_t, std::vector<int16_t>> fragmentMap;  // maps FRandSeed to list of players having that seed

--- a/src/gui/CServerWindow.cpp
+++ b/src/gui/CServerWindow.cpp
@@ -61,7 +61,7 @@ CServerWindow::CServerWindow(CApplication *app) : CWindow(app, "Server") {
     latencyBox->setCallback([this](std::string value) -> bool {
         double newLT = std::stod(value);
         // let SetFrameLatency() enforce limits on latencyTolerance
-        gCurrentGame->SetFrameLatency(std::ceil(newLT/gCurrentGame->fpsScale), -1);
+        gCurrentGame->SetFrameLatency(std::ceil(newLT/gCurrentGame->fpsScale));
 
         // it might be modified on a bad input so retrieve the computed value
         latencyBox->setValue(std::to_string(gCurrentGame->latencyTolerance));

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -1950,11 +1950,10 @@ void CUDPComm::Reconfigure() {
 long CUDPComm::GetMaxRoundTrip(short distribution, short *slowPlayerId) {
     float maxTrip = 0;
     CUDPConnection *conn;
-    // if set, use "rttx" value to multiply standard deviations
-    float mult = Debug::GetValue("rttx") / 10.0;  // rttx=25 --> mult=2.5
-    if (mult < 0) {
-        // 1.3*stdev = ~90.3% prob
-        mult = 1.3;
+    // 1.3*stdev = 90.3% prob, 1.4=91.9%, 1.5=93.3%, 1.6=94.5
+    float mult = 1.5;
+    if (Debug::IsEnabled("rttx")) {
+        mult = Debug::GetValue("rttx") / 10.0;  // rttx=25 --> mult=2.5
     }
 
     for (conn = connections; conn; conn = conn->next) {

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -392,9 +392,9 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, int32_t when) {
             #endif
         } else if (commandMultiplier > 0) {
             if (thePacket->packet.command == kpPing) {
-                // decrease ping roundTrip by about 20% because pings aren't as fast as urgent game packets and we
-                // want to start the game at about the right LT (based on average ping times)
-                roundTrip *= 0.8;
+                // decrease ping roundTrip because pings aren't as fast as urgent game packets and we
+                // want to start the game at about the right LT (which is based the average ping times)
+                roundTrip *= 0.9;
             }
 
             // compute an exponential moving average & variance of the roundTrip time


### PR DESCRIPTION
This is a pretty big refactor based on analysis of past games.

* don't allow LT to reduce when LatencyVote indicates clients waiting
* don't allow double-bounce increase or decrease from RTT and Add1 calculations
* Decreased HIGHERLATENCYCOUNT from 25% to 20% so that it's more likely to respond with significant wait counts
* tweaked RTT stddev multiplier
* add 0.25 to starting LT