### PR TITLE
Send my Elo rating on login

### DIFF
--- a/src/compat/Types.h
+++ b/src/compat/Types.h
@@ -23,6 +23,7 @@ typedef uint32_t UnsignedFixed;
 
 typedef uint8_t *StringPtr;
 typedef uint8_t Str255[256];
+static inline std::string ToString(Str255 s255) { return std::string((char *)s255 + 1, s255[0]); }
 
 typedef uint8_t Byte;
 typedef int8_t SignedByte;

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -448,10 +448,10 @@ void CAvaraAppImpl::LevelReset() {}
 void CAvaraAppImpl::ParamLine(short index, MsgAlignment align, StringPtr param1, StringPtr param2) {
     SDL_Log("CAvaraAppImpl::ParamLine(%d)\n", index);
     std::stringstream buffa;
-    std::string a = std::string((char *)param1 + 1, param1[0]);
+    std::string a = ToString(param1);
     std::string b;
     MsgCategory category = MsgCategory::System;
-    if (param2) b = std::string((char *)param2 + 1, param2[0]);
+    if (param2) b = ToString(param2);
 
     switch(index) {
         case kmPaused:

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -783,13 +783,15 @@ void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
             if (IAmAlive()) {
 
                 latencyVoteFrame = frameNumber;  // record the actual frame where the vote is initiated
+                // only use the "alive" players for the maxRTT calculation
                 maxRoundLatency = itsCommManager->GetMaxRoundTrip(AlivePlayersDistribution(), &maxId);
                 maxPlayer = playerTable[maxId].get();
                 uint8_t llv = std::min(long(UINT8_MAX), localLatencyVote);  // just in case, p1 can only accept a max of 256
 
+                // send to all "active" players ("alive" plus spectators)
                 itsCommManager->SendUrgentPacket(
                     activePlayersDistribution, kpLatencyVote, llv, maxRoundLatency, FRandSeed, 0, NULL);
-                DBG_Log("lt+", "*** fn=%d Sending kpLatencyVote to 0x%2hx, localLatencyVote=%ld, maxRoundLatency=%ld FRandSeed=%d\n",
+                DBG_Log("lt+", "*** fn=%d Sending kpLatencyVote to 0x%02hx, localLatencyVote=%ld, maxRoundLatency=%ld FRandSeed=%d\n",
                         frameNumber, activePlayersDistribution, localLatencyVote, maxRoundLatency, FRandSeed);
             } else {
                 // spectator just sends FRandSeed to self for fragmentation check

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -34,7 +34,7 @@
 
 #define kMaxLatencyTolerance 8
 
-#define kAvaraNetVersion 15
+#define kAvaraNetVersion 16
 
 
 enum { kNullNet, kServerNet, kClientNet };
@@ -138,7 +138,7 @@ public:
     virtual void SendRealName(short toSlot);
     virtual void RealNameReport(short slot, short regStatus, StringPtr realName);
     virtual void NameChange(StringPtr newName);
-    virtual void RecordNameAndState(short slotId, StringPtr theName, LoadingState status, PresenceType presence);
+    virtual void RecordNameAndState(short slotId, StringPtr theName, LoadingState status, PresenceType presence, float elo);
     virtual void ValueChange(short slot, std::string attributeName, bool value);
 
     virtual void SwapPositions(short ind1, short ind2);

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -1275,7 +1275,7 @@ Str255& CPlayerManagerImpl::PlayerName() {
     return playerName;
 }
 std::string CPlayerManagerImpl::GetPlayerName() {
-    return std::string((char *)playerName + 1, playerName[0]);
+    return ToString(playerName);
 }
 std::deque<char>& CPlayerManagerImpl::LineBuffer() {
     return lineBuffer;

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -1126,6 +1126,7 @@ bool CPlayerManagerImpl::IsAway() {
 
 void CPlayerManagerImpl::AbortRequest() {
     theNetManager->activePlayersDistribution &= ~(1 << slot);
+    DeadOrDone();
     if (isLocalPlayer) {
         itsGame->statusRequest = kAbortStatus;
     }

--- a/src/game/PlayerRatingsSimpleElo.h
+++ b/src/game/PlayerRatingsSimpleElo.h
@@ -54,14 +54,16 @@ struct CaseInsensitiveCompare {
 };
 
 class PlayerRatingsSimpleElo {
-    typedef std::map<std::string, Rating, CaseInsensitiveCompare> RatingsMap;  // set->[level->[tags]]
+    typedef std::map<std::string, Rating, CaseInsensitiveCompare> RatingsMap;
     JSONify<RatingsMap> ratingsMap;
 
 public:
     PlayerRatingsSimpleElo();
 
     std::vector<std::pair<std::string,Rating>> GetRatings(std::vector<std::string> playerIds);
+    std::pair<std::string,Rating> GetRating(const std::string& playerId);
     void UpdateRatings(std::vector<PlayerResult> &playerResults);
+    void UpdateRating(const std::string& playerId, float newRating, bool incrementCount = false);
 
     std::map<int, std::vector<std::string>> SplitIntoTeams(std::vector<int>, std::vector<std::string> playerIds);
     std::map<int, std::vector<std::string>> SplitIntoBestTeams(std::vector<int>, std::vector<std::string> playerIds);

--- a/src/gui/CRosterWindow.cpp
+++ b/src/gui/CRosterWindow.cpp
@@ -362,7 +362,7 @@ std::string CRosterWindow::ChatPromptFor(std::string theName) {
     return paddedName.substr(0, len) + ": ";
 }
 void CRosterWindow::NewChatLine(Str255 playerName, std::string message) {
-    std::string name = std::string((char *)playerName + 1, playerName[0]);
+    std::string name = ToString(playerName);
     std::string chatLine = ChatPromptFor(name) + message;
 
     AdvancedGridLayout *gridLayout = (AdvancedGridLayout*) chatPanel->layout();

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -83,7 +83,10 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             break;
         case kpNameChange:
             theNet->RecordNameAndState(
-                thePacket->sender, (StringPtr)thePacket->dataBuffer, (LoadingState)thePacket->p2, (PresenceType)thePacket->p3);
+                thePacket->sender, (StringPtr)thePacket->dataBuffer,
+                (LoadingState)thePacket->p2,
+                (PresenceType)thePacket->p1,
+                thePacket->p3/4.0);
             break;
         case kpOrderChange:
             theNet->PositionsChanged(thePacket->dataBuffer);

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -1962,19 +1962,21 @@ long CUDPComm::GetMaxRoundTrip(short distribution, short *slowPlayerId) {
             // add in mult*stdev but max it at CLASSICFRAMETIME (so we don't add more than 0.5 to LT)
             // note: is this really a erlang distribution?  if so, what's the proper equation?
             float rtt = conn->meanRoundTripTime + std::min<float>(mult*stdev, (1.0*CLASSICFRAMECLOCK));
+            if (slowPlayerId != nullptr) {
+                DBG_Log("rtt", "RTT[%d] = %.1f(%.2f) + min(%.1f * %.1f(%.2f), 64(0.5)) = %.1f(%.2fLT)\n",
+                        conn->myId,
+                        conn->meanRoundTripTime*MSEC_PER_GET_CLOCK,
+                        conn->meanRoundTripTime*MSEC_PER_GET_CLOCK / (2*CLASSICFRAMETIME),
+                        mult,
+                        stdev*MSEC_PER_GET_CLOCK,
+                        stdev*MSEC_PER_GET_CLOCK / (2*CLASSICFRAMETIME),
+                        rtt*MSEC_PER_GET_CLOCK,
+                        rtt*MSEC_PER_GET_CLOCK / (2*CLASSICFRAMETIME));
+            }
             if (rtt > maxTrip) {
                 maxTrip = rtt;
                 if (slowPlayerId != nullptr) {
                     *slowPlayerId = conn->myId;
-                    DBG_Log("rtt", "RTT[%d] = %.1f(%.2f) + min(%.1f * %.1f(%.2f), 64(0.5)) = %.1f(%.2fLT)\n",
-                            conn->myId,
-                            conn->meanRoundTripTime*MSEC_PER_GET_CLOCK,
-                            conn->meanRoundTripTime*MSEC_PER_GET_CLOCK / (2*CLASSICFRAMETIME),
-                            mult,
-                            stdev*MSEC_PER_GET_CLOCK,
-                            stdev*MSEC_PER_GET_CLOCK / (2*CLASSICFRAMETIME),
-                            rtt*MSEC_PER_GET_CLOCK,
-                            rtt*MSEC_PER_GET_CLOCK / (2*CLASSICFRAMETIME));
                 }
             }
         }


### PR DESCRIPTION
Generally, we will have more accurate Elo ratings if everyone sends their own rating on login (or name change) because each player has taken into account ALL of their own played games.  This does assume a certain amount of trust which is fine for now.  But we could add some better error/cheat checking if that becomes an issue.