### PR TITLE
more LT tweaks

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -840,7 +840,7 @@ bool CAvaraGame::GameTick() {
     if (startTime > nextPingTime) {
         // 3 pings every second, 1 ping used by each client for RTT calc (last ping not used)
         static uint32_t pingInterval = 1000; // msec
-        itsNet->SendPingCommand(3);
+        itsNet->SendPingCommand(4);
         nextPingTime = startTime + pingInterval;
     }
 

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -363,7 +363,7 @@ float CommandMultiplierForStats(const PacketInfo& thePacketInfo) {
             if (thePacketInfo.p3 > 0) {
                 // the last ping time can be too big if there aren't other messages coming after it
                 // because the receiver may have no reason to respond in a timely manner so ignore p3==0
-                multiplier = (RTTSMOOTHFACTOR_UP) * 0.3;
+                multiplier = CLASSICFRAMETIME * 0.4;  // smooth similarly to in-game rate
             }
             break;
     }
@@ -394,7 +394,7 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, int32_t when) {
             if (thePacket->packet.command == kpPing) {
                 // decrease ping roundTrip because pings aren't as fast as urgent game packets and we
                 // want to start the game at about the right LT (which is based the average ping times)
-                roundTrip *= 0.9;
+                roundTrip *= 0.82;
             }
 
             // compute an exponential moving average & variance of the roundTrip time


### PR DESCRIPTION
The main change is to **not** increase LT when players are getting smooth results and not having to wait for packets very often.  Sometimes RTT math would suggest an increase but reality says otherwise.

Also, trying to get that starting LT value more accurate by playing with RTT calculation on pings before the game starts.