### PR TITLE
Fix side loading

### DIFF
--- a/bin/multiplayer.sh
+++ b/bin/multiplayer.sh
@@ -1,9 +1,8 @@
 #!/bin/sh # -x
-count=0
-if [ "$#" -lt 1 ]; then
+if [ "$#" -lt 1 ] || [ $1 -lt 2 ]; then
     echo "Usage: $0 num" >&2
-    echo "  where num = number of players" >&2
-  exit 1
+    echo "  where num = number of players (min. 2)" >&2
+    exit 1
 fi
 
 count=$1
@@ -13,16 +12,17 @@ server_options=(-s)
 client_options=(-c $host)
 both_options=(-/ "p soundVolume 5")
 
-Avara -n "Player1" "${server_options[@]}" "${both_options[@]}" -/ "p latencyTolerance 1" &
+Avara -n "Player1" "${server_options[@]}" "${both_options[@]}" &
 sleep 3
 
 for (( i=2; i < $count; ++i ))
 do
-  Avara -n "Player$i" "${client_options[@]}" "${both_options[@]}" -/ "p latencyTolerance $i" &
+  Avara -n "Player$i" "${client_options[@]}" "${both_options[@]}" &
+  sleep 1
 done
 
 # don't put the last player in the background so all can be killed with Ctrl-C
-Avara -n "Player$count" "${client_options[@]}" "${both_options[@]}" -/ "p latencyTolerance $count"
+Avara -n "Player$count" "${client_options[@]}" "${both_options[@]}"
 
 # kill all subprocesses
 pkill -P $$

--- a/bin/multiplayer.sh
+++ b/bin/multiplayer.sh
@@ -1,0 +1,28 @@
+#!/bin/sh # -x
+count=0
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 num" >&2
+    echo "  where num = number of players" >&2
+  exit 1
+fi
+
+count=$1
+
+host=localhost
+server_options=(-s)
+client_options=(-c $host)
+both_options=(-/ "p soundVolume 5")
+
+Avara -n "Player1" "${server_options[@]}" "${both_options[@]}" -/ "p latencyTolerance 1" &
+sleep 3
+
+for (( i=2; i < $count; ++i ))
+do
+  Avara -n "Player$i" "${client_options[@]}" "${both_options[@]}" -/ "p latencyTolerance $i" &
+done
+
+# don't put the last player in the background so all can be killed with Ctrl-C
+Avara -n "Player$count" "${client_options[@]}" "${both_options[@]}" -/ "p latencyTolerance $count"
+
+# kill all subprocesses
+pkill -P $$

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -662,7 +662,7 @@ void CAvaraGame::StartIfReady() {
         bool allReady = true;
         for (int i = 0; i < kMaxAvaraPlayers; i++) {
             CPlayerManager *mgr = itsNet->playerTable[i].get();
-            if (mgr && mgr->LoadingStatus() == kLLoaded && mgr->Presence() == kzAvailable) {
+            if (mgr && mgr->IsLoaded() && mgr->Presence() == kzAvailable) {
                 allReady = false;
                 break;
             }

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -681,21 +681,8 @@ void CNetManager::ResumeGame() {
     if (thePlayerManager->GetPlayer()) {
         thePlayerManager->DoMouseControl(&tempPoint, !(itsGame->moJoOptions & kJoystickMode));
 
-        PlayerConfigRecord copy {};
-        BlockMoveData(&config, &copy, sizeof(PlayerConfigRecord));
-        copy.numGrenades = ntohs(config.numGrenades);
-        copy.numMissiles = ntohs(config.numMissiles);
-        copy.numBoosters = ntohs(config.numBoosters);
-        copy.hullType = ntohs(config.hullType);
-        copy.frameLatencyLimits = ntohs(config.frameLatencyLimits);
-        copy.frameLatency = ntohs(config.frameLatency);
-        copy.frameTime = ntohs(config.frameTime);
-        copy.spawnOrder = ntohs(config.spawnOrder);
-
-        copy.hullColor = ntohl(config.hullColor.GetRaw());
-        copy.trimColor = ntohl(config.trimColor.GetRaw());
-        copy.cockpitColor = ntohl(config.cockpitColor.GetRaw());
-        copy.gunColor = ntohl(config.gunColor.GetRaw());
+        PlayerConfigRecord copy = config;
+        ConfigByteSwap(&copy);
 
         // everyone sends this packet which eventually sets the LoadingStatus() to kLActive
         itsCommManager->SendUrgentPacket(
@@ -742,6 +729,7 @@ void CNetManager::ResumeGame() {
                 }
             }
         }
+        DoServerConfig();
 
         ProcessQueue();
         if (notReady) { // SysBeep(10);
@@ -1044,98 +1032,93 @@ void CNetManager::SendStartCommand() {
             dist |= 1 << i;
         }
     }
+    // estimate initial frameLatency from RTT amongst players in dist
+    int8_t rttFL = itsGame->RoundTripToFrameLatency(itsCommManager->GetMaxRoundTrip(dist));
 
-    if (itsCommManager->myId == 0) {
-        // to avoid multiple simultaneous starts, only the server sends the kpStartLevel requests to everyone
-        SDL_Log("  server sending kpStartLevel to all active = 0x%02x\n", activePlayersDistribution);
-        if (dist & kdServerOnly) {
-            // only if server will be playing
-            startingGame = true;
-        }
-        itsCommManager->SendPacket(dist, kpStartLevel, 0, dist, 0, 0, 0);
-    } else {
-        // clients ask the server to forward the kpStartLevel request to everyone
-        SDL_Log("  client sending kpStartLevel to server only = 0x01\n");
-        startingGame = false;
-        itsCommManager->SendPacket(kdServerOnly, kpStartLevel, 0, dist, 0, 0, 0);
-    }
-
+    itsCommManager->SendPacket(kdServerOnly, kpStartRequest, rttFL, dist, 0, 0, 0);
 }
 
-void CNetManager::ReceiveStartCommand(uint16_t activeDistribution, int16_t senderSlot) {
-    SDL_Log("CNetManager::ReceiveStartCommand(0x%02x, %d)\n", activeDistribution, senderSlot);
-
-    if (senderSlot != 0) {
-        // The server will forward clients' kpStartLevel message to kdEveryone,
-        // iff readyPlayers hasn't been set, to make sure we aren't sending multiple start commands.
-        if (itsCommManager->myId == 0) {
-            if (!startingGame) {
-                SDL_Log("  server sending kpStartLevel on behalf of %s to 0x%02x\n",
-                        playerTable[senderSlot]->GetPlayerName().c_str(), activeDistribution);
-                SendStartCommand();
-                itsCommManager->SendPacket(activeDistribution, kpStartLevel, 0, activeDistribution, 0, 0, 0);
-            } else {
-                SDL_Log("  server NOT sending kpStartLevel on behalf of %s because it's already trying to start a game\n",
-                        playerTable[senderSlot]->GetPlayerName().c_str());
-            }
+void CNetManager::ReceiveStartRequest(uint16_t activeDistribution, uint8_t initialFL, int16_t senderSlot) {
+    // called by the server in response to a client asking the server to send the kpStartLevel to everyone
+    SDL_Log("CNetManager::ReceiveStartRequest(0x%02x, %d, %d)\n", activeDistribution, initialFL, senderSlot);
+    // The server will forward clients' kpStartLevel message to activeDistribution,
+    // iff startingGame hasn't been set (to make sure we aren't sending multiple start commands).
+    if (!startingGame) {
+        // flag only set if server will be playing
+        startingGame = (activeDistribution & kdServerOnly);
+        SDL_Log("  server sending kpStartLevel on behalf of %s to 0x%02x\n",
+                playerTable[senderSlot]->GetPlayerName().c_str(), activeDistribution);
+        // if server isn't playing, need to send the server's config
+        if (!(activeDistribution & kdServerOnly)) {
+            UpdateLocalConfig();
+            PlayerConfigRecord copy = config;
+            ConfigByteSwap(&copy);
+            itsCommManager->SendUrgentPacket(activeDistribution, kpSendConfig, 0, 0, 0, sizeof(copy), (Ptr)&copy);
         }
+        itsCommManager->SendPacket(activeDistribution, kpStartLevel, initialFL, activeDistribution, 0, 0, 0);
     } else {
-        if (CanPlay()) {
-            deadOrDonePlayers = 0;
-            activePlayersDistribution = activeDistribution;
-            startPlayersDistribution = activeDistribution;
-            // set readyPlayers partly as an indicator that a start command is being processed
-            readyPlayers = 0;
-            readyPlayersConsensus = 0;
+        SDL_Log("  server NOT sending kpStartLevel on behalf of %s because it's already trying to start a game\n",
+                playerTable[senderSlot]->GetPlayerName().c_str());
+    }
+}
 
-            itsGame->itsApp->DoCommand(kGetReadyToStartCmd);
-            isPlaying = true;
-            itsGame->ResumeGame();
+void CNetManager::ReceiveStartLevel(uint16_t activeDistribution, uint8_t initialFL) {
+    // called by everyone in response to the server sending the kpStartLevel message
+    SDL_Log("CNetManager::ReceiveStartLevel(0x%02x, %d)\n", activeDistribution, initialFL);
+
+    if (CanPlay()) {
+        deadOrDonePlayers = 0;
+        activePlayersDistribution = activeDistribution;
+        startPlayersDistribution = activeDistribution;
+        // set readyPlayers partly as an indicator that a start command is being processed
+        readyPlayers = 0;
+        readyPlayersConsensus = 0;
+
+        itsGame->itsApp->DoCommand(kGetReadyToStartCmd);
+        isPlaying = true;
+        itsGame->ResumeGame();
+
+        // set initial LT based on passed rttFL and config/limits
+        if (IsAutoLatencyEnabled()) {
+            initialFL = std::min(std::max(minAutoLatency, initialFL), maxAutoLatency);
+        } else {
+            // fix LT to kLatencyToleranceTag value
+            initialFL = maxAutoLatency;
         }
+        itsGame->SetFrameLatency(initialFL);
     }
 }
 
 void CNetManager::SendResumeCommand() {
-    SDL_Log("CNetManager::SendResumeCommand()\n");
+    SDL_Log("CNetManager::SendResumeCommand(): dist=0x%02x\n", activePlayersDistribution);
 
-    uint16_t finalDestination = activePlayersDistribution;
+    itsCommManager->SendPacket(kdServerOnly, kpResumeRequest, 0, activePlayersDistribution, FRandSeed, 0, 0);
+}
 
-    if (itsCommManager->myId == 0) {
-        // to avoid multiple simultaneous starts, only the server sends the kpResumeLevel requests to everyone
-        startingGame = true;
-        SDL_Log("  server sending kpResumeLevel to all active = 0x%02x\n", activePlayersDistribution);
-        itsCommManager->SendPacket(activePlayersDistribution, kpResumeLevel, 0, finalDestination, FRandSeed, 0, 0);
+void CNetManager::ReceiveResumeRequest(uint16_t activeDistribution, Fixed randomKey, int16_t senderSlot) {
+    SDL_Log("CNetManager::ReceiveResumeRequest(0x%02x, 0x%08x, %d)\n", activeDistribution, randomKey, senderSlot);
+
+    // The server will forward clients' kpStartLevel message to activeDistribution,
+    // iff startingGame hasn't been set, to make sure we aren't sending multiple start commands.
+    if (!startingGame) {
+        startingGame = (activeDistribution & kdServerOnly);
+        SDL_Log("  server sending kpResumeLevel on behalf of %s to 0x%02x\n",
+                playerTable[senderSlot]->GetPlayerName().c_str(), activeDistribution);
+        itsCommManager->SendPacket(activeDistribution, kpResumeLevel, 0, activeDistribution, randomKey, 0, 0);
     } else {
-        // clients ask the server to forward the kpStartLevel request to all active players
-        startingGame = false;
-        SDL_Log("  client asking server to send kpResumeLevel to 0x%02x\n", activePlayersDistribution);
-        itsCommManager->SendPacket(kdServerOnly, kpResumeLevel, 0, finalDestination, FRandSeed, 0, 0);
+        SDL_Log("  server NOT sending kpResumeLevel on behalf of %s because it's already trying to resume a game\n",
+                playerTable[senderSlot]->GetPlayerName().c_str());
     }
 }
 
-void CNetManager::ReceiveResumeCommand(uint16_t activeDistribution, short senderSlot, Fixed randomKey) {
-    SDL_Log("CNetManager::ReceiveResumeCommand(0x%02x, %d, 0x%08x)\n", activeDistribution, senderSlot, randomKey);
+void CNetManager::ReceiveResumeLevel(uint16_t activeDistribution, Fixed randomKey) {
+    SDL_Log("CNetManager::ReceiveResumeCommand(0x%02x, 0x%08x)\n", activeDistribution, randomKey);
 
-    if (senderSlot != 0) {
-        // The server will forward clients' kpStartLevel message to kdEveryone,
-        // iff startingGame hasn't been set, to make sure we aren't sending multiple start commands.
-        if (itsCommManager->myId == 0) {
-            if (!startingGame) {
-                SDL_Log("  server sending kpResumeLevel on behalf of %s to 0x%02x\n",
-                        playerTable[senderSlot]->GetPlayerName().c_str(), activeDistribution);
-                itsCommManager->SendPacket(activeDistribution, kpResumeLevel, senderSlot, activeDistribution, randomKey, 0, 0);
-            } else {
-                SDL_Log("  server NOT sending kpResumeLevel on behalf of %s because it's already trying to resume a game\n",
-                        playerTable[senderSlot]->GetPlayerName().c_str());
-            }
-        }
-    } else {
-        activePlayersDistribution = activeDistribution;
-        if (CanPlay() && randomKey == FRandSeed) {
-            itsGame->itsApp->DoCommand(kGetReadyToStartCmd);
-            isPlaying = true;
-            itsGame->ResumeGame();
-        }
+    activePlayersDistribution = activeDistribution;
+    if (CanPlay() && randomKey == FRandSeed) {
+        itsGame->itsApp->DoCommand(kGetReadyToStartCmd);
+        isPlaying = true;
+        itsGame->ResumeGame();
     }
 }
 
@@ -1346,20 +1329,24 @@ void CNetManager::AttachPlayers(CAbstractPlayer *playerActorList) {
     }
 }
 
-void CNetManager::ConfigPlayer(short senderSlot, Ptr configData) {
-    PlayerConfigRecord *config = (PlayerConfigRecord *)configData;
+void CNetManager::ConfigByteSwap(PlayerConfigRecord *config) {
     config->numGrenades = ntohs(config->numGrenades);
     config->numMissiles = ntohs(config->numMissiles);
     config->numBoosters = ntohs(config->numBoosters);
     config->hullType = ntohs(config->hullType);
-    config->frameLatency = ntohs(config->frameLatency);
-    config->frameLatencyLimits = ntohs(config->frameLatencyLimits);
+    config->frameLatencyMin = ntohs(config->frameLatencyMin);
+    config->frameLatencyMax= ntohs(config->frameLatencyMax);
     config->frameTime = ntohs(config->frameTime);
     config->spawnOrder = ntohs(config->spawnOrder);
     config->hullColor = ntohl(config->hullColor.GetRaw());
     config->trimColor = ntohl(config->trimColor.GetRaw());
     config->cockpitColor = ntohl(config->cockpitColor.GetRaw());
     config->gunColor = ntohl(config->gunColor.GetRaw());
+}
+
+void CNetManager::ConfigPlayer(short senderSlot, Ptr configData) {
+    PlayerConfigRecord *config = (PlayerConfigRecord *)configData;
+    ConfigByteSwap(config);
     playerTable[senderSlot]->TheConfiguration() = *config;
 }
 
@@ -1369,40 +1356,32 @@ void CNetManager::DoConfig(short senderSlot) {
     if (playerTable[senderSlot]->GetPlayer()) {
         playerTable[senderSlot]->GetPlayer()->ReceiveConfig(theConfig);
     }
+}
 
-    // gets the frame info from the server (senderSlot==0) if server is playing OR anyone else if server not playing (seems bad)
-    // ... but what about the kAllowLatencyBit?
-    if (PermissionQuery(kAllowLatencyBit, 0) || !(activePlayersDistribution & kdServerOnly) || senderSlot == 0) {
-        // save the frameTime, latency, maxLatency sent by the server (normally)
+void CNetManager::DoServerConfig() {
+    // gets the frame info from the server (senderSlot==0)
+    PlayerConfigRecord *theConfig = &playerTable[0]->TheConfiguration();
+    // save the frameTime, latency, maxLatency sent by the server
 
-        // transmitting latencyTolerance in terms of frameLatency to keep it as a short value on transmission
-        itsGame->SetFrameTime(theConfig->frameTime);
-        minAutoLatency = theConfig->frameLatencyLimits >> 8;    // top 8 bits
-        maxAutoLatency = theConfig->frameLatencyLimits & 0xff;  // bottom 8 bits
-        itsGame->SetFrameLatency(theConfig->frameLatency);
-        SDL_Log("DoConfig LT = %.2lf, minFL = %d, maxFL = %d\n", itsGame->latencyTolerance, minAutoLatency, maxAutoLatency);
-        itsGame->SetSpawnOrder((SpawnOrder)theConfig->spawnOrder);
-        latencyVoteFrame = itsGame->NextFrameForPeriod(AUTOLATENCYPERIOD);
-    }
+    // (transmitting latencyTolerance in terms of frameLatency to keep it as a short value on transmission)
+    itsGame->SetFrameTime(theConfig->frameTime);
+    minAutoLatency = theConfig->frameLatencyMin;
+    maxAutoLatency = theConfig->frameLatencyMax;
+    SDL_Log("DoServerConfig(): frameTime = %d, FL = [%d, %d]\n", theConfig->frameTime, minAutoLatency, maxAutoLatency);
+
+    itsGame->SetSpawnOrder((SpawnOrder)theConfig->spawnOrder);
+    latencyVoteFrame = itsGame->NextFrameForPeriod(AUTOLATENCYPERIOD);
 }
 
 void CNetManager::UpdateLocalConfig() {
     CPlayerManager *thePlayerManager = playerTable[itsCommManager->myId].get();
 
-    uint16_t minFrameLatency = gApplication
-        ? gApplication->Get<float>(kLatencyToleranceMinTag) / itsGame->fpsScale : 0;
-    uint16_t maxFrameLatency = gApplication
-        ? gApplication->Get<float>(kLatencyToleranceTag) / itsGame->fpsScale : 0;
-    if (IsAutoLatencyEnabled()) {
-        // start with the max RTT value
-        config.frameLatency = itsGame->RoundTripToFrameLatency(itsCommManager->GetMaxRoundTrip(AlivePlayersDistribution()));
-        config.frameLatency = std::max(std::min(config.frameLatency, maxFrameLatency), minFrameLatency);
-    } else {
-        // fix LT to kLatencyToleranceTag
-        config.frameLatency = maxFrameLatency;
-    }
-    config.frameLatencyLimits = (minFrameLatency << 8) | maxFrameLatency;
     config.frameTime = itsGame->frameTime;
+    config.frameLatencyMin = gApplication
+        ? gApplication->Get<float>(kLatencyToleranceMinTag) / itsGame->fpsScale : 0;
+    config.frameLatencyMax = gApplication
+        ? gApplication->Get<float>(kLatencyToleranceTag) / itsGame->fpsScale : 0;
+
     config.spawnOrder = gApplication ? gApplication->Get<short>(kSpawnOrder) : ksHybrid;
     config.hullType = gApplication ? gApplication->Number(kHullTypeTag) : 0;
     config.hullColor = gApplication

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -167,7 +167,7 @@ public:
     virtual void SendStartCommand(int16_t originalSender = 0);
     virtual void ReceiveStartCommand(short activeDistribution, int16_t senderSlot, int16_t originalSender);
 
-    virtual void SendResumeCommand(int16_t originalSender = 0);
+    virtual void SendResumeCommand(int16_t originalSender = 0, uint16_t dist = 0, Fixed seed = 0);
     virtual void ReceiveResumeCommand(short activeDistribution, short fromSlot, Fixed randomKey, int16_t originalSender);
     virtual void ReceiveReady(short slot, uint32_t readyPlayers);
 

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -164,11 +164,15 @@ public:
     virtual void SendPingCommand(int trips);
     virtual Boolean ResumeEnabled();
     virtual bool CanPlay();
+
     virtual void SendStartCommand();
-    virtual void ReceiveStartCommand(uint16_t activeDistribution, int16_t senderSlot);
+    virtual void ReceiveStartRequest(uint16_t activeDistribution, uint8_t initialLT, int16_t senderSlot);
+    virtual void ReceiveStartLevel(uint16_t activeDistribution, uint8_t initialLT);
 
     virtual void SendResumeCommand();
-    virtual void ReceiveResumeCommand(uint16_t activeDistribution, short fromSlot, Fixed randomKey);
+    virtual void ReceiveResumeRequest(uint16_t activeDistribution, Fixed randomKey, int16_t fromSlot);
+    virtual void ReceiveResumeLevel(uint16_t activeDistribution, Fixed randomKey);
+
     virtual void ReceiveReady(short slot, uint32_t readyPlayers);
 
     virtual void ReceivePlayerStatus(short slotId, LoadingState newStatus, PresenceType newPresence, Fixed randomKey, FrameNumber winFrame);
@@ -209,8 +213,10 @@ public:
 
     virtual void StopGame(short newStatus);
 
+    virtual void ConfigByteSwap(PlayerConfigRecord *config);
     virtual void ConfigPlayer(short senderSlot, Ptr configData);
     virtual void DoConfig(short senderSlot);
+    virtual void DoServerConfig();
     virtual void UpdateLocalConfig();
 
     virtual void StoreMugShot(Handle mugPict);

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -34,7 +34,7 @@
 
 #define kMaxLatencyTolerance 8
 
-#define kAvaraNetVersion 16
+#define kAvaraNetVersion 17
 
 
 enum { kNullNet, kServerNet, kClientNet };
@@ -164,11 +164,11 @@ public:
     virtual void SendPingCommand(int trips);
     virtual Boolean ResumeEnabled();
     virtual bool CanPlay();
-    virtual void SendStartCommand(int16_t originalSender = 0);
-    virtual void ReceiveStartCommand(short activeDistribution, int16_t senderSlot, int16_t originalSender);
+    virtual void SendStartCommand();
+    virtual void ReceiveStartCommand(uint16_t activeDistribution, int16_t senderSlot);
 
-    virtual void SendResumeCommand(int16_t originalSender = 0, uint16_t dist = 0, Fixed seed = 0);
-    virtual void ReceiveResumeCommand(short activeDistribution, short fromSlot, Fixed randomKey, int16_t originalSender);
+    virtual void SendResumeCommand();
+    virtual void ReceiveResumeCommand(uint16_t activeDistribution, short fromSlot, Fixed randomKey);
     virtual void ReceiveReady(short slot, uint32_t readyPlayers);
 
     virtual void ReceivePlayerStatus(short slotId, LoadingState newStatus, PresenceType newPresence, Fixed randomKey, FrameNumber winFrame);

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -963,7 +963,7 @@ void CPlayerManagerImpl::SetPosition(short pos) {
 void CPlayerManagerImpl::LoadStatusChange(short serverCRC, OSErr serverErr, std::string serverTag) {
     short oldStatus;
 
-    if (loadingStatus != kLNotConnected && loadingStatus != kLActive && presence != kzAway)
+    if (loadingStatus != kLNotConnected && loadingStatus != kLActive)
     {
         oldStatus = loadingStatus;
 

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -1115,12 +1115,13 @@ void CPlayerManagerImpl::SetPlayerStatus(LoadingState newStatus, PresenceType ne
 }
 
 void CPlayerManagerImpl::SetPlayerReady(bool isReady) {
-    // toggle between kLLoaded and kLReady but not to/from other states
-    if (loadingStatus == kLLoaded && isReady) {
+    // toggle between kLLoaded/kLPaused and kLReady but not to/from other states
+    if (IsLoaded() && isReady) {
+        prevState = loadingStatus;
         loadingStatus = kLReady;
         itsGame->StartIfReady();
     } else if (loadingStatus == kLReady && !isReady) {
-        loadingStatus = kLLoaded;
+        loadingStatus = prevState;
     }
 }
 
@@ -1130,6 +1131,10 @@ bool CPlayerManagerImpl::IsAway() {
 
 bool CPlayerManagerImpl::IsSpectating() {
     return (presence == kzSpectating);
+}
+
+bool CPlayerManagerImpl::IsLoaded() {
+    return LoadingStatusIsIn(kLLoaded, kLPaused);
 }
 
 void CPlayerManagerImpl::AbortRequest() {

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -1137,6 +1137,10 @@ bool CPlayerManagerImpl::IsLoaded() {
     return LoadingStatusIsIn(kLLoaded, kLPaused);
 }
 
+bool CPlayerManagerImpl::IsReady() {
+    return loadingStatus == kLReady;
+}
+
 void CPlayerManagerImpl::AbortRequest() {
     theNetManager->activePlayersDistribution &= ~(1 << slot);
     DeadOrDone();

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -103,6 +103,7 @@ public:
     virtual bool IsAway() = 0;
     virtual bool IsSpectating() = 0;
     virtual bool IsLoaded() = 0;
+    virtual bool IsReady() = 0;
 
     virtual void ChangeName(StringPtr theName) = 0;
     virtual void SetPosition(short pos) = 0;
@@ -251,6 +252,7 @@ public:
     virtual bool IsAway();
     virtual bool IsSpectating();
     virtual bool IsLoaded();
+    virtual bool IsReady();
 
     virtual void ResendFrame(FrameNumber theFrame, short requesterId, short commandCode);
 

--- a/src/game/CPlayerManager.h
+++ b/src/game/CPlayerManager.h
@@ -102,6 +102,7 @@ public:
     virtual void SetPlayerStatus(LoadingState newStatus, PresenceType newPresence, FrameNumber theWin) = 0;
     virtual bool IsAway() = 0;
     virtual bool IsSpectating() = 0;
+    virtual bool IsLoaded() = 0;
 
     virtual void ChangeName(StringPtr theName) = 0;
     virtual void SetPosition(short pos) = 0;
@@ -191,7 +192,7 @@ private:
     std::deque<char> lineBuffer;
 
     FrameNumber winFrame;
-    LoadingState loadingStatus;
+    LoadingState loadingStatus, prevState;
     PresenceType presence;
     short slot;
     short playerColor;
@@ -249,6 +250,7 @@ public:
     virtual void SetPlayerReady(bool isReady);
     virtual bool IsAway();
     virtual bool IsSpectating();
+    virtual bool IsLoaded();
 
     virtual void ResendFrame(FrameNumber theFrame, short requesterId, short commandCode);
 

--- a/src/game/PlayerConfig.h
+++ b/src/game/PlayerConfig.h
@@ -13,14 +13,17 @@
 #include "FastMat.h"
 
 struct PlayerConfigRecord {
+    // hull config
     short numGrenades {};
     short numMissiles {};
     short numBoosters {};
     short hullType {};
-    uint16_t frameLatency {};
-    uint16_t frameLatencyLimits {};   // min & max values in each byte
+    // server config
+    uint16_t frameLatencyMin {};
+    uint16_t frameLatencyMax {};
     short frameTime {};
     short spawnOrder {};
+    // hull colors
     ARGBColor hullColor { (*ColorManager::getMarkerColor(0)).WithA(0xff) };
     ARGBColor trimColor { (*ColorManager::getMarkerColor(1)).WithA(0xff) };
     ARGBColor cockpitColor { (*ColorManager::getMarkerColor(2)).WithA(0xff) };

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -111,10 +111,10 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             theGame->itsApp->BroadcastCommand(kNetChangedCmd);
             break;
         case kpStartLevel:
-            theNet->ReceiveStartCommand(thePacket->p2, thePacket->sender, thePacket->p1);
+            theNet->ReceiveStartCommand(thePacket->p2, thePacket->sender);
             break;
         case kpResumeLevel:
-            theNet->ReceiveResumeCommand(thePacket->p2, thePacket->sender, thePacket->p3, thePacket->p1);
+            theNet->ReceiveResumeCommand(thePacket->p2, thePacket->sender, thePacket->p3);
             break;
         case kpReadySynch:
             theNet->ReceiveReady(thePacket->sender, thePacket->p2);

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -110,14 +110,22 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
         case kpKillNet:
             theGame->itsApp->BroadcastCommand(kNetChangedCmd);
             break;
+        case kpStartRequest:
+            theNet->ReceiveStartRequest(thePacket->p2, thePacket->p1, thePacket->sender);
         case kpStartLevel:
-            theNet->ReceiveStartCommand(thePacket->p2, thePacket->sender);
+            theNet->ReceiveStartLevel(thePacket->p2, thePacket->p1);
+            break;
+        case kpResumeRequest:
+            theNet->ReceiveResumeRequest(thePacket->p2, thePacket->p3, thePacket->sender);
             break;
         case kpResumeLevel:
-            theNet->ReceiveResumeCommand(thePacket->p2, thePacket->sender, thePacket->p3);
+            theNet->ReceiveResumeLevel(thePacket->p2, thePacket->p3);
             break;
         case kpReadySynch:
             theNet->ReceiveReady(thePacket->sender, thePacket->p2);
+            break;
+        case kpSendConfig:
+            theNet->ConfigPlayer(thePacket->sender, thePacket->dataBuffer);
             break;
         case kpStartSynch:
             theNet->ConfigPlayer(thePacket->sender, thePacket->dataBuffer);

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -112,6 +112,7 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             break;
         case kpStartRequest:
             theNet->ReceiveStartRequest(thePacket->p2, thePacket->p1, thePacket->sender);
+            break;
         case kpStartLevel:
             theNet->ReceiveStartLevel(thePacket->p2, thePacket->p1);
             break;

--- a/src/net/CommDefs.h
+++ b/src/net/CommDefs.h
@@ -71,7 +71,11 @@ enum {
     kpPing, // 31
     kpRealName, // 32
 
-    kpJSON      // 33
+    kpSendConfig, // 33
+    kpStartRequest,  // 34
+    kpResumeRequest, // 35
+
+    kpJSON      // 36
 };
 
 /*

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -73,6 +73,7 @@ public:
     virtual bool IsAway() { return false; };
     virtual bool IsSpectating() { return false; };
     virtual bool IsLoaded() { return true; };
+    virtual bool IsReady() { return false; };
     virtual void ChangeName(StringPtr theName) {}
     virtual void SetPosition(short pos) {}
 

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -72,6 +72,7 @@ public:
     virtual void SetPlayerStatus(LoadingState newStatus, PresenceType newPresence, FrameNumber theWin) {}
     virtual bool IsAway() { return false; };
     virtual bool IsSpectating() { return false; };
+    virtual bool IsLoaded() { return true; };
     virtual void ChangeName(StringPtr theName) {}
     virtual void SetPosition(short pos) {}
 


### PR DESCRIPTION
This started out as a fix for pause/resume of games when the server was /away.  But the fixes also seem to help the side-loading of games.  It comes down to setting the activePlayersDistribution correctly for each game that's being played at once.

Bonus fix: can used checkmarks to restart paused games.