### PR TITLE
Fix chat tab

### DIFF
--- a/Avara.xcodeproj/project.pbxproj
+++ b/Avara.xcodeproj/project.pbxproj
@@ -2084,7 +2084,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "GIT_HASH=`/usr/bin/git describe --always --dirty`\necho \"#define GIT_VERSION \\\"$GIT_HASH\\\"\" > src/util/GitVersion.h\n";
+			shellScript = "GIT_HASH=`/usr/bin/git describe --always --dirty` \ngrep -q $GIT_HASH src/util/GitVersion.h || (echo \"#define GIT_VERSION \\\"$GIT_HASH\\\"\" > src/util/GitVersion.h)\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
We've all seen it.  After a long game session the chat gets mangled up.  I just put a limit of 256 messages and made sure to destroy the Label objects created beyond that limit.  I'm hoping this will make the chat tab more useful.