### PR TITLE
Latency intolerance 3

### DIFF
--- a/Avara.xcodeproj/project.pbxproj
+++ b/Avara.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		E2210CC12A1C9D9C000712AA /* Tags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E20752EE2A003EC600DCC210 /* Tags.cpp */; };
 		E247DE242A0EB51B001CA630 /* PlayerRatingsSimpleElo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E247DE222A0EB51B001CA630 /* PlayerRatingsSimpleElo.cpp */; };
 		E247DE252A0EB51B001CA630 /* PlayerRatingsSimpleElo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E247DE222A0EB51B001CA630 /* PlayerRatingsSimpleElo.cpp */; };
+		E2CF30032DA88F4D002DD786 /* LegacyOpenGLRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 60C274E22C23EBE9005B67A9 /* LegacyOpenGLRenderer.cpp */; };
 		E2DCC6562BDE0D3200D70C49 /* SDL2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E5890F9729895294007A875D /* SDL2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E517F053299713DB0036B206 /* tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E2B62D7D2997052B00600401 /* tests.cpp */; };
 		E517F054299713DB0036B206 /* CBasicSound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5890C7529895118007A875D /* CBasicSound.cpp */; };
@@ -1984,10 +1985,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E517F052299713990036B206 /* Build configuration list for PBXNativeTarget "AvaraTests" */;
 			buildPhases = (
+				E2DCC6552BDE0D1B00D70C49 /* Embed Frameworks */,
 				E517F048299713990036B206 /* Sources */,
 				E517F049299713990036B206 /* Frameworks */,
 				E517F04A299713990036B206 /* CopyFiles */,
-				E2DCC6552BDE0D1B00D70C49 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2224,6 +2225,7 @@
 				E517F0C5299713DB0036B206 /* CHuffProcessor.cpp in Sources */,
 				E517F0C6299713DB0036B206 /* CAbstractPipe.cpp in Sources */,
 				E517F0C7299713DB0036B206 /* CAbstractHuffPipe.cpp in Sources */,
+				E2CF30032DA88F4D002DD786 /* LegacyOpenGLRenderer.cpp in Sources */,
 				E517F0C8299713DB0036B206 /* CHandlePipe.cpp in Sources */,
 				E517F0C9299713DB0036B206 /* PascalStrings.cpp in Sources */,
 				E517F0CA299713DB0036B206 /* RamFiles.cpp in Sources */,

--- a/bin/multiplayer.sh
+++ b/bin/multiplayer.sh
@@ -1,13 +1,20 @@
 #!/bin/sh # -x
+
+host=localhost
+if [ "$1" == "-x" ]; then
+    host=`curl locallhost.com 2> /dev/null`
+    shift # $2 -> $1
+fi
+
 if [ "$#" -lt 1 ] || [ $1 -lt 2 ]; then
-    echo "Usage: $0 num" >&2
-    echo "  where num = number of players (min. 2)" >&2
+    echo "Usage: $0 [-x] num" >&2
+    echo "  num = number of players (min. 2)" >&2
+    echo "  -x use external IP when connecting to server" >&2
     exit 1
 fi
 
 count=$1
 
-host=localhost
 server_options=(-s)
 client_options=(-c $host)
 both_options=(-/ "p soundVolume 5")

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -798,7 +798,12 @@ void CAvaraGame::GameStart() {
 #ifdef _WIN32
     nanogui::throttle = 0;   // let 'er rip
 #else
-    nanogui::throttle = std::min(static_cast<FrameTime>(itsApp->Number(kThrottle)), frameTime);
+    FrameTime throttle = static_cast<FrameTime>(itsApp->Number(kThrottle));
+    if (Debug::IsEnabled("cpu")) {
+        // when measuring "cpu", disable throttle so it doesn't thow off the cpu usage calculation
+        throttle = 0;
+    }
+    nanogui::throttle = std::min(throttle, frameTime);
 #endif
     SDL_Log("CAvaraGame::GameStart, throttle = %d\n", nanogui::throttle);
 }

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -448,10 +448,8 @@ void CAvaraGame::RunFrameActions() {
     RunActorFrameActions();
 
     itsNet->ProcessQueue();
-    if (!latencyTolerance) {
-        while (frameNumber > topSentFrame) {
-            itsNet->FrameAction();
-        }
+    while (topSentFrame <= FramesFromNow(latencyTolerance)) {
+        itsNet->FrameAction();   // increments topSentFrame while sending frame packet
     }
 
     thePlayer = playerList;
@@ -917,10 +915,6 @@ bool CAvaraGame::GameTick() {
     IncrementFrame();
 
     timeInSeconds = frameNumber * frameTime / 1000;
-
-    if (latencyTolerance)
-        while (FramesFromNow(latencyTolerance) > topSentFrame)
-            itsNet->FrameAction();
 
     canPreSend = true;
 

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -181,8 +181,15 @@ public:
     uint32_t nextScheduledFrame;
     uint32_t nextPingTime;
     uint32_t nextLoadTime;
-    long lastFrameTime;
+
     Boolean canPreSend;
+
+    uint32_t nextStatTime;
+    long lastFrameTime;
+    RolloverCounter<uint32_t> lastFramePackets;
+    float msecPerFrame;
+    float packetsPerFrame;
+    float effectiveLT;
 
     Boolean didWait;
     Boolean longWait;
@@ -244,6 +251,7 @@ public:
     virtual bool GameTick();
     virtual void GameStop();
     virtual ~CAvaraGame();
+    virtual void DoStats(uint32_t frameStartTime, int interval);
 
     virtual void SpectateNext();
     virtual void SpectatePrevious();

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -1071,7 +1071,7 @@ void CNetManager::SetLT(uint8_t frameLatency) {
         // fix LT to kLatencyToleranceTag value
         frameLatency = maxAutoLatency;
     }
-    itsGame->latencyTolerance = 0; // forces SetFrameLatency() to output the message
+    itsGame->latencyTolerance = -1; // forces SetFrameLatency() to output the message
     itsGame->SetFrameLatency(frameLatency);
 }
 

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -773,7 +773,7 @@ void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
 
                 latencyVoteFrame = frameNumber;  // record the actual frame where the vote is initiated
                 // only use the "alive" players for the maxRTT calculation
-                maxRoundLatency = itsCommManager->GetMaxRoundTrip(AlivePlayersDistribution(), &maxId);
+                maxRoundLatency = itsCommManager->GetMaxRoundTrip(AlivePlayersDistribution(), -1, &maxId);
                 maxPlayer = playerTable[maxId].get();
                 uint8_t llv = std::min(long(UINT8_MAX), localLatencyVote);  // just in case, p1 can only accept a max of 256
 
@@ -796,9 +796,10 @@ void CNetManager::AutoLatencyControl(FrameNumber frameNumber, Boolean didWait) {
                 itsGame->itsApp->AddMessageLine(FragmentMapToString(), MsgAlignment::Left, MsgCategory::Error);
             }
 
+            if (autoLatencyVoteCount)
+                DBG_Log("lt+", "====autoLatencyVote = %ld\n", autoLatencyVote/autoLatencyVoteCount);
             if (IsAutoLatencyEnabled() && autoLatencyVoteCount) {
                 autoLatencyVote /= autoLatencyVoteCount;
-                DBG_Log("lt+", "====autoLatencyVote = %ld\n", autoLatencyVote);
 
                 short curFrameLatency = itsGame->FrameLatency();
                 short rttFrameLatency = itsGame->RoundTripToFrameLatency(maxRoundTripLatency);
@@ -1033,7 +1034,7 @@ void CNetManager::SendStartCommand() {
         }
     }
     // estimate initial frameLatency from RTT amongst players in dist
-    int8_t rttFL = itsGame->RoundTripToFrameLatency(itsCommManager->GetMaxRoundTrip(dist));
+    int8_t rttFL = itsGame->RoundTripToFrameLatency(itsCommManager->GetMaxRoundTrip(dist, -1));
 
     itsCommManager->SendPacket(kdServerOnly, kpStartRequest, rttFL, dist, 0, 0, 0);
 }

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -167,6 +167,7 @@ public:
 
     virtual void SendStartCommand();
     virtual void ReceiveStartRequest(uint16_t activeDistribution, uint8_t initialLT, int16_t senderSlot);
+    virtual void SetLT(uint8_t frameLatency);
     virtual void ReceiveStartLevel(uint16_t activeDistribution, uint8_t initialLT);
 
     virtual void SendResumeCommand();

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -34,7 +34,7 @@
 
 #define kMaxLatencyTolerance 8
 
-#define kAvaraNetVersion 17
+#define kAvaraNetVersion 18
 
 
 enum { kNullNet, kServerNet, kClientNet };

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -536,6 +536,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
         long firstTime = askAgainTime = TickCount();
         long quickTick = firstTime;
         long giveUpTime = firstTime + MSEC_TO_TICK_COUNT(15000);
+        uint32_t time0 = SDL_GetTicks();
 
         short askCount = 0;
         LoadingState oldStatus = loadingStatus;
@@ -612,11 +613,12 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
             // HideCursor();
         }
 
-        if (quickTick != firstTime) {
-            if (quickTick > firstTime + 3 || itsGame->longWait) {
+        uint32_t waitTime = SDL_GetTicks() - time0;
+        if (waitTime >= itsGame->frameTime) {
+            if (waitTime > 3*itsGame->frameTime || itsGame->longWait) {
                 itsGame->veryLongWait = true;
             }
-
+//            SDL_Log("fn=%d, waitTime = %u\n", itsGame->frameNumber, waitTime);
             itsGame->longWait = true;
         }
     }

--- a/src/game/CPlayerManager.cpp
+++ b/src/game/CPlayerManager.cpp
@@ -567,7 +567,7 @@ FunctionTable *CPlayerManagerImpl::GetFunctions() {
                 SendResendRequest(askCount++);
                 // if we get the packet from the Resend above, it might be stuck on the end of the readQ waiting for
                 // a lost packet, so skip 1 lost packet every other time until it frees up the queue again
-                if (askCount % 2 == 1) {
+                if (askCount % 2 == 0) {
                     theNetManager->SkipLostPackets(1 << slot);
                 }
 

--- a/src/gui/CServerWindow.cpp
+++ b/src/gui/CServerWindow.cpp
@@ -60,6 +60,7 @@ CServerWindow::CServerWindow(CApplication *app) : CWindow(app, "Server") {
     latencyBox->setEnabled(true);
     latencyBox->setCallback([this](std::string value) -> bool {
         double newLT = std::stod(value);
+        double curLT = gCurrentGame->latencyTolerance;
         // let SetFrameLatency() enforce limits on latencyTolerance
         gCurrentGame->SetFrameLatency(std::ceil(newLT/gCurrentGame->fpsScale));
 
@@ -68,7 +69,8 @@ CServerWindow::CServerWindow(CApplication *app) : CWindow(app, "Server") {
 
         // save the pref
         gApplication->Set(kLatencyToleranceTag, gCurrentGame->latencyTolerance);
-
+        // restore the game LT
+        gCurrentGame->latencyTolerance = curLT;
         return true;
     });
 

--- a/src/net/CCommManager.cpp
+++ b/src/net/CCommManager.cpp
@@ -331,7 +331,7 @@ Boolean CCommManager::ReconfigureAvailable() {
 
 void CCommManager::Reconfigure() {}
 
-long CCommManager::GetMaxRoundTrip(short distribution, short *slowPlayerId) {
+long CCommManager::GetMaxRoundTrip(short distribution, float stdMult, short *slowPlayerId) {
     return 0; //	Local net.
 }
 float CCommManager::GetMaxMeanSendCount(short distribution) {
@@ -339,4 +339,8 @@ float CCommManager::GetMaxMeanSendCount(short distribution) {
 }
 float CCommManager::GetMaxMeanReceiveCount(short distribution) {
     return 0; //	Local net.
+}
+
+const RolloverCounter<uint32_t>& CCommManager::TotalPacketsSent() {
+    return totalPacketsSent;
 }

--- a/src/net/CCommManager.h
+++ b/src/net/CCommManager.h
@@ -12,6 +12,7 @@
 #include "Memory.h"
 #include <list>
 #include <vector>
+#include "RolloverCounter.h"
 
 #define TALKERSTRINGS 1000
 #define PACKETDATABUFFERSIZE (1024-40)          // -40 to get UDPPacketInfo to 1024 bytes
@@ -65,6 +66,8 @@ public:
 
     short genericInfoTextRes;
 
+    RolloverCounter<uint32_t> totalPacketsSent = 0;
+
     //	For method documentation, see .c-file:
     ~CCommManager() { Dispose(); }
 
@@ -98,7 +101,9 @@ public:
     virtual Boolean ReconfigureAvailable();
     virtual void Reconfigure();
 
-    virtual long GetMaxRoundTrip(short distribution, short *slowPlayerId = nullptr);
+    virtual long GetMaxRoundTrip(short distribution, float stdMult = 0.0, short *slowPlayerId = nullptr);
     virtual float GetMaxMeanSendCount(short distribution);
     virtual float GetMaxMeanReceiveCount(short distribution);
+
+    virtual const RolloverCounter<uint32_t>& TotalPacketsSent();
 };

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -140,11 +140,6 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             theNet->ReceiveJSON(
                 thePacket->p1, thePacket->p2, thePacket->p3, std::string(thePacket->dataBuffer));
             break;
-        case kpKeyAndMouseRequest: {
-            theGame->itsNet->playerTable[itsManager->myId]->ResendFrame(
-                thePacket->p3, thePacket->sender, kpKeyAndMouse);
-        } break;
-
         case kpGetMugShot:
             theNet->MugShotRequest(thePacket->sender, thePacket->p3);
             break;
@@ -222,9 +217,9 @@ Boolean CProtoControl::PacketHandler(PacketInfo *thePacket) {
             }
             break;
         case kpKeyAndMouseRequest:
-
-            didHandle = false;
-            //	Fall through to kpKeyAndMouse!
+            // handle the resend request right away
+            theNet->playerTable[itsManager->myId]->ResendFrame(thePacket->p3, thePacket->sender, kpKeyAndMouse);
+            //	Fall through to kpKeyAndMouse because this request ALSO contains kpKeyAndMouse info from the sender!
         case kpKeyAndMouse: {
             short playerIndex;
 

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -1004,6 +1004,9 @@ Boolean CUDPComm::AsyncWrite() {
             char *fp;
             uint8_t flags = 0;
 
+            // increment global packet counter
+            totalPacketsSent++;
+
             p = &thePacket->packet;
 
             *outData.uw++ = thePacket->serialNumber;
@@ -1947,13 +1950,12 @@ void CUDPComm::Reconfigure() {
     */
 }
 
-long CUDPComm::GetMaxRoundTrip(short distribution, short *slowPlayerId) {
+long CUDPComm::GetMaxRoundTrip(short distribution, float mult, short *slowPlayerId) {
     float maxTrip = 0;
     CUDPConnection *conn;
     // 1.3*stdev = 90.3% prob, 1.4=91.9%, 1.5=93.3%, 1.6=94.5
-    float mult = 1.5;
-    if (Debug::IsEnabled("rttx")) {
-        mult = Debug::GetValue("rttx") / 10.0;  // rttx=25 --> mult=2.5
+    if (mult < 0) {
+        mult = 1.5;  // default
     }
 
     for (conn = connections; conn; conn = conn->next) {

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -152,7 +152,7 @@ public:
 
     virtual Boolean ReconfigureAvailable();
     virtual void Reconfigure();
-    virtual long GetMaxRoundTrip(short distribution, short *slowPlayerId = nullptr);
+    virtual long GetMaxRoundTrip(short distribution, float multiplier = 0.0, short *slowPlayerId = nullptr);
     virtual float GetMaxMeanSendCount(short distribution);
     virtual float GetMaxMeanReceiveCount(short distribution);
 

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -35,19 +35,23 @@
 
 #if PACKET_DEBUG || LATENCY_DEBUG
 void CUDPConnection::DebugPacket(char eType, UDPPacketInfo *p) {
-    SDL_Log("CUDPConnection::DebugPacket(%c) cn=%d rsn=%d sn=%d-%d cmd=%d p1=%d p2=%d p3=%d flags=0x%02x sndr=%d dist=0x%02x\n",
-        eType,
-        myId,
-        (uint16_t)receiveSerial,
-        (uint16_t)p->serialNumber,
-        p->sendCount,
-        p->packet.command,
-        p->packet.p1,
-        p->packet.p2,
-        p->packet.p3,
-        p->packet.flags,
-        p->packet.sender,
-        p->packet.distribution);
+    if (p) {
+        SDL_Log("CUDPConnection::DebugPacket(%c) cn=%d rsn=%d sn=%d-%d cmd=%d p1=%d p2=%d p3=%d flags=0x%02x sndr=%d dist=0x%02x\n",
+                eType,
+                myId,
+                (uint16_t)receiveSerial,
+                (uint16_t)p->serialNumber,
+                p->sendCount,
+                p->packet.command,
+                p->packet.p1,
+                p->packet.p2,
+                p->packet.p3,
+                p->packet.flags,
+                p->packet.sender,
+                p->packet.distribution);
+    } else {
+        SDL_Log("CUDPConnection::DebugPacket(%c) ----------NULL PACKET----------\n", eType);
+    }
 }
 #endif
 
@@ -324,7 +328,7 @@ UDPPacketInfo *CUDPConnection::GetOutPacket(int32_t curTime, int32_t cramTime, i
 
         if (thePacket == kPleaseSendAcknowledge) {
             #if PACKET_DEBUG
-                SDL_Log("CUDPConnection::DebugPacket(S) <ACK> cn=%d rsn=%d\n", myId, receiveSerial - kSerialNumberStepSize);
+                SDL_Log("CUDPConnection::DebugPacket(S) <ACK> cn=%d rsn=%hu\n", myId, uint16_t(receiveSerial - kSerialNumberStepSize));
             #endif
         } else {
             totalSent++;
@@ -335,7 +339,7 @@ UDPPacketInfo *CUDPConnection::GetOutPacket(int32_t curTime, int32_t cramTime, i
                 numResendsWithoutReceive++;
                 recentResendRate += RECENT_RESEND_SMOOTH;
                 #if PACKET_DEBUG | LATENCY_DEBUG
-                    SDL_Log("CUDPConnection::GetOutPacket   RESENDING cn=%d sn=%d age=%ld resend:count=%ld total=%.1f%% recent=%.1f%%\n",
+                    SDL_Log("CUDPConnection::GetOutPacket   RESENDING cn=%d sn=%d age=%d resend:count=%ld total=%.1f%% recent=%.1f%%\n",
                             myId, (uint16_t)thePacket->serialNumber, curTime - thePacket->birthDate,
                             numResendsWithoutReceive, 100.0*totalResent/totalSent, 100.0*recentResendRate);
                 #endif
@@ -458,7 +462,7 @@ void CUDPConnection::ValidatePacket(UDPPacketInfo *thePacket, int32_t when) {
             urgentRetransmitTime = std::min(urgentRetransmitTime, retransmitTime);
 
             #if PACKET_DEBUG || LATENCY_DEBUG
-                SDL_Log("                               cn=%d cmd=%d roundTrip=%ld mean=%.1f std = %.1f retransmitTime=%ld urgentRetransmit=%ld\n",
+            SDL_Log("                               cn=%d cmd=%d roundTrip=%ld mean=%.1f std = %.1f retransmitTime=%d urgentRetransmit=%d\n",
                         myId, thePacket->packet.command, roundTrip, meanRoundTripTime, stdevRoundTripTime, retransmitTime, urgentRetransmitTime);
             #endif
 
@@ -527,7 +531,7 @@ char *CUDPConnection::ValidatePackets(char *validateInfo, int32_t curTime) {
     validateInfo += sizeof(short);               // point to the AckMap field (if there is one)
 
     #if PACKET_DEBUG
-        SDL_Log("ValidatePackets transmittedSerial=%d, maxValid = %d\n", transmittedSerial, maxValid);
+        SDL_Log("ValidatePackets transmittedSerial=%hu, maxValid = %hu\n", uint16_t(transmittedSerial), uint16_t(maxValid));
     #endif
 
     if (transmittedSerial & 1) {

--- a/src/tui/CommandManager.cpp
+++ b/src/tui/CommandManager.cpp
@@ -114,10 +114,8 @@ CommandManager::CommandManager(CAvaraAppImpl *theApp) : itsApp(theApp) {
     
     cmd = new TextCommand("/info           <- show build info",
                           [this](VectorOfArgs vargs) -> bool {
-        std::string infoString(GetOsName());
-        infoString += " ";
+        std::string infoString(GetOsName() + " " + GIT_VERSION + "\r");
         itsApp->rosterWindow->SendRosterMessage(infoString);
-        itsApp->rosterWindow->SendRosterMessage(GIT_VERSION);
 
         return false;
     });

--- a/src/util/RolloverCounter.h
+++ b/src/util/RolloverCounter.h
@@ -5,6 +5,8 @@
     File: RolloverCounter.h
 */
 
+#pragma once
+
 #include <limits>
 #include <iostream>
 


### PR DESCRIPTION
This branch contains 3 fixes to latency-related code that attempt to increase the frame rate.  These fixes are especially noticeable when LT is set to zero but they should also improve overall game smoothness.

The 3 fixes in this PR are:

 * **resend request**: This is the first fix that jumped out when looking at the code and is a no-brainer.  Sometimes you need to remove packets from the queue because they can potentially block re-send packets you are requesting and need to continue.  However, this is a rare situation and skipping packets too early can cause issues.  This fix resulted in an immediate improvement for games running at LT=0.  I also made the resend request a higher priority message that is acted on right away instead of stuffed in a queue to be acted on later. 
 * **send earlier** : This bug addresses the LT elephant in the room.  The fix itself is quite simple in that it moves all calls to `itsNet->FrameAction()` to the same spot, right before the player `FrameAction()` calls.  I found that calling it earlier like this helped with all marginal LT cases because getting that packet out before a potential wait loop helps everyone.  Win-win!  But it also effectively redefines LT=0 to send 1 frame forward.  In other words, LT=0 is now what you might have thought LT=0.25 was, but LT=0.25 is actually what you thought LT=0.5 was, etc.  So this aligns the definition of LT=0 with all other LT values.  The result of redefining LT=0 this way is that it makes it even happier to run at this level because it gets an additional 16 msec of breathing room. 
 * **frame catchup** : Remember chipmunk mode?  There is a check in the code to prevent a backlog of commands from playing all at once, we called that “chipmunk mode”.  The effect of this check is that it will jump the current frame time forward towards the clock time.  What I changed here is where the adjusted time lands.  I wanted to make it land as far back as possible to both keep it moving forward but not so far forward that it slows down the game excessively.  I tested this under many scenarios and empirically landed on a value for the next frame time that seems to give the best improvement.  This isn’t a big improvement overall but it does seem to help some cases.  Every little bit helps. 