### PR TITLE
dynamic LT

### DIFF
--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -448,6 +448,7 @@ void CAvaraGame::RunFrameActions() {
     RunActorFrameActions();
 
     itsNet->ProcessQueue();
+
     while (topSentFrame <= FramesFromNow(latencyTolerance)) {
         itsNet->FrameAction();   // increments topSentFrame while sending frame packet
     }
@@ -480,6 +481,19 @@ void CAvaraGame::RunActorFrameActions() {
               theActor->FrameAction();
             }
         }
+    }
+}
+
+void CAvaraGame::PreSendFrameActions() {
+    // When called, send up to preSendCount frames early based on whether the clock is "behind".
+    // "behind" is defined as our current time being beyond the projected time of topSentFrame minus an offset.
+    // This allows us to increase the effective LT by as many as FRAME_OFFSET frames during a wait loop.
+    static float FRAME_OFFSET = 2.0;
+    while (preSendCount > 0 &&
+           SDL_GetTicks() >= nextScheduledFrame + frameTime*(topSentFrame-frameNumber-FRAME_OFFSET)) {
+        itsNet->FrameAction();
+        DBG_Log("presend", "fn=%d, preSent frame #%d, N=%d, ahead=%d, start=%d time=%d nSF=%d\n", frameNumber, topSentFrame, preSendCount, topSentFrame - frameNumber, frameStart, SDL_GetTicks(), nextScheduledFrame);
+        preSendCount--;
     }
 }
 
@@ -763,7 +777,7 @@ void CAvaraGame::GameStart() {
         // init stat vars
         msecPerFrame = frameTime;
         packetsPerFrame = 1.0;
-        effectiveLT = latencyTolerance;
+        effectiveLT = latencyTolerance + 1;
     }
 
     playersStanding = 0;
@@ -772,7 +786,7 @@ void CAvaraGame::GameStart() {
 
     // frameAdvance = INIT_ADVANCE;
     // frameCredit = frameAdvance << 16;
-    canPreSend = false;
+    preSendCount = 0;
 
     // The difference between the last frame's time and frameTime
     frameAdjust = 0;
@@ -842,25 +856,25 @@ void CAvaraGame::HandleEvent(SDL_Event &event) {
 }
 
 bool CAvaraGame::GameTick() {
-    uint32_t startTime = SDL_GetTicks();
+    frameStart = SDL_GetTicks();
 
     // No matter what, process any pending network packets
     itsNet->ProcessQueue();
 
-    if (startTime > nextPingTime) {
+    if (frameStart > nextPingTime) {
         // 3 pings every second, 1 ping used by each client for RTT calc (last ping not used)
         static uint32_t pingInterval = 1000; // msec
         itsNet->SendPingCommand(4);
-        nextPingTime = startTime + pingInterval;
+        nextPingTime = frameStart + pingInterval;
     }
 
     int randLoadPeriod = Debug::GetValue("rload"); // randomly load a level every `rload` seconds
     if (randLoadPeriod > 0) {
-        if (startTime > nextLoadTime) {
+        if (frameStart > nextLoadTime) {
             auto p = CPlayerManagerImpl::LocalPlayer();
             auto *tui = itsApp->GetTui();
             tui->ExecuteMatchingCommand("/rand", p);
-            nextLoadTime = startTime + 1000*randLoadPeriod;
+            nextLoadTime = frameStart + 1000*randLoadPeriod;
         }
     }
 
@@ -869,11 +883,11 @@ bool CAvaraGame::GameTick() {
         return false;
 
     // Not time to process the next frame yet
-    if (startTime < nextScheduledFrame)
+    if (frameStart < nextScheduledFrame)
         return false;
 
     // SDL_Log("CAvaraGame::GameTick frame=%d dt=%d start=%d end=%d\n", frameNumber, SDL_GetTicks() - lastFrameTime,
-    // startTime, endTime); lastFrameTime = SDL_GetTicks();
+    // frameStart, endTime); lastFrameTime = SDL_GetTicks();
 
     if (Debug::IsEnabled("stats")) {
         DoStats(SDL_GetTicks(), Debug::GetValue("stats"));
@@ -888,6 +902,7 @@ bool CAvaraGame::GameTick() {
     playersStanding = 0;
     teamsStanding = 0;
     teamsStandingMask = 0;
+    preSendCount = 2;
 
     ViewControl(); // This was called by itsApp->theGameWind->DoUpdate() calling RefreshWindow
 
@@ -916,10 +931,8 @@ bool CAvaraGame::GameTick() {
 
     timeInSeconds = frameNumber * frameTime / 1000;
 
-    canPreSend = true;
-
     // if the game hasn't kept up with the frame schedule, reset the next frame time (prevents chipmunk mode, unless player is dead)
-    if (nextScheduledFrame < startTime && itsNet->IAmAlive()) {
+    if (nextScheduledFrame < frameStart && itsNet->IAmAlive()) {
         // at the start of this frame we were ALREADY a full frame or more behind...
         // the further back we can stay, the closer we are to original frame rate, the better it is for
         // smoothness.  But that has to be weighed against micro-jitter.  Ideally we want to minimze the
@@ -927,7 +940,7 @@ bool CAvaraGame::GameTick() {
         // is traded off with reducing overall wait time.  Sometimes it's better to wait longer if we
         // have fewer interruptions.
         uint32_t prevNSF = nextScheduledFrame;
-        nextScheduledFrame = startTime + 0.25*frameTime;
+        nextScheduledFrame = frameStart + 0.25*frameTime;
         DBG_Log("presend", "fn=%d, frame reset %u --> %u = +%d\n", frameNumber, prevNSF, nextScheduledFrame, nextScheduledFrame - prevNSF);
     }
 

--- a/src/game/CAvaraGame.h
+++ b/src/game/CAvaraGame.h
@@ -178,11 +178,12 @@ public:
     ScoreInterfaceReasons lastReason;
     std::deque<ScoreInterfaceEvent> scoreEventList;
 
+    uint32_t frameStart;
     uint32_t nextScheduledFrame;
     uint32_t nextPingTime;
     uint32_t nextLoadTime;
 
-    Boolean canPreSend;
+    int preSendCount;
 
     uint32_t nextStatTime;
     long lastFrameTime;
@@ -232,6 +233,7 @@ public:
     virtual void PauseActors();
     virtual void RunFrameActions();
     virtual void RunActorFrameActions();
+    virtual void PreSendFrameActions();
 
     virtual void Score(short team, short player, long points, Fixed energy, short hitTeam, short hitPlayer);
     virtual void AddScoreNotify(ScoreInterfaceEvent event);


### PR DESCRIPTION
This simple-looking fix allows the effective LT to adjust with each frame based on whether the client had to wait for packets.  It will then pre-send up to 2 packets depending on how far behind the clock gets.

While this started as a fix to help out with LT=0, it should also help out with "marginal" LT settings to push those up to the proper level in real time.

This will be merged in once the other set of latency changes has gotten more playing time.