### PR TITLE
Misc. quick fixes

### DIFF
--- a/levels/avaraline-strict-mode/alf/layout/nighthouse.alf
+++ b/levels/avaraline-strict-mode/alf/layout/nighthouse.alf
@@ -1,5 +1,5 @@
 <SkyColor color="#16151f" color.1="#e4cfcb" thickness="30000" />
-<GroundColor color="#0f0b0a" material.specular="#161c1c" material.shininess="8.0" />
+<GroundColor color="#0f0b0a" />
 <set
   designer="$mMalkfox"
   information="I’d probably get fired if that were my job, after killing Jason off and countless screaming Argonauts."

--- a/src/bsp/CBSPPart.cpp
+++ b/src/bsp/CBSPPart.cpp
@@ -531,6 +531,12 @@ void CBSPPart::CheckForAlpha() {
     }
 }
 
+bool CBSPPart::Has3D() const {
+    return !(maxBounds.x == minBounds.x ||
+             maxBounds.y == minBounds.y ||
+             maxBounds.z == minBounds.z);
+}
+
 bool CBSPPart::HasAlpha() const {
     return hasAlpha;
 }

--- a/src/bsp/CBSPPart.h
+++ b/src/bsp/CBSPPart.h
@@ -243,6 +243,7 @@ public:
     virtual void PrependMatrix(Matrix *m); //	modelTransform = m * modelTransform
     virtual Matrix *GetInverseTransform();
 
+    virtual bool Has3D() const;
     virtual bool HasAlpha() const;
     virtual void SetScale(Fixed x, Fixed y, Fixed z);
     virtual void ResetScale();

--- a/src/game/CDoor2Actor.cpp
+++ b/src/game/CDoor2Actor.cpp
@@ -100,6 +100,10 @@ void CDoor2Actor::ReadDoorVariables() {
 
 bool CDoor2Actor::IsGeometryStatic()
 {
+    if (!CGlowActors::IsGeometryStatic()) {
+        return false;
+    }
+    
     if (doorStatus == kDoorClosed &&
         openActivator.messageId > 0 &&
         classicOpenSpeed != 0 && (

--- a/src/render/OpenGLVertices.cpp
+++ b/src/render/OpenGLVertices.cpp
@@ -114,7 +114,7 @@ void OpenGLVertices::Append(const CBSPPart &part)
     for (auto &poly : part.polyTable)
     {
         material = part.materialTable[poly.materialIdx].current;
-        vis = (part.HasAlpha() && poly.vis != 0) ? 3 : poly.vis;
+        vis = (part.HasAlpha() && poly.vis != 0 && part.Has3D()) ? 3 : poly.vis;
         if (!vis) vis = 0;
         switch (vis) {
             case 0:
@@ -148,7 +148,7 @@ void OpenGLVertices::Append(const CBSPPart &part)
     int pAlpha = 0;
     for (auto &poly : part.polyTable) {
         material = part.materialTable[poly.materialIdx].current;
-        uint8_t vis = (part.HasAlpha() && poly.vis != 0) ? 3 : poly.vis;
+        uint8_t vis = (part.HasAlpha() && poly.vis != 0 && part.Has3D()) ? 3 : poly.vis;
         if (!vis) vis = 0; // default to 0 (none) if vis is empty
 
         // vis can ONLY be 0 for None, 1 for Front, 2 for Back, or 3 for Both


### PR DESCRIPTION
Flat transparent geometry no longer doubles faces. Glow/destructible Door2/WallDoor objects no longer considered static. Removed shine from Nighthouse ground.