### PR TITLE
Start/Ready button sends ready checkmark

### DIFF
--- a/.github/workflows/avara-ci.yml
+++ b/.github/workflows/avara-ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: make
       run: make -j2
     - name: Run headless test
-      uses: GabrielBB/xvfb-action@v1.2
+      uses: GabrielBB/xvfb-action@v1.7
       with:
         run: make tests
   Windows:

--- a/.github/workflows/avara-ci.yml
+++ b/.github/workflows/avara-ci.yml
@@ -68,9 +68,9 @@ jobs:
           brew install googletest
       - uses: actions/checkout@v4
       - name: Run headless tests
-        run: make -j3 tests
+        run: make -j4 tests
       - name: make macdist
-        run: make -j3 clean macdist
+        run: make -j4 clean macdist
       - name: deploy main nightly
         if: startsWith(github.repository_owner, 'avaraline') && endsWith(github.ref, 'main')
         uses: WebFreak001/deploy-nightly@v1.0.1

--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -356,6 +356,10 @@ void CNetManager::SendRosterMessage(size_t len, char *c) {
     }
 }
 
+void CNetManager::SendRosterMessage(const std::string msg) {
+    SendRosterMessage(msg.length(), (char*)msg.c_str());
+}
+
 void CNetManager::ReceiveRosterMessage(short slotId, short len, char *c) {
     CPlayerManager *thePlayer;
 

--- a/src/game/CNetManager.h
+++ b/src/game/CNetManager.h
@@ -148,6 +148,7 @@ public:
     virtual void FlushMessageBuffer();
     virtual void BufferMessage(size_t len, char *c);
     virtual void SendRosterMessage(size_t len, char *c);
+    virtual void SendRosterMessage(const std::string msg);
     virtual void ReceiveRosterMessage(short slotId, short len, char *c);
 
     // Color here refers to the team color, not custom color(s)!

--- a/src/gui/CLevelWindow.cpp
+++ b/src/gui/CLevelWindow.cpp
@@ -44,8 +44,13 @@ CLevelWindow::CLevelWindow(CApplication *app) : CWindow(app, "Levels") {
 
     startBtn = new nanogui::Button(this, "Start/Ready");
     startBtn->setCallback([app] {
-        CNetManager* net = ((CAvaraAppImpl *)app)->GetNet();
-        net->SendRosterMessage(checkMark_utf8);
+        if (SDL_GetModState() & KMOD_ALT) {
+            // if ALT key pressed, start right away
+            ((CAvaraAppImpl *)app)->GetGame()->SendStartCommand();
+        } else {
+            // send the "ready" checkmark √
+            ((CAvaraAppImpl *)app)->GetNet()->SendRosterMessage(checkMark_utf8);
+        }
     });
     SelectSet(0);
     levelBox->setSelectedIndex(0);

--- a/src/gui/CLevelWindow.cpp
+++ b/src/gui/CLevelWindow.cpp
@@ -42,9 +42,11 @@ CLevelWindow::CLevelWindow(CApplication *app) : CWindow(app, "Levels") {
     loadBtn = new nanogui::Button(this, "Load Level");
     loadBtn->setCallback([this] { this->SendLoad(); });
 
-    startBtn = new nanogui::Button(this, "Start Game");
-    startBtn->setCallback([app] { ((CAvaraAppImpl *)app)->GetGame()->SendStartCommand(); });
-
+    startBtn = new nanogui::Button(this, "Start/Ready");
+    startBtn->setCallback([app] {
+        CNetManager* net = ((CAvaraAppImpl *)app)->GetNet();
+        net->SendRosterMessage(checkMark_utf8);
+    });
     SelectSet(0);
     levelBox->setSelectedIndex(0);
 }


### PR DESCRIPTION
All non-Hosts will output a ready checkmark when hitting the Start/Ready button.  This prevents newbies from starting a game before everyone is ready.  But the Host can still force a start by hitting the button.