### PR TITLE
FRandSeed random when host not playing

### DIFF
--- a/src/game/CNetManager.cpp
+++ b/src/game/CNetManager.cpp
@@ -46,6 +46,7 @@
 #define kMessageWaitTime 12
 
 extern Fixed FRandSeed;
+extern Fixed NewFRandSeed();
 
 void CNetManager::INetManager(CAvaraGame *theGame) {
     short i;
@@ -426,7 +427,7 @@ void CNetManager::SendLoadLevel(std::string theSet, std::string levelTag, int16_
     aPacket->command = kpLoadLevel;
     aPacket->p1 = 0;
     aPacket->p2 = originalSender;
-    aPacket->p3 = FRandSeed;
+    aPacket->p3 = NewFRandSeed();
     if (itsCommManager->myId == 0) {
         // to avoid multiple simultaneous loads, only the server sends the kpLoadLevel requests to everyone
         SDL_Log("  server sending to everyone\n");

--- a/src/util/FastMat.cpp
+++ b/src/util/FastMat.cpp
@@ -91,12 +91,18 @@ uint32_t randLCG() {
     return seedLCG;
 }
 
-void InitMatrix() {
-    InitTrigTables();
+Fixed NewFRandSeed() {
+    Fixed seed = 0;
     // call randLCG() a "few" times for a good shuffle
     for (short count = 2 + (randLCG() & 0x3); count > 0; count--) {
-        FRandSeed = (Fixed)randLCG();
+        seed = (Fixed)randLCG();
     }
+    return (seed ^ FRandSeed);  // XOR with FRandSeed to add even more randomness via actual game play
+}
+
+void InitMatrix() {
+    InitTrigTables();
+    FRandSeed = NewFRandSeed();
 }
 
 Fixed FSqroot(int *ab) {


### PR DESCRIPTION
What looked like a problem with HUD kills sticking around too long was actually due to the fact that the currentGameId (which is set from FRandSeed) was not changing when the host was out.  This makes that random by setting a new random value on game load, regardless if the host is playing or not.