### PR TITLE
moved `isInGame` check out of CollisionTest()

### DIFF
--- a/src/bsp/CSmartPart.cpp
+++ b/src/bsp/CSmartPart.cpp
@@ -100,8 +100,7 @@ Boolean CSmartPart::CollisionTest(CSmartPart *other) {
     quickDist = FDistanceEstimate(sphereGlobCenter[0] - other->sphereGlobCenter[0],
         sphereGlobCenter[1] - other->sphereGlobCenter[1],
         sphereGlobCenter[2] - other->sphereGlobCenter[2]);
-    if (other->theOwner->isInGame &&
-        quickDist < enclosureRadius + other->enclosureRadius) { //	It seems the bounding spheres overlap, so we have to
+    if (quickDist < enclosureRadius + other->enclosureRadius) { //	It seems the bounding spheres overlap, so we have to
                                                                 // do more exhaustive tests.
         //	We end up here about half the time this function is called, if reasonable initial
         //	culling is done.

--- a/src/game/CAbstractActor.cpp
+++ b/src/game/CAbstractActor.cpp
@@ -508,7 +508,8 @@ void CAbstractActor::BuildPartProximityList(Fixed *origin, Fixed range, MaskType
 
             while (head->next) {
                 anActor = head->me;
-                if (anActor->searchCount != searchCount) {
+                if (anActor->isInGame &&
+                    anActor->searchCount != searchCount) {
                     anActor->searchCount = searchCount;
                     if (anActor->maskBits & filterMask) {
                         for (thePart = anActor->partList; *thePart; thePart++) {


### PR DESCRIPTION
You can't rely on whether the passed part is the candidate or source part so you shouldn't check `isInGame` in there.  Instead, moved that check to where the candidate list is built in `BuildPartProximityList()`.