### PR TITLE
fix sound bug found on scimitar

### DIFF
--- a/src/audio/CSoundMixer.cpp
+++ b/src/audio/CSoundMixer.cpp
@@ -472,7 +472,8 @@ void CSoundMixer::DoubleBack(uint8_t *stream, int size) {
             mix++;
         } while (--i);
 
-        volumeLimit >>= 5;
+        // ignore mixes with volume below this threshold
+        volumeLimit /= maxChannels;
         if (volumeLimit) {
             mix = infoTable;
             i = maxChannels;


### PR DESCRIPTION
Sounds get nullified if they are below a threshold. If you throw a grenade at a spot with many objects that threshold could increase in such a way that NONE of the sounds would be above the threshold.