### PR TITLE
Remove app->Get calls from main loop

### DIFF
--- a/Avara.xcodeproj/project.pbxproj
+++ b/Avara.xcodeproj/project.pbxproj
@@ -2285,7 +2285,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastUpgradeCheck = 1410;
+				LastUpgradeCheck = 1630;
 				TargetAttributes = {
 					E517F04B299713990036B206 = {
 						CreatedOnToolsVersion = 14.1;

--- a/Avara.xcodeproj/xcshareddata/xcschemes/Avara.xcscheme
+++ b/Avara.xcodeproj/xcshareddata/xcschemes/Avara.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1630"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Avara.xcodeproj/xcshareddata/xcschemes/AvaraTests.xcscheme
+++ b/Avara.xcodeproj/xcshareddata/xcschemes/AvaraTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/levels/avaraline-strict-mode/alf/layout/banzai.alf
+++ b/levels/avaraline-strict-mode/alf/layout/banzai.alf
@@ -1,6 +1,17 @@
-<set designer="Vertigo - dcwatson@gmail.com" information="The giving tree also taketh away." />
+<set
+  designer="Vertigo - dcwatson@gmail.com"
+  information="The giving tree also taketh away."
+  light.0.i="0.7"
+  light.0.a="30"
+  light.0.b="40"
+  light.0.c="#AA6633"
+  light.0.r="60.0"
+  light.0.s="true"
+  baseMaterial.specular="#3A6A1A"
+  baseMaterial.shininess="4.0"
+/>
 
-<SkyColor color="#335599" color.1="#009999" />
+<SkyColor color="#AA7733" color.1="#455D21" thickness="6666" />
 <GroundColor color="#2A201C" />
 
 <Incarnator y="30" cx="36" cz="-36" angle="225" />

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -319,7 +319,7 @@ void CAvaraAppImpl::drawContents() {
     }
     itsGame->Render();
     if (ui) {
-        if (Get<bool>(kShowNewHUD)) {
+        if (itsGame->showNewHUD) {
             ui->RenderNewHUD(mNVGContext);
         } else {
             ui->Render(mNVGContext);
@@ -338,6 +338,12 @@ void CAvaraAppImpl::WindowResized(int width, int height) {
     if (gRenderer->viewParams->viewPixelDimensions.h != width || gRenderer->viewParams->viewPixelDimensions.v != height)
         gRenderer->UpdateViewRect(width, height, mPixelRatio);
     // performLayout();
+}
+
+void CAvaraAppImpl::PrefChanged(std::string name) {
+    CApplication::PrefChanged(name);
+    if (itsGame) itsGame->ReadGamePrefs();
+    if (gRenderer) gRenderer->PrefChanged(name);
 }
 
 bool CAvaraAppImpl::handleSDLEvent(SDL_Event &event) {

--- a/src/game/CAvaraApp.cpp
+++ b/src/game/CAvaraApp.cpp
@@ -343,7 +343,7 @@ void CAvaraAppImpl::WindowResized(int width, int height) {
 void CAvaraAppImpl::PrefChanged(std::string name) {
     CApplication::PrefChanged(name);
     if (itsGame) itsGame->ReadGamePrefs();
-    if (gRenderer) gRenderer->PrefChanged(name);
+    if (gRenderer) gRenderer->ApplyPrefs(name);
 }
 
 bool CAvaraAppImpl::handleSDLEvent(SDL_Event &event) {

--- a/src/game/CAvaraApp.h
+++ b/src/game/CAvaraApp.h
@@ -146,7 +146,8 @@ public:
     
     virtual bool DoCommand(int theCommand) override;
     virtual void WindowResized(int width, int height) override;
-    
+    virtual void PrefChanged(std::string name) override;
+
     virtual void Done() override;
     
     virtual bool handleSDLEvent(SDL_Event &event) override;

--- a/src/game/CAvaraGame.cpp
+++ b/src/game/CAvaraGame.cpp
@@ -743,7 +743,8 @@ void CAvaraGame::ReadGamePrefs() {
         moJoOptions += kFlipAxis;
     }
     sensitivity = pow(2.0, gApplication->Get<double>(kMouseSensitivityTag));
-    SDL_Log("mouse sensitivity multiplier = %.2lf\n", sensitivity);
+    //SDL_Log("mouse sensitivity multiplier = %.2lf\n", sensitivity);
+    showNewHUD = gApplication->Get<bool>(kShowNewHUD);
 }
 
 void CAvaraGame::ResumeGame() {
@@ -1102,7 +1103,6 @@ void CAvaraGame::StopGame() {
 
 void CAvaraGame::Render() {
     //if (gameStatus == kPlayingStatus || gameStatus == kPauseStatus || gameStatus == kWinStatus || gameStatus == kLoseStatus) {
-    showNewHUD = gApplication ? gApplication->Get<bool>(kShowNewHUD) : false;
     ViewControl();
     gRenderer->RenderFrame();
 }

--- a/src/gui/CApplication.cpp
+++ b/src/gui/CApplication.cpp
@@ -124,6 +124,7 @@ bool CApplication::Update(const std::string name, std::string &value) {
         // this will easily cause a crash when reading the json
         if (_prefs[name].type_name() == updatePref[name].type_name()) {
             _prefs.update(updatePref);
+            PrefChanged(name);
             WritePrefs(_prefs);
         } else {
             SDL_Log("Type mismatch. User added type '%s' did not match existing type '%s'. Prefs were not updated.", _prefs[name].type_name(), updatePref[name].type_name());

--- a/src/render/AbstractRenderer.h
+++ b/src/render/AbstractRenderer.h
@@ -105,6 +105,12 @@ public:
      * @param pixelRatio The pixel ratio.
      */
     virtual void UpdateViewRect(int width, int height, float pixelRatio) = 0;
+    
+    /**
+     * Sent when a preference value is updated. Can be used to alter render settings without checking every frame.
+     */
+    virtual void PrefChanged(std::string name) {}
+
 protected:
     float fov = 50.0f;
 };

--- a/src/render/AbstractRenderer.h
+++ b/src/render/AbstractRenderer.h
@@ -7,6 +7,16 @@
 
 #include <memory>
 
+#ifdef __has_include
+#  if __has_include(<optional>)                // Check for a standard library
+#    include <optional>
+#  elif __has_include(<experimental/optional>) // Check for an experimental version
+#    include <experimental/optional>           // Check if __has_include is present
+#  else                                        // Not found at all
+#     error "Missing <optional>"
+#  endif
+#endif
+
 class AbstractRenderer {
 public:
     CViewParameters *viewParams;
@@ -33,6 +43,11 @@ public:
      * Update lights in the scene with the currently configured lighting.
      */
     virtual void ApplyLights() = 0;
+    
+    /**
+     * Sent when a preference value is updated. Can be used to alter render settings without checking every frame.
+     */
+    virtual void ApplyPrefs(std::optional<std::string> name = std::optional<std::string>{}) {}
 
     /**
      * Update the camera with the currently configured resolution and FOV.
@@ -105,11 +120,6 @@ public:
      * @param pixelRatio The pixel ratio.
      */
     virtual void UpdateViewRect(int width, int height, float pixelRatio) = 0;
-    
-    /**
-     * Sent when a preference value is updated. Can be used to alter render settings without checking every frame.
-     */
-    virtual void PrefChanged(std::string name) {}
 
 protected:
     float fov = 50.0f;

--- a/src/render/LegacyOpenGLRenderer.cpp
+++ b/src/render/LegacyOpenGLRenderer.cpp
@@ -182,14 +182,21 @@ void LegacyOpenGLRenderer::ApplyLights()
     float ambientRGB[3];
     viewParams->ambientLightColor.ExportGLFloats(ambientRGB, 3);
 
+    dither = gApplication ? gApplication->Get<bool>(kDither) : true;
+    showSpecular = gApplication ? gApplication->Get<bool>(kSpecular) : true;
+    
     worldShader->Use();
     AdjustAmbient(*worldShader, ambientIntensity);
     worldShader->SetFloat3("ambientColor", ambientRGB);
     worldShader->SetFloat("maxShininess", MAX_SHININESS_EXP);
     worldShader->SetBool("lightsActive", true);
+    worldShader->SetBool("dither", dither);
+    worldShader->SetBool("showSpecular", showSpecular);
 
     skyShader->Use();
     skyShader->SetFloat("celestialDistance", DIR_LIGHT_DISTANCE);
+    skyShader->SetBool("dither", dither);
+    skyShader->SetBool("showSpecular", showSpecular);
 
     for (int i = 0; i < MAXLIGHTS; i++) {
         float rgb[3];
@@ -341,8 +348,6 @@ void LegacyOpenGLRenderer::RenderFrame()
     glEnableVertexAttribArray(0);
 
     skyShader->Use();
-    skyShader->SetBool("dither", gApplication ? gApplication->Get<bool>(kDither) : true);
-    skyShader->SetBool("showSpecular", gApplication ? gApplication->Get<bool>(kSpecular) : true);
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
@@ -359,8 +364,6 @@ void LegacyOpenGLRenderer::RenderFrame()
     glEnable(GL_DEPTH_TEST);
 
     worldShader->Use();
-    worldShader->SetBool("dither", gApplication ? gApplication->Get<bool>(kDither) : true);
-    worldShader->SetBool("showSpecular", gApplication ? gApplication->Get<bool>(kSpecular) : true);
 
     dynamicWorld->PrepareForRender();
 
@@ -605,4 +608,19 @@ void LegacyOpenGLRenderer::SetTransforms(const CBSPPart &part)
     worldShader->Use();
     worldShader->SetTransposedMat4("model", m);
     worldShader->SetTransposedMat3("normalTransform", normalMat);
+}
+
+void LegacyOpenGLRenderer::PrefChanged(std::string name) {
+    if (gApplication) {
+        dither = gApplication->Get<bool>(kDither);
+        showSpecular = gApplication->Get<bool>(kSpecular);
+
+        worldShader->Use();
+        worldShader->SetBool("dither", dither);
+        worldShader->SetBool("showSpecular", showSpecular);
+
+        skyShader->Use();
+        skyShader->SetBool("dither", dither);
+        skyShader->SetBool("showSpecular", showSpecular);
+    }
 }

--- a/src/render/LegacyOpenGLRenderer.h
+++ b/src/render/LegacyOpenGLRenderer.h
@@ -30,6 +30,7 @@ public:
     virtual void RemovePart(CBSPPart *part) override;
     virtual void RenderFrame() override;
     void UpdateViewRect(int width, int height, float pixelRatio) override;
+    virtual void PrefChanged(std::string name) override;
 private:
     SDL_Window *window;
     
@@ -46,6 +47,8 @@ private:
     GLsizei resolution[2];
     GLuint skyBuffer;
     GLuint skyVertArray;
+
+    bool showSpecular, dither;
 
     void AdjustAmbient(OpenGLShader &shader, float intensity);
     void ApplyView();

--- a/src/render/LegacyOpenGLRenderer.h
+++ b/src/render/LegacyOpenGLRenderer.h
@@ -20,6 +20,7 @@ public:
     virtual void AddHUDPart(CBSPPart *part) override;
     virtual void AddPart(CBSPPart *part) override;
     virtual void ApplyLights() override;
+    virtual void ApplyPrefs(std::optional<std::string> name = std::optional<std::string>{}) override;
     virtual void ApplyProjection() override;
     virtual void ApplySky() override;
     virtual void LevelReset() override;
@@ -30,7 +31,6 @@ public:
     virtual void RemovePart(CBSPPart *part) override;
     virtual void RenderFrame() override;
     void UpdateViewRect(int width, int height, float pixelRatio) override;
-    virtual void PrefChanged(std::string name) override;
 private:
     SDL_Window *window;
     

--- a/src/render/ModernOpenGLRenderer.h
+++ b/src/render/ModernOpenGLRenderer.h
@@ -20,6 +20,7 @@ public:
     virtual void AddHUDPart(CBSPPart *part) override;
     virtual void AddPart(CBSPPart *part) override;
     virtual void ApplyLights() override;
+    virtual void ApplyPrefs(std::optional<std::string> name = std::optional<std::string>{}) override;
     virtual void ApplyProjection() override;
     virtual void ApplySky() override;
     virtual void LevelReset() override;
@@ -30,7 +31,6 @@ public:
     virtual void RemovePart(CBSPPart *part) override;
     virtual void RenderFrame() override;
     virtual void UpdateViewRect(int width, int height, float pixelRatio) override;
-    virtual void PrefChanged(std::string name) override;
 private:
     SDL_Window *window;
     

--- a/src/render/ModernOpenGLRenderer.h
+++ b/src/render/ModernOpenGLRenderer.h
@@ -30,6 +30,7 @@ public:
     virtual void RemovePart(CBSPPart *part) override;
     virtual void RenderFrame() override;
     virtual void UpdateViewRect(int width, int height, float pixelRatio) override;
+    virtual void PrefChanged(std::string name) override;
 private:
     SDL_Window *window;
     
@@ -55,6 +56,8 @@ private:
     GLuint fbo[2];
     GLuint rbo[2];
     GLuint texture[2];
+
+    bool showSpecular, dither, fxaa;
 
     void AdjustAmbient(OpenGLShader &shader, float intensity);
     void ApplyView();


### PR DESCRIPTION
It's not a huge thing, but there's no need to read prefs (and parse/cast out of the json object) every time through the main loop. If nothing else, will shave a few percent off our render frame time, if the flame graph is correct.