### PR TITLE
Clean up Enqueue/Dequeue

### DIFF
--- a/src/compat/System.cpp
+++ b/src/compat/System.cpp
@@ -2,7 +2,6 @@
 #include "Debug.h"
 
 #include <SDL2/SDL.h>
-#include <deque>
 #include <iterator>
 #include <map>
 #include <string>

--- a/src/compat/System.cpp
+++ b/src/compat/System.cpp
@@ -14,68 +14,60 @@ uint64_t TickCount() {
     return MSEC_TO_TICK_COUNT(SDL_GetTicks());
 }
 
-static std::map<QHdrPtr, std::deque<QElemPtr>> gQueues;
+void InitQueue(QHdrPtr qHeader) {
+    qHeader->qHead = NULL;
+    qHeader->qTail = NULL;
+    qHeader->qSize = 0;
+}
 
 void Enqueue(QElemPtr qElement, QHdrPtr qHeader) {
-    // SDL_Log("Enqueue(%x, %x)\n", qElement, qHeader);
-    if (gQueues.count(qHeader) == 1) {
-        std::deque<QElemPtr> &q = gQueues.at(qHeader);
-        if (!q.empty()) {
-            // Point the previous back of the queue to the new element
-            q.back()->qLink = qElement;
-        }
-        q.push_back(qElement);
-        qHeader->qHead = q.front();
+    if (!qElement || !qHeader) return;
+
+    if (qHeader->qTail) {
+        qHeader->qTail->qLink = qElement;
         qHeader->qTail = qElement;
-        // SDL_Log("  - new element (%x, front=%x)\n", qElement, q.front());
-    } else {
-        std::deque<QElemPtr> newQueue = {qElement};
-        gQueues.insert(std::make_pair(qHeader, newQueue));
-        qHeader->qHead = qHeader->qTail = qElement;
-        // SDL_Log("  - inserting into gQueues with key %lx\n", qHeader);
-        DBG_Log("q", "Enqueue: gQueues has %zu elements\n", gQueues.size());
     }
-    // New element has no next link
+    else {
+        qHeader->qHead = qHeader->qTail = qElement;
+    }
     qElement->qLink = NULL;
+    qHeader->qSize += 1;
 }
 
 OSErr Dequeue(QElemPtr qElement, QHdrPtr qHeader) {
-    // SDL_Log("Dequeue(%x, %x)\n", qElement, qHeader);
-    QElemPtr lastElement = NULL;
-    if (gQueues.count(qHeader) == 1) {
-        std::deque<QElemPtr> &q = gQueues.at(qHeader);
-        if (q.empty()) {
-            return qErr;
-        }
-        for (size_t i = 0; i < q.size(); i++) {
-            QElemPtr curElement = q.at(i);
-            if (curElement == qElement) {
-                if (lastElement) {
-                    lastElement->qLink = curElement->qLink;
-                }
-                // SDL_Log("  - old size = %d\n", q.size());
-                q.erase(q.begin() + i);
-                // SDL_Log("  - new size = %d\n", q.size());
-                qHeader->qHead = q.empty() ? NULL : q.front();
-                qHeader->qTail = q.empty() ? NULL : q.back();
-                // SDL_Log("  - found it\n", qElement);
-                return noErr;
-            }
-            lastElement = curElement;
-        }
+    if (!qElement || !qHeader) return qErr;
+
+    if (qElement == qHeader->qHead && qElement == qHeader->qTail) {
+        // Special case for when there is only one item in the queue.
+        qHeader->qHead = qHeader->qTail = NULL;
+        qHeader->qSize = 0;
+        return noErr;
     }
+
+    QElemPtr remove = qHeader->qHead, last = NULL;
+    while (remove) {
+        if (remove == qElement) break;
+        last = remove;
+        remove = remove->qLink;
+    }
+
+    if (remove) {
+        if (remove == qHeader->qHead) {
+            // Removing the head; all we need to do is advance the head pointer.
+            qHeader->qHead = qHeader->qHead->qLink;
+        }
+        else if (remove == qHeader->qTail) {
+            // Removing the tail; the last element becomes the tail (and points to NULL).
+            last->qLink = NULL;
+            qHeader->qTail = last;
+        }
+        else {
+            // Otherwise, the last element points to the element following the one removed.
+            last->qLink = remove->qLink;
+        }
+        qHeader->qSize -= 1;
+        return noErr;
+    }
+
     return qErr;
-}
-
-void DisposeQueue(QHdrPtr qHeader) {
-    gQueues.erase(qHeader);
-    DBG_Log("q", "DisposeQueues: gQueues now has %zu elements\n", gQueues.size());
-}
-
-size_t QueueCount() {
-    return gQueues.size();
-}
-
-size_t QueueSize(QHdrPtr qHeader) {
-    return gQueues.count(qHeader) ? gQueues.at(qHeader).size() : 0;
 }

--- a/src/compat/System.h
+++ b/src/compat/System.h
@@ -7,9 +7,7 @@
 #define TICK_COUNT_TO_MSEC(tick) ((tick)*1000/60)
 uint64_t TickCount();
 
+void InitQueue(QHdrPtr qHeader);
+
 void Enqueue(QElemPtr qElement, QHdrPtr qHeader);
 OSErr Dequeue(QElemPtr qElement, QHdrPtr qHeader);
-
-void DisposeQueue(QHdrPtr qHeader);
-size_t QueueCount();
-size_t QueueSize(QHdrPtr);

--- a/src/compat/Types.h
+++ b/src/compat/Types.h
@@ -66,14 +66,13 @@ typedef struct Point Point;
 
 struct QElem {
     struct QElem *qLink;
-    int16_t qType;
-    int16_t qData[1];
 };
 typedef struct QElem QElem;
 typedef QElem *QElemPtr;
 struct QHdr {
-    volatile QElemPtr qHead;
-    volatile QElemPtr qTail;
+    QElemPtr qHead;
+    QElemPtr qTail;
+    size_t qSize;
 };
 typedef struct QHdr QHdr;
 typedef QHdr *QHdrPtr;

--- a/src/compat/Types.h
+++ b/src/compat/Types.h
@@ -77,11 +77,6 @@ struct QHdr {
 typedef struct QHdr QHdr;
 typedef QHdr *QHdrPtr;
 
-// From QuickDraw
-enum { kQDGrafVerbFrame = 0, kQDGrafVerbPaint = 1, kQDGrafVerbErase = 2, kQDGrafVerbInvert = 3, kQDGrafVerbFill = 4 };
-
-typedef uint8_t GrafVerb;
-
 #ifdef _WIN32
 #include <winsock2.h>
 #include <Windows.h>

--- a/src/net/CCommManager.cpp
+++ b/src/net/CCommManager.cpp
@@ -28,12 +28,9 @@ void CCommManager::InitializePacketQueues(int numPackets, std::size_t pSize) {
     packetSize = pSize;
     myId = 0; //	Default to server.
 
-    freeQ.qHead = 0;
-    freeQ.qTail = 0;
-
-    inQ.qHead = 0;
-    inQ.qTail = 0;
-
+    InitQueue(&freeQ);
+    InitQueue(&inQ);
+    
     firstReceivers[0] = NULL;
     firstReceivers[1] = NULL;
 
@@ -56,9 +53,6 @@ void CCommManager::AllocatePacketBuffers(int numPackets) {
 **	Release allocated packet buffer storage and then dispose of self.
 */
 void CCommManager::Dispose() {
-    // SDL_Log("  - called Dispose with &inQ = %lx, &freeQ = %lx\n", &inQ, &freeQ);
-    DisposeQueue(&freeQ);
-    DisposeQueue(&inQ);
 }
 
 /*
@@ -183,7 +177,7 @@ PacketInfo* CCommManager::GetPacket() {
             Dequeue((QElemPtr)thePacket, &freeQ);
             break;
         } else {
-            DBG_Log("q", "CCommManager::GetPacket myId=%d, allocating %d more packets, inQ size = %zu\n", myId, FRESHALLOCSIZE, QueueSize(&inQ));
+            DBG_Log("q", "CCommManager::GetPacket myId=%d, allocating %d more packets, inQ size = %zu\n", myId, FRESHALLOCSIZE, inQ.qSize);
             // no packets left? dynamically increase the freeQ then try again
             AllocatePacketBuffers(FRESHALLOCSIZE);
         }

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -66,8 +66,7 @@ void CUDPConnection::IUDPConnection(CUDPComm *theOwner) {
     port = 0;
 
     for (i = 0; i < kQueueCount; i++) {
-        queues[i].qHead = 0;
-        queues[i].qTail = 0;
+        InitQueue(&queues[i]);
     }
 
     serialNumber = INITIAL_SERIAL_NUMBER;
@@ -292,7 +291,7 @@ UDPPacketInfo *CUDPConnection::FindBestPacket(int32_t curTime, int32_t cramTime,
     if (transmitQueueLength > kMaxTransmitQueueLength) {
         DBG_Log("q", "Transmit Queue Overflow - myId = %d\n", myId);
         for (int i = 0; i < kQueueCount; i++) {
-            DBG_Log("q", "   Queue[%d] size = %zu\n", i, QueueSize(&queues[i]));
+            DBG_Log("q", "   Queue[%d] size = %zu\n", i, queues[i].qSize);
         }
         ErrorKill();
     }
@@ -637,7 +636,7 @@ size_t CUDPConnection::ReceivedPacket(UDPPacketInfo *thePacket) {
                 changeInReceiveQueue = true;
                 Enqueue((QElemPtr)thePacket, &queues[kReceiveQ]);
 
-                size_t qsize = QueueSize(&queues[kReceiveQ]);
+                size_t qsize = queues[kReceiveQ].qSize;
                 if (Debug::IsEnabled("q")) {
                     if (qsize % 5 == 0) {
                         DBG_Log("q", "%d: rsn=%d, queued sn=%d to kReceivedQ.size = %zu\n", myId, (int)receiveSerial, (int)thePacket->serialNumber, qsize);
@@ -686,7 +685,7 @@ size_t CUDPConnection::ReceivedPacket(UDPPacketInfo *thePacket) {
         *receiveSerials++ = -12345;
     }
 
-    return QueueSize(&queues[kReceiveQ]);
+    return queues[kReceiveQ].qSize;
 }
 
 bool CUDPConnection::ReceiveQueuedPackets() {
@@ -706,9 +705,9 @@ bool CUDPConnection::ReceiveQueuedPackets() {
                     DebugPacket('+', pack);
 #endif
                     if (Debug::IsEnabled("q")) {
-                        size_t qsize = QueueSize(&queues[kReceiveQ]);
+                        size_t qsize = queues[kReceiveQ].qSize;
                         if (qsize > 0 && qsize % 5 == 0) {
-                            DBG_Log("q", "%d: rsn=%d, dequeued sn=%d to kReceivedQ.size = %zu\n", myId, (int)receiveSerial, (int)pack->serialNumber, QueueSize(&queues[kReceiveQ]));
+                            DBG_Log("q", "%d: rsn=%d, dequeued sn=%d to kReceivedQ.size = %zu\n", myId, (int)receiveSerial, (int)pack->serialNumber, qsize);
                         }
                     }
 

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -1174,11 +1174,6 @@ TEST(SERIAL_NUMBER, Rollover) {
     test_rollover("CUDPConnection::ackBase", conn1, conn2, &CUDPConnection::ackBase);
 }
 
-TEST(QUEUES, Clean) {
-    // after all of the tests have run, the queues should be all cleaned up suggesting all destructors did their job
-    ASSERT_EQ(QueueCount(), 0)  << "queues not empty";
-}
-
 TEST(MATERIALS, Manipulation) {
     Material defaultMaterial = Material().WithColor(0xff000000).WithSpecular(0x00000000).WithShininess(0x00);
     ASSERT_EQ(defaultMaterial.GetColor().GetRaw(), 0xff000000) << "defaultMaterial color not black";


### PR DESCRIPTION
I don't know why I implemented queues using separate `std::deque`s before, but there's no need. This is the way.