### PR TITLE
Fix punch handling

### DIFF
--- a/bin/multiplayer.sh
+++ b/bin/multiplayer.sh
@@ -1,19 +1,35 @@
 #!/bin/sh # -x
 
 host=localhost
+port=0
+
+if [ "$1" == "-p" ]; then
+    shift
+    port=$1
+    shift
+fi
+
 if [ "$1" == "-x" ]; then
     host=`curl locallhost.com 2> /dev/null`
-    shift # $2 -> $1
+    shift
 fi
 
 if [ "$#" -lt 1 ] || [ $1 -lt 2 ]; then
-    echo "Usage: $0 [-x] num" >&2
+    echo "Usage: $0 [-p initialClientPort] [-x] num" >&2
     echo "  num = number of players (min. 2)" >&2
     echo "  -x use external IP when connecting to server" >&2
     exit 1
 fi
 
 count=$1
+
+nextPort()
+{
+    if [ "$port" -gt 0 ]; then
+	((port++))
+    fi
+    return $port
+}
 
 server_options=(-s)
 client_options=(-c $host)
@@ -24,12 +40,13 @@ sleep 3
 
 for (( i=2; i < $count; ++i ))
 do
-  Avara -n "Player$i" "${client_options[@]}" "${both_options[@]}" &
+  Avara -n "Player$i" "${client_options[@]}" "${both_options[@]}" -p $port &
+  nextPort
   sleep 1
 done
 
 # don't put the last player in the background so all can be killed with Ctrl-C
-Avara -n "Player$count" "${client_options[@]}" "${both_options[@]}"
+Avara -n "Player$count" "${client_options[@]}" "${both_options[@]}" -p $port
 
 # kill all subprocesses
 pkill -P $$

--- a/src/net/AvaraTCP.cpp
+++ b/src/net/AvaraTCP.cpp
@@ -43,16 +43,38 @@ typedef struct {
 } UDPReadData;
 
 #pragma pack(1)
-typedef struct {
+typedef struct PunchPacket {
     uint8_t command;
-    IPaddress address;
+    union {
+        IPaddress address = {};     // sent with kPunchRequest (client-to-punch) and kPunch (punch-to-client)
+        int8_t connectionId;   // sent with kHolePunch (client-to-client)
+    };
+
+    std::string toString() const {
+        std::string str = {};
+        switch (command) {
+            case kPunchRequest:
+                str = "kPunchRequest";
+            case kPunch:
+                str = "kPunch";
+                str = "{cmd = " + str + ", addr = " + FormatAddress(address) + "}";
+                break;
+            case kHolePunch:
+                str = "{cmd = kHolePunch, connId = " + std::to_string(connectionId) + "}";
+                break;
+            default:
+                str = "{cmd = " + std::to_string(command) + "}";
+                break;
+        }
+        return str;
+    }
 } PunchPacket;
 #pragma pack()
 
 static Boolean gAvaraTCPOpen = false;
 static int gAvaraSocket = -1;
 UDPReadData gReadCallback;
-PunchAddressHandler gPunchAddressHandler;
+PunchHandler gPunchHandler;
 
 static IPaddress punchServer = {0, 0};
 static IPaddress punchLocal = {0, 0};
@@ -162,13 +184,14 @@ void PunchSetup(const char *host, uint16_t port) {
     ResolveHost(&punchServer, host, port);
 }
 
-void PunchSend(uint8_t cmd, IPaddress &addr) {
-    PunchPacket pp = {cmd, addr};
-    //SDL_Log("Sending PunchPacket %d = %s", cmd, FormatAddress(pp.address).c_str());
+void PunchSend(const PunchPacket pp, const IPaddress &dest) {
+    if (pp.command != kPunchPing) {
+        SDL_Log("Sending PunchPacket %s to %s", pp.toString().c_str(), FormatAddress(dest).c_str());
+    }
     struct sockaddr_in sock_addr;
     memset(&sock_addr, 0, sizeof(sock_addr));
-    sock_addr.sin_addr.s_addr = punchServer.host;
-    sock_addr.sin_port = punchServer.port;
+    sock_addr.sin_addr.s_addr = dest.host;
+    sock_addr.sin_port = dest.port;
     sock_addr.sin_family = AF_INET;
     sendto(
         gAvaraSocket,
@@ -183,7 +206,7 @@ void PunchSend(uint8_t cmd, IPaddress &addr) {
 void PingPunchServer() {
     if (gAvaraSocket == -1 || punchLocal.port == 0 || punchServer.port == 0) return;
 
-    PunchSend(kPunchPing, punchLocal);
+    PunchSend({kPunchPing, .address = punchLocal}, punchServer);
 }
 
 void RegisterPunchServer(IPaddress &localAddr) {
@@ -198,45 +221,35 @@ void RequestPunch(IPaddress &addr) {
     if (gAvaraSocket == -1 || punchServer.port == 0) return;
 
     SDL_Log("Requesting that %s punch a hole", FormatAddress(addr).c_str());
-    PunchSend(kPunchRequest, addr);
+    PunchSend({kPunchRequest, .address = addr}, punchServer);
 }
 
-// this is an empty packet, or kJab sent in response to receiving kPunch from the Punch server
-// just to let the requester know we got the kPunch
-void Punch(IPaddress &addr) {
+// this is a simple packet sent in response to receiving kPunch from the Punch server
+// just to let the requester know we got the kPunch and tell them what our connectionId is
+void PunchHole(const IPaddress &addr, int8_t connId) {
     if (gAvaraSocket == -1) return;
 
-    SDL_Log("Punching back directly (no-data) to %s", FormatAddress(addr).c_str());
-
-    struct sockaddr_in sock_addr;
-    memset(&sock_addr, 0, sizeof(sock_addr));
-    sock_addr.sin_addr.s_addr = addr.host;
-    sock_addr.sin_port = addr.port;
-    sock_addr.sin_family = AF_INET;
-    sendto(
-        gAvaraSocket,
-        "",
-        0,
-        0,
-        (struct sockaddr *)&sock_addr,
-        sizeof(sock_addr)
-   );
+    SDL_Log("Sending a HolePunch to %s", FormatAddress(addr).c_str());
+    PunchPacket pp = {};  // just to clear out the un-used bytes
+    pp = {kHolePunch, .connectionId = connId};
+    PunchSend(pp, addr);
 }
 
 void HandlePunchPacket(UDPpacket *packet) {
-    if (packet->len != sizeof(PunchPacket)) {
-        SDL_Log("Invalid PunchPacket size (%d)", packet->len);
-        return;
-    }
     PunchPacket *pp = (PunchPacket *)packet->data;
-    SDL_Log("Got packet from punch server - (%d) %s", pp->command, FormatAddress(pp->address).c_str());
+    SDL_Log("Got PUNCH packet from %s: %s", FormatAddress(packet->address).c_str(), pp->toString().c_str());
 
-    if (gPunchAddressHandler) {
-        gPunchAddressHandler(PunchType(pp->command), pp->address);
-    }
-
-    if (pp->command == kPunch) {
-        Punch(pp->address);
+    if (gPunchHandler) {
+        switch (pp->command) {
+            case kPunch:
+                gPunchHandler(PunchType(pp->command), pp->address, -1);
+                break;
+            case kHolePunch:
+                gPunchHandler(PunchType(pp->command), packet->address, pp->connectionId);
+                break;
+            default:
+                break;
+        }
     }
 }
 
@@ -280,7 +293,8 @@ void CheckSockets() {
             packet->address.host = addr.sin_addr.s_addr;
             packet->address.port = addr.sin_port;
             if (bytesRead > 0) {
-                if (packet->address.host == punchServer.host && packet->address.port == punchServer.port && punchServer.port != 0) {
+                if (packet->len == sizeof(PunchPacket)) {
+                    // because PunchPacket is an oddly sized 7 byte, it's safe to assume this is a PunchPacket
                     HandlePunchPacket(packet);
                 }
                 else {
@@ -288,9 +302,7 @@ void CheckSockets() {
                 }
             }
             else {
-                SDL_Log("Read 0 bytes from %s - JAB", FormatAddress(packet->address).c_str());
-                // probably a Jab but the handler should check the sender address
-                gPunchAddressHandler(PunchType(kJab), packet->address);
+                SDL_Log("IGNORING 0 bytes sent from %s", FormatAddress(packet->address).c_str());
             }
             FreePacket(packet);
         }
@@ -338,10 +350,10 @@ std::string FormatHostPort(uint32_t host, uint16_t port) {
     return os.str();
 }
 
-std::string FormatAddress(IPaddress &addr) {
+std::string FormatAddress(const IPaddress &addr) {
     return FormatHostPort(addr.host, addr.port);
 }
 
-void SetPunchMessageHandler(PunchAddressHandler handler) {
-    gPunchAddressHandler = handler;
+void SetPunchMessageHandler(PunchHandler handler) {
+    gPunchHandler = handler;
 }

--- a/src/net/AvaraTCP.cpp
+++ b/src/net/AvaraTCP.cpp
@@ -206,7 +206,7 @@ void PunchSend(const PunchPacket pp, const IPaddress &dest) {
 void PingPunchServer() {
     if (gAvaraSocket == -1 || punchLocal.port == 0 || punchServer.port == 0) return;
 
-    PunchSend({kPunchPing, .address = punchLocal}, punchServer);
+    PunchSend({kPunchPing, {punchLocal}}, punchServer);
 }
 
 void RegisterPunchServer(IPaddress &localAddr) {
@@ -221,17 +221,17 @@ void RequestPunch(IPaddress &addr) {
     if (gAvaraSocket == -1 || punchServer.port == 0) return;
 
     SDL_Log("Requesting that %s punch a hole", FormatAddress(addr).c_str());
-    PunchSend({kPunchRequest, .address = addr}, punchServer);
+    PunchSend({kPunchRequest, {addr}}, punchServer);
 }
 
 // this is a simple packet sent in response to receiving kPunch from the Punch server
 // just to let the requester know we got the kPunch and tell them what our connectionId is
-void PunchHole(const IPaddress &addr, int8_t connId) {
+void PunchHole(const IPaddress &addr, const int8_t connId) {
     if (gAvaraSocket == -1) return;
 
     SDL_Log("Sending a HolePunch to %s", FormatAddress(addr).c_str());
-    PunchPacket pp = {};  // just to clear out the un-used bytes
-    pp = {kHolePunch, .connectionId = connId};
+    PunchPacket pp = {kHolePunch};   // with C++20 can initialize using designators: {kHolePunch, .connectionId=connId}
+    pp.connectionId = connId;
     PunchSend(pp, addr);
 }
 

--- a/src/net/AvaraTCP.h
+++ b/src/net/AvaraTCP.h
@@ -29,6 +29,13 @@ typedef struct {
     IPaddress address;
 } UDPpacket;
 
+enum PunchType {
+    kPunchPing = 1,     // ping the punch server to keep connection open
+    kPunchRequest = 2,  // request the punch server send a Punch to another client
+    kPunch = 3,         // the message sent by punch server in response to kPunchRequest
+    kJab = 4            // simple zero-size packet sent directly between clients after getting kPunch'ed
+};
+
 OSErr PascalStringToAddress(StringPtr name, ip_addr *addr);
 OSErr AddressToPascalString(ip_addr addr, StringPtr name);
 
@@ -58,5 +65,5 @@ std::string FormatHostPort(uint32_t host, uint16_t port);
 std::string FormatAddress(IPaddress &addr);
 
 // call this handler when IP address received from punch server
-typedef std::function<void(const IPaddress &)> PunchAddressHandler;
-void SetPunchAddressHandler(PunchAddressHandler handler);
+typedef std::function<void(PunchType, const IPaddress &)> PunchAddressHandler;
+void SetPunchMessageHandler(PunchAddressHandler handler);

--- a/src/net/AvaraTCP.h
+++ b/src/net/AvaraTCP.h
@@ -33,7 +33,7 @@ enum PunchType {
     kPunchPing = 1,     // ping the punch server to keep connection open
     kPunchRequest = 2,  // request the punch server send a Punch to another client
     kPunch = 3,         // the message sent by punch server in response to kPunchRequest
-    kJab = 4            // simple zero-size packet sent directly between clients after getting kPunch'ed
+    kHolePunch = 4      // simple packet sent directly between clients with the sender's connection ID
 };
 
 OSErr PascalStringToAddress(StringPtr name, ip_addr *addr);
@@ -52,7 +52,7 @@ int ResolveHost(IPaddress *address, const char *host, uint16_t port);
 void PunchSetup(const char *host, uint16_t port);
 void RegisterPunchServer(IPaddress &localAddr);
 void RequestPunch(IPaddress &addr);
-void Punch(IPaddress &addr);
+void PunchHole(const IPaddress &addr, const int8_t connectionId);
 
 int CreateSocket(uint16_t &port /* value changed when port==0 */);
 void DestroySocket(int sock);
@@ -62,8 +62,8 @@ void UDPRead(int sock, ReadCompleteProc callback, void *userData);
 void UDPWrite(int sock, UDPpacket *packet, WriteCompleteProc callback, void *userData);
 
 std::string FormatHostPort(uint32_t host, uint16_t port);
-std::string FormatAddress(IPaddress &addr);
+std::string FormatAddress(const IPaddress &addr);
 
-// call this handler when IP address received from punch server
-typedef std::function<void(PunchType, const IPaddress &)> PunchAddressHandler;
-void SetPunchMessageHandler(PunchAddressHandler handler);
+// call this handler when any PunchPacket received
+typedef std::function<void(PunchType cmd, const IPaddress &addr, int8_t connId)> PunchHandler;
+void SetPunchMessageHandler(PunchHandler handler);

--- a/src/net/CProtoControl.cpp
+++ b/src/net/CProtoControl.cpp
@@ -82,7 +82,7 @@ Boolean CProtoControl::DelayedPacketHandler(PacketInfo *thePacket) {
             theNet->SendRealName(thePacket->p1);
             break;
         case kpNameChange:
-            DBG_Log("login+", "received kpNameChange from %d with name='%s'\n", thePacket->sender, &thePacket->dataBuffer[1]);
+            DBG_Log("login+", "received kpNameChange from %d with name='%s'\n", thePacket->sender, ToString(StringPtr(thePacket->dataBuffer)).c_str());
             theNet->RecordNameAndState(
                 thePacket->sender, (StringPtr)thePacket->dataBuffer,
                 (LoadingState)thePacket->p2,

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -650,9 +650,9 @@ CUDPConnection *CUDPComm::UpdateConnectionMatchingSender(const UDPPacketInfo &th
                     pp.sender, pp.command, pSerial, addrStr);
         }
         DBG_Log("login+", "Current connections list: \n%s\n", FormatConnectionsList().c_str());
-    } else {
-        SDL_Log("Got a packet from UNMATCHED ADDRESS, sndr=%d, cmd=%d, sn=%d addr: %s",
-                pp.sender, pp.command, pSerial, addrStr);
+//    } else {
+//        SDL_Log("Got a packet from UNMATCHED ADDRESS, sndr=%d, cmd=%d, sn=%d addr: %s",
+//                pp.sender, pp.command, pSerial, addrStr);
     }
 
     return conn;

--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -379,7 +379,7 @@ std::string CUDPComm::FormatConnectionTable(CompleteAddress *table) {
     // oss << "   1   | " << FormatHostPort(table->host, table->port) << "\n";
     int slot = 2;
     for (CUDPConnection *conn = connections; conn; conn = conn->next, table++, slot++) {
-        oss << "   " << slot << "  |   " << conn->myId + 1 << "  | " << FormatHostPort(table->host, table->port) << "\n";
+        oss << "   " << slot << "  |   " << conn->myId << "  | " << FormatHostPort(table->host, table->port) << "\n";
     }
     return oss.str();
 }

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -22,7 +22,7 @@
 
 #define CRAMTIME 5000 //	About 20 seconds.
 #define CRAMPACKSIZE 64
-#define kClientConnectTimeoutTicks 600 //(60*30)
+#define kClientConnectTimeoutMsec 3000
 
 // Should be at most half of the lowest frameTime.  In classic game this was 4.096 ms.
 #define MSEC_PER_GET_CLOCK (1)
@@ -118,8 +118,9 @@ public:
     virtual std::string FormatConnectionTable(CompleteAddress *table);
     static bool IsLAN(uint32_t host);
     virtual void SendConnectionTable();
-    virtual void ReplaceMatchingNAT(const IPaddress &addr);
     virtual void ReadFromTOC(PacketInfo *thePacket);
+    virtual void ReplaceMatchingNAT(const IPaddress &addr);
+    virtual void PunchHandler(PunchType ptype, const IPaddress &addr);
 
     virtual void SendRejectPacket(ip_addr remoteHost, port_num remotePort, OSErr loginErr);
 

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -127,6 +127,7 @@ public:
     virtual void SendRejectPacket(ip_addr remoteHost, port_num remotePort, OSErr loginErr);
 
     virtual CUDPConnection *DoLogin(PacketInfo *thePacket, UDPpacket *udp);
+    virtual CUDPConnection *UpdateConnectionMatchingSender(const UDPPacketInfo &thePacket, const IPaddress &newAddress);
 
     virtual Boolean PacketHandler(PacketInfo *thePacket);
 

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -122,7 +122,7 @@ public:
     virtual void SendConnectionTable();
     virtual void ReadFromTOC(PacketInfo *thePacket);
     virtual void ReplaceMatchingNAT(const IPaddress &addr);
-    virtual void PunchHandler(PunchType ptype, const IPaddress &addr);
+    virtual void PunchHandler(PunchType cmd, const IPaddress &addr, int8_t connId);
 
     virtual void SendRejectPacket(ip_addr remoteHost, port_num remotePort, OSErr loginErr);
 

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -17,6 +17,7 @@
 #include <string>
 
 #define INITIAL_SERIAL_NUMBER     SerialNumber(0)  // must be even
+#define SERIAL_NUMBER_UDP_SETTLE  SerialNumber(100)
 
 #define ROUTE_THRU_SERVER 0  // non-zero to route all messages through the server
 

--- a/src/net/CUDPComm.h
+++ b/src/net/CUDPComm.h
@@ -116,6 +116,7 @@ public:
     virtual void ProcessQueue();
 
     virtual std::string FormatConnectionTable(CompleteAddress *table);
+    virtual std::string FormatConnectionsList();
     static bool IsLAN(uint32_t host);
     virtual void SendConnectionTable();
     virtual void ReadFromTOC(PacketInfo *thePacket);

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -18,9 +18,6 @@
 
 #include <SDL2/SDL.h>
 
-#include <thread>   // this_thread::sleep_for
-#include <chrono>   // chrono::miliseconds
-
 
 #define kInitialRetransmitTime    (2000 / MSEC_PER_GET_CLOCK)  // 2 seconds
 #define kInitialRoundTripTime     (500 / MSEC_PER_GET_CLOCK)   // 0.5 second
@@ -867,7 +864,6 @@ void CUDPConnection::FreshClient(ip_addr remoteHost, port_num remotePort, uint16
         IPaddress addr = { remoteHost, remotePort };
         // ask the punch server to have this newly connected client punch back to us
         RequestPunch(addr);
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));  // experiment, wait after punch before sending out commands
     }
 }
 

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -794,11 +794,6 @@ void CUDPConnection::RewriteConnections(CompleteAddress *table, const CompleteAd
             // if the server sees the connection coming from localhost, change the host to whatever host we connected to server with (which could ALSO be localhost)
             table->host = serverHost;
         }
-        else if (table->host == myAddressInTOC.host && table->port != myAddressInTOC.port) {
-            // if I have the same host IP as the client in the connection table, and a diff port, assume we're on the same machine
-            // (this helps with the case of connecting a couple of clients/bots out to an external server)
-            table->host = LOCALHOST;
-        }
         // TODO: what if host is the IP of the router?  e.g. someone connects to a LAN game using the WAN address...
         // the workaround for this is to have everyone in the LAN game use the LAN address but it would be nice to make it automatic
         // else if (IsWanRouter(table->host)) { /* do something, might have to send local IP address to the server??? */ }

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -766,10 +766,10 @@ void CUDPConnection::MarkOpenConnections(CompleteAddress *table) {
         for (int idx = 1; idx < itsOwner->maxClients; idx++) {
             if (conn->myId == idx && conn->port) {
                 // if port is set in both places it's assumed to be in use (can't rely on host or port being equal tho)
-                if (table[idx].port) {
+                if (table[idx-1].port) {
                     // remove the connection from the connection table
-                    table[idx].host = 0;
-                    table[idx].port = 0;
+                    table[idx-1].host = 0;
+                    table[idx-1].port = 0;
                 } else {
                     DBG_Log("login", "myId=%d (%s) no longer in connection table, marking as GONE",
                             conn->myId, FormatHostPort(conn->ipAddr, conn->port).c_str());

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -568,6 +568,9 @@ char *CUDPConnection::ValidatePackets(char *validateInfo, int32_t curTime) {
 }
 
 void CUDPConnection::ResendNonValidatedPackets() {
+    if (serialNumber == INITIAL_SERIAL_NUMBER) {
+        return;
+    }
     uint16_t serialBegin = maxValid + kSerialNumberStepSize;
     uint16_t serialEnd = serialNumber - kSerialNumberStepSize;
     DBG_Log("punch", "   resending serial numbers (%hu-%hu)", serialBegin, serialEnd);
@@ -580,7 +583,7 @@ void CUDPConnection::ResendNonValidatedPackets() {
             pp->nextSendTime = curTime;
         }
         pp = (UDPPacketInfo *)pp->packet.qLink;
-     }
+    }
 }
 
 void CUDPConnection::Dispose() {

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -18,6 +18,10 @@
 
 #include <SDL2/SDL.h>
 
+#include <thread>   // this_thread::sleep_for
+#include <chrono>   // chrono::miliseconds
+
+
 #define kInitialRetransmitTime    (2000 / MSEC_PER_GET_CLOCK)  // 2 seconds
 #define kInitialRoundTripTime     (500 / MSEC_PER_GET_CLOCK)   // 0.5 second
 #define kInitialRoundTripVar      long(CLASSICFRAMECLOCK*CLASSICFRAMECLOCK)
@@ -859,6 +863,7 @@ void CUDPConnection::FreshClient(ip_addr remoteHost, port_num remotePort, uint16
         IPaddress addr = { remoteHost, remotePort };
         // ask the punch server to have this newly connected client punch back to us
         RequestPunch(addr);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));  // experiment, wait after punch before sending out commands
     }
 }
 

--- a/src/net/CUDPConnection.cpp
+++ b/src/net/CUDPConnection.cpp
@@ -567,6 +567,22 @@ char *CUDPConnection::ValidatePackets(char *validateInfo, int32_t curTime) {
     return validateInfo;
 }
 
+void CUDPConnection::ResendNonValidatedPackets() {
+    uint16_t serialBegin = maxValid + kSerialNumberStepSize;
+    uint16_t serialEnd = serialNumber - kSerialNumberStepSize;
+    DBG_Log("punch", "   resending serial numbers (%hu-%hu)", serialBegin, serialEnd);
+
+    ClockTick curTime = itsOwner->GetClock();
+
+    UDPPacketInfo *pp = (UDPPacketInfo *)queues[kTransmitQ].qHead;
+    while (pp) {
+        if (serialBegin <= pp->serialNumber && pp->serialNumber <= serialEnd) {
+            pp->nextSendTime = curTime;
+        }
+        pp = (UDPPacketInfo *)pp->packet.qLink;
+     }
+}
+
 void CUDPConnection::Dispose() {
     FlushQueues();
     delete latencyHistogram;

--- a/src/net/CUDPConnection.h
+++ b/src/net/CUDPConnection.h
@@ -126,6 +126,7 @@ public:
     virtual void ValidatePacket(UDPPacketInfo *thePacket, int32_t when);
     virtual void ValidateReceivedPacket(UDPPacketInfo *thePacket);
     virtual char *ValidatePackets(char *validateInfo, int32_t curTime);
+    virtual void ResendNonValidatedPackets();
 
     virtual size_t ReceivedPacket(UDPPacketInfo *thePacket);
     virtual bool ReceiveQueuedPackets();


### PR DESCRIPTION
Fixed a crash related to the punch handler.  It was being set in a place where "this" could go away.

BONUS fix - I *think* I finally figured out the @Sphinx connection issue.  I found that you can't rely on the incoming host OR port matching what you connect out on.  This fix forces the first sent message to append its connection ID to the packet so that it can be matched with a connection that hasn't received any packets.  Then that connection's address is modified to match that first packet so that it matches all subsequent packets.
