### PR TITLE
Fix compilation on musl

### DIFF
--- a/src/Avara.cpp
+++ b/src/Avara.cpp
@@ -17,7 +17,9 @@
 #include "BasePath.h"
 #include "Logging.h"
 #include "signal.h"
+#if !defined(__linux__) || defined(__GLIBC__)
 #include "signalhandling.hpp"
+#endif
 #ifdef _WIN32
 #include <Windows.h>
 #include <ShellAPI.h>
@@ -44,7 +46,9 @@ void SetHiDPI() {
 #include <sstream>
 #include <string>
 
+#if !defined(__linux__) || defined(__GLIBC__)
 SignalHandling sh;
+#endif
 
 using namespace nanogui;
 


### PR DESCRIPTION
backward.hpp seems to assume glibc on Linux, and execinfo.h is not available on musl.