### PR TITLE
Index the actor locator table correctly on 32-bit targets

### DIFF
--- a/src/game/CAbstractActor.cpp
+++ b/src/game/CAbstractActor.cpp
@@ -83,9 +83,6 @@ void CAbstractActor::LinkBox(Fixed minX, Fixed minZ, Fixed maxX, Fixed maxZ) {
     ActorLocator *loc;
     uint32_t mask = LOCCOORDMASK;
 
-    //  Cell indices, computed exactly as the lookup side computes them:
-    //  BuildPartProximityList's (x << LOCATORTABLEBITS) + z, and LOCTOTABLE.
-    //  The x term occupies bits 6..11 and the z term bits 0..5, so | is +.
     minX = (minX & mask) >> (LOCATORRECTSCALE - LOCATORTABLEBITS);
     maxX = (maxX & mask) >> (LOCATORRECTSCALE - LOCATORTABLEBITS);
     minZ = (minZ & mask) >> LOCATORRECTSCALE;

--- a/src/game/CAbstractActor.cpp
+++ b/src/game/CAbstractActor.cpp
@@ -77,24 +77,25 @@ void CAbstractActor::UnlinkLocation() {
     } while (--i);
 }
 
-#define LOCATORTABLESCALE (LOCATORRECTSCALE - 2)
-
 void CAbstractActor::LinkBox(Fixed minX, Fixed minZ, Fixed maxX, Fixed maxZ) {
-    short *linkTable;
+    ActorLocator **linkTable;
     ActorLocator *head;
     ActorLocator *loc;
     uint32_t mask = LOCCOORDMASK;
 
-    minX = (minX & mask) >> (LOCATORTABLESCALE - LOCATORTABLEBITS);
-    maxX = (maxX & mask) >> (LOCATORTABLESCALE - LOCATORTABLEBITS);
-    minZ = (minZ & mask) >> LOCATORTABLESCALE;
-    maxZ = (maxZ & mask) >> LOCATORTABLESCALE;
+    //  Cell indices, computed exactly as the lookup side computes them:
+    //  BuildPartProximityList's (x << LOCATORTABLEBITS) + z, and LOCTOTABLE.
+    //  The x term occupies bits 6..11 and the z term bits 0..5, so | is +.
+    minX = (minX & mask) >> (LOCATORRECTSCALE - LOCATORTABLEBITS);
+    maxX = (maxX & mask) >> (LOCATORRECTSCALE - LOCATORTABLEBITS);
+    minZ = (minZ & mask) >> LOCATORRECTSCALE;
+    maxZ = (maxZ & mask) >> LOCATORRECTSCALE;
 
     loc = locLinks;
     if (loc->next) {
         UnlinkLocation();
     }
-    linkTable = (short *)gCurrentGame->locatorTable;
+    linkTable = gCurrentGame->locatorTable;
 
     head = (ActorLocator *)&linkTable[minX | minZ];
     loc->prev = head;

--- a/src/game/CAbstractActor.cpp
+++ b/src/game/CAbstractActor.cpp
@@ -83,6 +83,9 @@ void CAbstractActor::LinkBox(Fixed minX, Fixed minZ, Fixed maxX, Fixed maxZ) {
     ActorLocator *loc;
     uint32_t mask = LOCCOORDMASK;
 
+    //  Cell indices, computed exactly as the lookup side computes them:
+    //  BuildPartProximityList's (x << LOCATORTABLEBITS) + z, and LOCTOTABLE.
+    //  The x term occupies bits 6..11 and the z term bits 0..5, so | is +.
     minX = (minX & mask) >> (LOCATORRECTSCALE - LOCATORTABLEBITS);
     maxX = (maxX & mask) >> (LOCATORRECTSCALE - LOCATORTABLEBITS);
     minZ = (minZ & mask) >> LOCATORRECTSCALE;


### PR DESCRIPTION
Hello and thank you for this project. I've been having Claude develop a WebAssembly build for fun and ran across a couple of bugs which I'll send PRs for.

---

`LinkBox()` indexes `gCurrentGame->locatorTable`, an `ActorLocator **`, through a
`short *` — and shifts the cell coordinates two bits less than the lookup side
does, which pre-multiplies each index by 4. Four `short`s is eight bytes, so
`&linkTable[4 * i]` lands on `locatorTable[i]` only where a pointer is eight
bytes wide.

That holds for every platform Avara currently ships on, so this has never
mattered. It stops holding on a 32-bit target: each actor gets linked into cell
`2 * i` instead of `i`, so `BuildPartProximityList` and `RayTest` find nothing
where the actor actually is, and actors at high cell indices write past the end of a table
allocated as `sizeof(ActorLocator *) * LOCATORTABLESIZE`.

I hit this building a WebAssembly target (wasm32 is the first 32-bit platform
this code has seen). The symptom is walking through walls: the spatial hash
returns an empty proximity list, so nothing ever collides.

## The fix

Compute the index the way the lookup side already does — the
`(x << LOCATORTABLEBITS) + z` of `BuildPartProximityList`, and `LOCTOTABLE` —
and index the table as the `ActorLocator **` it is. `LOCATORTABLESCALE` then has
no remaining use and goes away.

## Why this is a no-op where you build today

Comparing the address the old and new code compute, for all 4096 cells:

```
sizeof(void *) = 8
cells where old != new:             0 / 4096
cells where old runs off the table: 0 / 4096

sizeof(void *) = 4
cells where old != new:             4095 / 4096
cells where old runs off the table: 2048 / 4096
```

On a 32-bit build the usual failure is the benign-looking one — the actor is in
the wrong cell, still inside the table — because most levels occupy low cell
indices; cells are 32 m and the table wraps at 2048 m. Indices at or above 2048
write past the end.

## Testing

- Linux, clang, `make -j4`: builds clean.
- `make tests` under xvfb: 16/16 pass.
- On the wasm32 build, instrumented to compare the locator table against a
  brute-force scan of every solid part within the same radius, walking a fixed
  path on HalfPipe: before, the hash returned 0 parts where brute force found 2,
  with 19 mismatched frames by frame 61; after, the two agree, with 1 mismatched
  frame by frame 91 (a large actor whose bounding-box corners link into distant
  cells — inherent to the algorithm, and the same on desktop).

---

Also, not making a PR for this unless you want it, but Claude identified another pre-existing potential issue:

_CAbstractPlayer.cpp:1947, spawn point selection:_

> return (a->distance * b->useCount) > (b->distance * a->useCount);

_distance is Fixed (int32), useCount is long. On Linux/macOS that product is evaluated in 64 bits; on Windows and wasm32, in 32 bits, where it can overflow. It takes roughly 180 reuses of one incarnator in a match — unlikely, not impossible in a long game. Since spawn choice feeds everything downstream, it's exactly the shape of thing that desyncs a lockstep match hours in and never reproduces._

_Worth stressing: this is a pre-existing Windows-vs-Linux difference, not something the port introduces. One (int64_t) cast fixes it. I haven't proposed it upstream — it's speculative until someone sees a matching desync_


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)