### PR TITLE
Draw the skybox as triangles, with a count in vertices not bytes

### DIFF
--- a/src/render/LegacyOpenGLRenderer.cpp
+++ b/src/render/LegacyOpenGLRenderer.cpp
@@ -374,7 +374,9 @@ void LegacyOpenGLRenderer::RenderFrame()
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, sizeof(legacySkyboxVertices));
+    // legacySkyboxVertices is 36 vertices making up 12 independent triangles
+    // (a cube), and glDrawArrays counts vertices, not bytes.
+    glDrawArrays(GL_TRIANGLES, 0, sizeof(legacySkyboxVertices) / (3 * sizeof(float)));
     glDisableVertexAttribArray(0);
 
     __glCheckErrors();

--- a/src/render/ModernOpenGLRenderer.cpp
+++ b/src/render/ModernOpenGLRenderer.cpp
@@ -435,7 +435,9 @@ void ModernOpenGLRenderer::RenderFrame()
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, sizeof(skyboxVertices));
+    // skyboxVertices is 36 vertices making up 12 independent triangles (a
+    // cube), and glDrawArrays counts vertices, not bytes.
+    glDrawArrays(GL_TRIANGLES, 0, sizeof(skyboxVertices) / (3 * sizeof(float)));
     glDisableVertexAttribArray(0);
 
     // RENDER WORLD ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hello and thank you for this project. I've been having Claude develop a WebAssembly build for fun and ran across a couple of bugs which I'll send PRs for.

---

Both renderers draw the skybox with

```c
glDrawArrays(GL_TRIANGLE_STRIP, 0, sizeof(skyboxVertices));
```

The vertex data is 108 floats: 36 vertices forming 12 independent triangles, one
cube. Two things are off:

- `glDrawArrays` takes a **vertex count**, but `sizeof()` is in bytes, so the
  call asks for 432 vertices from a 36-vertex buffer and reads 396 vertices past
  the end.
- The data is independent triangles, not a strip.

Desktop drivers return whatever follows the buffer and the sky still looks
right, so this has never been visible. It is undefined behaviour either way, and
where out-of-range vertex fetches are *defined* to zero-fill — GLES and WebGL
robust buffer access — the extra vertices collapse to the origin and fan
enormous triangles across the view. That is how I found it, porting to
WebAssembly.

## Testing

- Linux, clang, `make -j4`: builds clean.
- `make tests` under xvfb: 16/16 pass.
- Level preview renders as before under llvmpipe.

No behaviour change is expected on desktop, since the correct 36 vertices were
always the first 36 the driver read. The fix removes the out-of-bounds read and
draws the intended primitive.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)