### PR TITLE
Optimize basic lighting calcs

### DIFF
--- a/rsrc/shaders/hud_frag.glsl
+++ b/rsrc/shaders/hud_frag.glsl
@@ -1,6 +1,7 @@
 in vec4 fragmentColor;
-in vec4 fragmentSpecular;
+in float fragmentGlow;
 in vec3 fragmentNormal;
+in vec3 baseLightColor;
 
 uniform float ambient; // = 0.0;
 uniform float extraAmbient; // = 0.0;
@@ -8,25 +9,11 @@ uniform bool lightsActive; // = true;
 
 out vec4 color;
 
-vec3 light0 = vec3(0.136808053, 0.282842726, -0.375877053);
-vec3 light1 = vec3(-0.102606051, 0.102606043, 0.281907797);
-vec3 lightColor = vec3(1, 1, 1);
-
-vec3 diffuse_light(vec3 light) {
-    return max(dot(fragmentNormal, light), 0.0) * lightColor;
-}
-
-vec3 diffuse() {
-    return diffuse_light(light0)
-            + diffuse_light(light1);
-
-}
-
 vec4 light_color() {
     return mix(
-        (ambient + extraAmbient) * vec4(lightColor, 1.0) * fragmentColor,
-        vec4(((ambient + extraAmbient) * lightColor) + diffuse(), 1.0) * fragmentColor,
-        float(lightsActive)
+        vec4(baseLightColor, 1.0) * fragmentColor,
+        (1 + extraAmbient) * fragmentColor,
+        float(fragmentGlow > 0.0)
     );
 }
 

--- a/rsrc/shaders/hud_vert.glsl
+++ b/rsrc/shaders/hud_vert.glsl
@@ -7,20 +7,39 @@ layout(location = 5) in float vertexReserved2;
 layout(location = 6) in float vertexReserved3;
 layout(location = 7) in vec3 vertexNormal;
 
+uniform float ambient; // = 0.0;
+uniform bool lightsActive; // = true;
 uniform mat4 view;
 uniform mat4 proj;
 uniform mat4 model;
 
 out vec4 fragmentColor;
-out vec4 fragmentSpecular;
 out float fragmentGlow;
 out vec3 fragmentNormal;
+out vec3 baseLightColor;
+
+vec3 light0 = vec3(0.136808053, 0.282842726, -0.375877053);
+vec3 light1 = vec3(-0.102606051, 0.102606043, 0.281907797);
+vec3 lightColor = vec3(1, 1, 1);
+
+vec3 diffuse_light(vec3 light, vec3 normal) {
+    return max(dot(normal, light), 0.0) * lightColor;
+}
+
+vec3 diffuse(vec3 normal) {
+    vec3 sum = vec3(0, 0, 0);
+    if (lightsActive) {
+        sum += diffuse_light(light0, normal);
+        sum += diffuse_light(light1, normal);
+    }
+    return sum;
+}
 
 void main() {
     vec4 pos = vec4(vertexPosition_modelspace, 1.0);
     gl_Position = proj * (pos * model * view);
     fragmentColor = vertexColor;
-    fragmentSpecular = vertexSpecular;
     fragmentGlow = vertexGlow;
     fragmentNormal = vertexNormal;
+    baseLightColor = (ambient * lightColor) + diffuse(fragmentNormal);
 }

--- a/rsrc/shaders/world_frag.glsl
+++ b/rsrc/shaders/world_frag.glsl
@@ -7,6 +7,7 @@ in float fragmentShininess;
 in float fragmentGlow;
 in vec3 fragmentNormal;
 in vec3 fragPos;
+in vec3 baseLightColor;
 
 uniform vec3 camPos;
 uniform bool dither;
@@ -39,21 +40,8 @@ vec3 apply_fog(vec3 color, float dist)
     return color * extColor + hazeColor * (1.0 - insColor);
 }
 
-vec3 diffuse_light(int i) {
-    return max(dot(fragmentNormal, lightDir[i]), 0.0) * lightColor[i];
-}
-
-vec3 diffuse() {
-    vec3 sum = vec3(0, 0, 0);
-    for (int i = 0; i < MAX_LIGHTS; i++) {
-        sum += diffuse_light(i);
-    }
-    return sum;
-
-}
-
 vec3 spec_light(int i, vec3 viewDir) {
-    if (!lightApplySpecular[i] || fragmentShininess == 0.0 || !lightsActive) return vec3(0);
+    if (!lightApplySpecular[i]) return vec3(0);
     vec3 lightDir = normalize(adjustedLightPos[i] - fragPos);
     vec3 halfwayDir = normalize(lightDir + viewDir);
     float spec = pow(max(dot(fragmentNormal, halfwayDir), 0.0), fragmentShininess);
@@ -63,7 +51,10 @@ vec3 spec_light(int i, vec3 viewDir) {
 
 vec3 spec(vec3 viewDir) {
     vec3 sum = vec3(0, 0, 0);
-    if (showSpecular) {
+    if (lightsActive &&
+        showSpecular &&
+        fragmentSpecular != vec3(0.0, 0.0, 0.0) &&
+        fragmentShininess > 0.0) {
         for (int i = 0; i < MAX_LIGHTS; i++) {
             sum += spec_light(i, viewDir);
         }
@@ -83,11 +74,7 @@ float noise() {
 
 vec4 light_color(vec3 viewDir) {
     return mix(
-        mix(
-            (ambient + extraAmbient) * vec4(ambientColor, 1.0) * fragmentColor,
-            vec4(((ambient + extraAmbient) * ambientColor) + diffuse() + spec(viewDir), 1.0) * fragmentColor,
-            float(lightsActive)
-        ),
+        vec4(baseLightColor + spec(viewDir), 1.0) * fragmentColor,
         (1 + extraAmbient) * fragmentColor,
         float(fragmentGlow > 0.0)
     );

--- a/rsrc/shaders/world_vert.glsl
+++ b/rsrc/shaders/world_vert.glsl
@@ -1,3 +1,5 @@
+#define MAX_LIGHTS 4
+
 layout(location = 0) in vec3 vertexPosition_modelspace;
 layout(location = 1) in vec4 vertexColor;
 layout(location = 2) in vec4 vertexSpecular;
@@ -7,6 +9,12 @@ layout(location = 5) in float vertexReserved2;
 layout(location = 6) in float vertexReserved3;
 layout(location = 7) in vec3 vertexNormal;
 
+uniform vec3 lightDir[MAX_LIGHTS];
+uniform vec3 lightColor[MAX_LIGHTS];
+uniform float ambient; // = 0.0;
+uniform float extraAmbient; // = 0.0;
+uniform vec3 ambientColor; // = vec3(1, 1, 1);
+uniform bool lightsActive; // = true;
 uniform float maxShininess;
 uniform float maxGlow;
 uniform mat4 model;
@@ -20,6 +28,22 @@ out float fragmentShininess;
 out float fragmentGlow;
 out vec3 fragmentNormal;
 out vec3 fragPos;
+out vec3 baseLightColor;
+
+vec3 diffuse_light(int i, vec3 normal) {
+    return max(dot(normal, lightDir[i]), 0.0) * lightColor[i];
+}
+
+vec3 diffuse(vec3 normal) {
+    vec3 sum = vec3(0, 0, 0);
+    if (lightsActive) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            sum += diffuse_light(i, normal);
+        }
+    }
+    return sum;
+
+}
 
 void main() {
     vec4 pos = vec4(vertexPosition_modelspace, 1.0);
@@ -30,4 +54,5 @@ void main() {
     fragmentGlow = vertexGlow * maxGlow;
     fragmentNormal = vertexNormal * normalTransform;
     fragPos = (pos * model).xyz;
+    baseLightColor = ((ambient + extraAmbient) * ambientColor) + diffuse(fragmentNormal);
 }


### PR DESCRIPTION
Moved ambient and diffuse lighting calculations to the vertex shader(s) to hopefully improve performance slightly, though the impact is likely to be negligible.